### PR TITLE
feat: add project website with Hugo and GitHub Pages

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,0 +1,76 @@
+name: Website
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'website/**'
+      - '.github/workflows/website.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: 0.147.7
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.25'
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Setup Hugo
+        run: |
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
+          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+
+      - name: Build
+        working-directory: website
+        env:
+          HUGO_ENVIRONMENT: production
+          HUGO_ENV: production
+        run: |
+          hugo \
+            --gc --minify \
+            --baseURL "${{ steps.pages.outputs.base_url }}/"
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: website/public
+
+  deploy:
+    name: Deploy
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,8 @@ api/proto/v1/*.pb.go
 
 # Build output
 /dist/
+
+# Hugo (website)
+website/public/
+website/resources/
+website/.hugo_build.lock

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # NetVantage
 
+[![Website](https://img.shields.io/badge/website-netvantage.net-4ade80)](https://netvantage.net)
 [![Go Report Card](https://goreportcard.com/badge/github.com/HerbHall/netvantage)](https://goreportcard.com/report/github.com/HerbHall/netvantage)
 [![codecov](https://codecov.io/gh/HerbHall/netvantage/branch/main/graph/badge.svg)](https://codecov.io/gh/HerbHall/netvantage)
 

--- a/docs/adr/0005-hugo-website-github-pages.md
+++ b/docs/adr/0005-hugo-website-github-pages.md
@@ -1,0 +1,67 @@
+# ADR-0005: Project Website with Hugo and GitHub Pages
+
+## Status
+Accepted
+
+## Date
+2025-02-02
+
+## Context
+NetVantage needs a public-facing product website to communicate the project's purpose, features, roadmap, and documentation to potential users and contributors. The project is currently unfunded, so hosting costs must be zero or near-zero. The website should be maintainable by a single developer, automatable via CI/CD, and capable of growing with the project.
+
+The domain netvantage.net has been registered via Cloudflare Registrar (~$12/yr).
+
+Requirements:
+- Product landing page (hero, features, architecture, roadmap)
+- Documentation section (getting started, contributing, architecture, FAQ)
+- Blog for development updates and release announcements
+- Dark theme matching the NetVantage brand identity (forest greens, earth tones)
+- Automated deployment on content changes
+- Zero hosting cost
+
+## Decision
+Use Hugo static site generator with the Hextra theme, deployed to GitHub Pages via GitHub Actions.
+
+- **Hugo site source** lives in a `website/` directory within the main repository
+- **Theme**: Hextra (MIT licensed), installed via Hugo Modules
+- **Deployment**: GitHub Actions workflow triggered on push to `main` when `website/**` files change
+- **Hosting**: GitHub Pages (free for public repositories)
+- **Domain**: netvantage.net with CNAME record pointing to GitHub Pages
+
+## Consequences
+
+### Positive
+- Zero hosting cost (GitHub Pages is free for public repos)
+- Content is version-controlled alongside the code
+- Hugo builds are fast (Go-based, consistent with our tech stack)
+- Hextra provides landing page, documentation, and blog layouts in a single theme
+- No external dependencies required (no Node.js, npm, or database)
+- GitHub Actions automates deployment with zero manual intervention
+- Dark mode and custom CSS support matches NetVantage brand identity
+- Content is Markdown files -- easy for developers to maintain
+- Site can be fully automated (future: auto-generate pages from releases, milestones)
+
+### Negative
+- Hugo Modules require Go to resolve dependencies (handled by CI, not needed locally for content edits)
+- Static site limitations: no server-side forms, no dynamic content without third-party services
+- Custom shortcodes needed for roadmap timeline and architecture diagrams
+- Hextra is a newer theme with a smaller community than Docsy or Hugo Blox
+
+### Neutral
+- The `website/` directory adds ~50 files to the repository but is isolated from application code
+- GitHub Pages enforces HTTPS automatically
+- The workflow only triggers on `website/**` path changes, so application code pushes do not cause rebuilds
+
+## Alternatives Considered
+
+### Alternative 1: WordPress.com (herbhall.net subpage)
+Product page under the existing personal website. Free, no additional hosting, but limited design control on free/personal plans. WordPress.com branding on free tier. Product page lives under a personal site, which limits professional perception. Can't install custom themes/plugins without Business plan ($25/mo).
+
+### Alternative 2: Hugo with Docsy theme
+Docsy (by Google, Apache 2.0) is battle-tested for documentation (used by Kubernetes). Excellent docs features but landing page system requires more manual work. Heavier dependency chain (Hugo Extended + Go + PostCSS + npm). Better choice if documentation is the primary concern and landing page is secondary.
+
+### Alternative 3: Hugo with Hugo Blox theme
+Hugo Blox has the best landing page capabilities (20+ content blocks). But weaker documentation features, "open core" model with some premium blocks behind paywall, and higher complexity. Better choice if marketing is the primary concern and documentation is secondary.
+
+### Alternative 4: Separate hosting (Netlify, Vercel, Cloudflare Pages)
+More features (serverless functions, edge rendering, form handling) but adds another service to manage. Not needed for a static content site. GitHub Pages is sufficient and keeps everything in one platform.

--- a/website/assets/css/custom.css
+++ b/website/assets/css/custom.css
@@ -1,0 +1,227 @@
+/*
+ * NetVantage Brand Colors
+ * Forest greens + earth tones dark theme
+ * See: docs/requirements/12-brand-identity.md
+ */
+
+:root {
+  --primary-hue: 142deg;
+  --primary-saturation: 71%;
+  --primary-lightness: 45%;
+}
+
+/* Dark mode overrides for NetVantage forest green palette */
+html[class~="dark"] {
+  --bg-primary: #0c1a0e;
+  --bg-surface: #0f1a10;
+  --bg-card: #1a2e1c;
+  --accent-primary: #4ade80;
+  --accent-primary-dark: #16a34a;
+  --accent-secondary: #c4a77d;
+  --accent-tertiary: #9ca389;
+  --text-primary: #f5f0e8;
+  --text-secondary: #9ca389;
+  --danger: #ef4444;
+}
+
+/* Apply forest background to dark mode body */
+html[class~="dark"] body {
+  background-color: #0c1a0e;
+}
+
+/* Dark mode content area */
+html[class~="dark"] .nx-bg-white {
+  background-color: #0f1a10;
+}
+
+/* Dark mode card surfaces */
+html[class~="dark"] .hextra-card {
+  background-color: #1a2e1c;
+  border-color: #2d4a30;
+}
+
+html[class~="dark"] .hextra-card:hover {
+  border-color: #4ade80;
+}
+
+/* Feature card styling */
+html[class~="dark"] .hextra-feature-card {
+  background-color: #1a2e1c;
+  border-color: #2d4a30;
+}
+
+html[class~="dark"] .hextra-feature-card:hover {
+  border-color: #4ade80;
+}
+
+/* Primary accent links in dark mode */
+html[class~="dark"] a {
+  color: #4ade80;
+}
+
+html[class~="dark"] a:hover {
+  color: #16a34a;
+}
+
+/* Sidebar active item */
+html[class~="dark"] .sidebar-active {
+  color: #4ade80;
+}
+
+/* Code blocks */
+html[class~="dark"] pre {
+  background-color: #0c1a0e;
+  border: 1px solid #2d4a30;
+}
+
+html[class~="dark"] code {
+  color: #c4a77d;
+}
+
+/* Navbar dark mode */
+html[class~="dark"] nav.nextra-nav-container {
+  background-color: #0f1a10;
+  border-color: #2d4a30;
+}
+
+/* Footer */
+html[class~="dark"] footer {
+  border-color: #2d4a30;
+}
+
+/* Hero section enhancements */
+.hero-gradient {
+  background: linear-gradient(135deg, #0c1a0e 0%, #1a2e1c 50%, #0f1a10 100%);
+}
+
+/* Roadmap shortcode styles */
+.roadmap-timeline {
+  position: relative;
+  padding-left: 2rem;
+}
+
+.roadmap-timeline::before {
+  content: '';
+  position: absolute;
+  left: 0.5rem;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: linear-gradient(to bottom, #4ade80, #2d4a30);
+}
+
+.roadmap-phase {
+  position: relative;
+  margin-bottom: 2rem;
+  padding-left: 1.5rem;
+}
+
+.roadmap-phase::before {
+  content: '';
+  position: absolute;
+  left: -1.75rem;
+  top: 0.5rem;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 2px solid #4ade80;
+  background: #0c1a0e;
+}
+
+.roadmap-phase.active::before {
+  background: #4ade80;
+  box-shadow: 0 0 8px rgba(74, 222, 128, 0.4);
+}
+
+.roadmap-phase.completed::before {
+  background: #16a34a;
+}
+
+.roadmap-phase h3 {
+  margin-top: 0;
+}
+
+.roadmap-phase .phase-status {
+  display: inline-block;
+  padding: 0.125rem 0.5rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.phase-status.planned {
+  background: #2d4a30;
+  color: #9ca389;
+}
+
+.phase-status.active {
+  background: rgba(74, 222, 128, 0.15);
+  color: #4ade80;
+}
+
+.phase-status.completed {
+  background: rgba(22, 163, 74, 0.15);
+  color: #16a34a;
+}
+
+/* Architecture diagram container */
+.architecture-diagram {
+  background: #0c1a0e;
+  border: 1px solid #2d4a30;
+  border-radius: 0.5rem;
+  padding: 1.5rem;
+  overflow-x: auto;
+  margin: 1.5rem 0;
+}
+
+.architecture-diagram pre {
+  margin: 0;
+  background: transparent;
+  border: none;
+  color: #4ade80;
+  font-family: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
+/* Support/sponsor section */
+.sponsor-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  margin: 1.5rem 0;
+}
+
+.sponsor-card {
+  background: #1a2e1c;
+  border: 1px solid #2d4a30;
+  border-radius: 0.5rem;
+  padding: 1.25rem;
+  text-align: center;
+  transition: border-color 0.2s;
+}
+
+.sponsor-card:hover {
+  border-color: #4ade80;
+}
+
+/* Module feature icons */
+.module-icon {
+  width: 2.5rem;
+  height: 2.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.5rem;
+  background: rgba(74, 222, 128, 0.1);
+  color: #4ade80;
+  margin-bottom: 0.75rem;
+  font-size: 1.25rem;
+}
+
+/* Typography: code font override */
+code, pre, .mono {
+  font-family: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', ui-monospace, monospace;
+}

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -1,0 +1,107 @@
+---
+title: NetVantage
+layout: hextra-home
+---
+
+{{< hextra/hero-badge link="https://github.com/HerbHall/netvantage" >}}
+  Open Source on GitHub
+{{< /hextra/hero-badge >}}
+
+<div class="hx-mt-6 hx-mb-6">
+{{< hextra/hero-headline >}}
+  Network Monitoring,&nbsp;<br class="sm:hx-block hx-hidden" />Unified and Self-Hosted
+{{< /hextra/hero-headline >}}
+</div>
+
+<div class="hx-mb-12">
+{{< hextra/hero-subtitle >}}
+  Modular platform for device discovery, monitoring, remote access,&nbsp;<br class="sm:hx-block hx-hidden" />credential management, and IoT awareness — in a single application.
+{{< /hextra/hero-subtitle >}}
+</div>
+
+<div class="hx-mb-6">
+{{< hextra/hero-button text="Get Started" link="docs/getting-started" >}}
+{{< hextra/hero-button text="View on GitHub" link="https://github.com/HerbHall/netvantage" style="alt" >}}
+</div>
+
+<div class="hx-mt-6"></div>
+
+## Modules
+
+{{< hextra/feature-grid >}}
+  {{< hextra/feature-card
+    title="Recon"
+    subtitle="Network scanning and device discovery. Automatically find every device on your network using ARP, ICMP, SNMP, mDNS, and UPnP."
+    icon="magnifying-glass"
+  >}}
+  {{< hextra/feature-card
+    title="Pulse"
+    subtitle="Health monitoring, metrics collection, and alerting. Track device availability, performance, and resource utilization in real time."
+    icon="heart"
+  >}}
+  {{< hextra/feature-card
+    title="Dispatch"
+    subtitle="Scout agent enrollment and management. Deploy lightweight agents to Windows, Linux, and macOS endpoints for deep telemetry."
+    icon="paper-airplane"
+  >}}
+  {{< hextra/feature-card
+    title="Vault"
+    subtitle="Encrypted credential storage. Securely manage SSH keys, SNMP community strings, and device passwords with zero-knowledge encryption."
+    icon="lock-closed"
+  >}}
+  {{< hextra/feature-card
+    title="Gateway"
+    subtitle="Browser-based remote access. Connect to devices via SSH, RDP, and HTTP proxy directly from the dashboard — no VPN required."
+    icon="globe-alt"
+  >}}
+  {{< hextra/feature-card
+    title="Plugin Architecture"
+    subtitle="Every major feature is a plugin. Replace, extend, or supplement any module. Apache 2.0 licensed SDK for third-party development."
+    icon="puzzle-piece"
+  >}}
+{{< /hextra/feature-grid >}}
+
+## Architecture
+
+{{< architecture-diagram >}}
+
+## Why NetVantage?
+
+<div class="hx-mt-4">
+
+No existing source-available tool combines device discovery, monitoring, remote access, credential management, and IoT awareness in a single product.
+
+**One tool instead of five.** Stop stitching together Zabbix for monitoring, Netbox for inventory, Guacamole for remote access, and a password manager for credentials. NetVantage does it all.
+
+**Free for personal use, forever.** Built for home labs, prosumers, and small business IT. The core is licensed under BSL 1.1, which converts to Apache 2.0 after 4 years. The plugin SDK is Apache 2.0 from day one.
+
+**Time to First Value under 10 minutes.** Download, install, see your network. No complex configuration, no mandatory dependencies, no tech degree required.
+
+**Self-hosted. Your data stays yours.** No cloud dependency. No telemetry. No vendor lock-in. Run it on your hardware, your way.
+
+</div>
+
+## Roadmap
+
+{{< roadmap >}}
+
+## Support the Project
+
+NetVantage is free for personal, home-lab, and non-competing production use. If you find it useful and want to support continued development:
+
+<div class="sponsor-grid">
+  <a href="https://github.com/sponsors/HerbHall" class="sponsor-card">
+    <strong>GitHub Sponsors</strong><br/>
+    <small>Monthly or one-time sponsorship</small>
+  </a>
+  <a href="https://ko-fi.com/herbhall" class="sponsor-card">
+    <strong>Ko-fi</strong><br/>
+    <small>Buy me a coffee</small>
+  </a>
+  <a href="https://buymeacoffee.com/herbhall" class="sponsor-card">
+    <strong>Buy Me a Coffee</strong><br/>
+    <small>One-time support</small>
+  </a>
+</div>
+
+Financial supporters are recognized in [SUPPORTERS.md](https://github.com/HerbHall/netvantage/blob/main/SUPPORTERS.md) and the in-app About page.

--- a/website/content/blog/_index.md
+++ b/website/content/blog/_index.md
@@ -1,0 +1,5 @@
+---
+title: Blog
+---
+
+Development updates, release announcements, and technical deep-dives from the NetVantage project.

--- a/website/content/blog/introducing-netvantage/index.md
+++ b/website/content/blog/introducing-netvantage/index.md
@@ -1,0 +1,81 @@
+---
+title: Introducing NetVantage
+date: 2025-02-02
+authors:
+  - name: Herb Hall
+    link: https://github.com/HerbHall
+tags:
+  - announcement
+  - roadmap
+---
+
+NetVantage is a modular, self-hosted network monitoring and management platform -- and today we're making it public.
+
+<!--more-->
+
+## The Problem
+
+If you manage a home lab, a small business network, or client infrastructure as an MSP, you've probably assembled a patchwork of tools: one for device discovery, another for monitoring, a separate solution for remote access, and yet another for credential management. Each has its own setup, its own update cycle, and its own learning curve.
+
+We set out to build something better.
+
+## What NetVantage Is
+
+NetVantage combines five capabilities into a single self-hosted application:
+
+- **Recon** -- Network scanning and device discovery (ARP, ICMP, SNMP, mDNS, UPnP)
+- **Pulse** -- Health monitoring, metrics collection, and alerting
+- **Dispatch** -- Scout agent enrollment and management across Windows, Linux, and macOS
+- **Vault** -- Encrypted credential storage with zero-knowledge architecture
+- **Gateway** -- Browser-based remote access via SSH, RDP, and HTTP proxy
+
+Every module is a plugin. You can replace, extend, or supplement any part of the system. The Plugin SDK is licensed under Apache 2.0, so there are no restrictions on building integrations.
+
+## Design Principles
+
+Four principles guide every decision:
+
+1. **Ease of use first.** You shouldn't need a tech degree to understand your network health.
+2. **Sensible defaults, deep customization.** Install and go. Then make it yours.
+3. **Stability and security are non-negotiable.** If a feature compromises either, it doesn't ship.
+4. **Time to First Value under 10 minutes.** Download, install, see your network.
+
+## Current Status
+
+NetVantage is in **Phase 1: Foundation**. Here's what's implemented:
+
+- Go server with HTTP API and middleware stack
+- Plugin registry with lifecycle management and dependency resolution
+- SQLite database with repository pattern
+- Health and plugin status endpoints
+- JWT authentication framework
+- Prometheus metrics integration
+- CI/CD pipeline across Windows, Linux, and macOS
+
+## What's Next
+
+The immediate roadmap:
+
+- **Phase 1 (continued)**: React dashboard shell, agentless network scanning, topology visualization
+- **Phase 1b**: Windows Scout agent with gRPC communication
+- **Phase 2**: SNMP/mDNS/UPnP discovery, comprehensive monitoring, alerting, multi-tenancy
+- **Phase 3**: Browser-based remote access, encrypted credential vault
+- **Phase 4**: MQTT/IoT awareness, cross-platform agents, ecosystem growth
+
+## Licensing
+
+NetVantage uses a split licensing model:
+
+- **Core**: BSL 1.1 -- free for personal, home-lab, educational, and non-competing production use. Converts to Apache 2.0 after 4 years.
+- **Plugin SDK**: Apache 2.0 -- no restrictions.
+
+This means individual users and small businesses can use NetVantage freely, while the project maintains a sustainable path for commercial development.
+
+## Get Involved
+
+- **Star the repo**: [github.com/HerbHall/netvantage](https://github.com/HerbHall/netvantage)
+- **Report issues**: [Issue tracker](https://github.com/HerbHall/netvantage/issues)
+- **Contribute**: [Contributing guide](/docs/contributing)
+- **Support development**: [GitHub Sponsors](https://github.com/sponsors/HerbHall) | [Ko-fi](https://ko-fi.com/herbhall) | [Buy Me a Coffee](https://buymeacoffee.com/herbhall)
+
+We're building NetVantage in the open and welcome feedback at every stage. If you manage networks and want a unified, self-hosted solution, we'd love to hear from you.

--- a/website/content/docs/_index.md
+++ b/website/content/docs/_index.md
@@ -1,0 +1,14 @@
+---
+title: Documentation
+cascade:
+  type: docs
+---
+
+Welcome to the NetVantage documentation. Here you'll find everything you need to get started, contribute, and understand the architecture.
+
+{{< cards >}}
+  {{< card link="getting-started" title="Getting Started" icon="play" subtitle="Install, configure, and run NetVantage in under 10 minutes." >}}
+  {{< card link="architecture" title="Architecture" icon="cube" subtitle="Understand the system design, plugin model, and data flow." >}}
+  {{< card link="contributing" title="Contributing" icon="users" subtitle="Report bugs, request features, and submit code contributions." >}}
+  {{< card link="faq" title="FAQ" icon="question-mark-circle" subtitle="Licensing, self-hosting, plugin development, and more." >}}
+{{< /cards >}}

--- a/website/content/docs/architecture/_index.md
+++ b/website/content/docs/architecture/_index.md
@@ -1,0 +1,95 @@
+---
+title: Architecture
+weight: 2
+---
+
+NetVantage is a modular, self-hosted network monitoring platform built in Go with a React/TypeScript dashboard.
+
+## System Overview
+
+```
+                    +------------------+
+                    |    Dashboard     |
+                    | (React + TS)     |
+                    +--------+---------+
+                             |
+                    REST / WebSocket
+                             |
++----------+       +---------+---------+       +----------+
+|  Scout   | gRPC  |   NetVantage      |       | Network  |
+|  Agent   +------>+   Server (Go)     +------>+ Devices  |
+|          |       |                   | ICMP/  | (SNMP,   |
++----------+       | +------+ +------+ | SNMP/  |  mDNS,   |
+                   | |Recon | |Pulse | | ARP/   |  UPnP)   |
+                   | +------+ +------+ | mDNS   +----------+
+                   | |Dsptch | Vault | |
+                   | +------+ +------+ |
+                   | |Gatway |        |
+                   | +------+         |
+                   +-------------------+
+```
+
+## Components
+
+### NetVantage Server
+
+The core Go application. Hosts the REST API, serves the dashboard SPA, manages the plugin lifecycle, and coordinates all modules.
+
+- **HTTP server** with middleware stack (logging, recovery, CORS, metrics)
+- **gRPC server** for Scout agent communication
+- **Plugin registry** with dependency resolution and lifecycle management
+- **SQLite database** for persistent storage
+- **Event bus** for decoupled inter-module communication
+
+### Dashboard
+
+React + TypeScript single-page application served by the Go server. Communicates via REST API and WebSocket for real-time updates.
+
+### Scout Agent
+
+Lightweight agent deployed to endpoints. Connects to the server via gRPC and reports system metrics, health status, and telemetry.
+
+## Plugin Architecture
+
+Every major feature in NetVantage is a plugin. The plugin system is inspired by [Caddy's module architecture](https://caddyserver.com/) (see [ADR-0003](https://github.com/HerbHall/netvantage/blob/main/docs/adr/0003-plugin-architecture-caddy-model.md)).
+
+Plugins implement role interfaces defined in the SDK:
+
+| Role | Interface | Description |
+|------|-----------|-------------|
+| Scanner | `ScannerPlugin` | Network discovery methods |
+| Monitor | `MonitorPlugin` | Health checks and metrics collection |
+| Notifier | `NotifierPlugin` | Alert delivery channels |
+| Store | `StorePlugin` | Data persistence backends |
+| HealthChecker | `HealthChecker` | Component health reporting |
+
+The Plugin SDK is licensed under **Apache 2.0** -- no restrictions on building and distributing plugins.
+
+## Database
+
+NetVantage uses SQLite as its primary database (see [ADR-0002](https://github.com/HerbHall/netvantage/blob/main/docs/adr/0002-sqlite-first-database.md)). Benefits:
+
+- Zero external dependencies -- no separate database server
+- Single-file backup and restore
+- Sufficient for the target scale (home lab to small business)
+- Optional upgrade path to PostgreSQL for larger deployments
+
+## API Design
+
+- RESTful JSON API under `/api/v1/`
+- [RFC 7807](https://datatracker.ietf.org/doc/html/rfc7807) structured error responses
+- `X-NetVantage-Version` header on all responses
+- Integer-based protocol versioning (see [ADR-0004](https://github.com/HerbHall/netvantage/blob/main/docs/adr/0004-integer-protocol-versioning.md))
+
+## Licensing Model
+
+Split licensing to balance open-source accessibility with commercial sustainability (see [ADR-0001](https://github.com/HerbHall/netvantage/blob/main/docs/adr/0001-split-licensing-model.md)):
+
+- **Core** (server, agent, built-in modules): BSL 1.1 -- free for personal, home-lab, educational, and non-competing production use. Converts to Apache 2.0 after 4 years.
+- **Plugin SDK** (`pkg/plugin/`, `pkg/roles/`, `pkg/models/`, `api/proto/`): Apache 2.0 -- build plugins with no restrictions.
+
+## Further Reading
+
+- [Requirements specifications](https://github.com/HerbHall/netvantage/tree/main/docs/requirements) -- 28 detailed requirement documents
+- [Architecture Decision Records](https://github.com/HerbHall/netvantage/tree/main/docs/adr) -- recorded architectural decisions
+- [Development setup](/docs/contributing/development-setup) -- get the codebase running locally

--- a/website/content/docs/contributing/_index.md
+++ b/website/content/docs/contributing/_index.md
@@ -1,0 +1,47 @@
+---
+title: Contributing
+weight: 3
+---
+
+NetVantage welcomes contributions from the community. Whether you're reporting a bug, requesting a feature, or submitting code, this section covers everything you need to know.
+
+## Quick Links
+
+{{< cards >}}
+  {{< card link="reporting-bugs" title="Report a Bug" icon="exclamation-circle" subtitle="Found something broken? Help us fix it." >}}
+  {{< card link="feature-requests" title="Request a Feature" icon="light-bulb" subtitle="Have an idea? We'd love to hear it." >}}
+  {{< card link="development-setup" title="Development Setup" icon="code" subtitle="Set up your environment to contribute code." >}}
+{{< /cards >}}
+
+## Contributor License Agreement
+
+All contributors must sign the [CLA](https://github.com/HerbHall/netvantage/blob/main/.github/CLA.md) before their first PR can be merged. This is automated -- the CLA bot will prompt you on your first pull request.
+
+**Why a CLA?** NetVantage uses a split licensing model (BSL 1.1 + Apache 2.0). The CLA ensures a clean IP chain, which is essential for the project's long-term sustainability.
+
+## Code of Conduct
+
+All contributors are expected to follow our [Code of Conduct](https://github.com/HerbHall/netvantage/blob/main/CODE_OF_CONDUCT.md). We are committed to providing a welcoming and inclusive environment.
+
+## Commit Conventions
+
+NetVantage uses [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: add device type icon mapping
+fix: prevent duplicate scan entries on network change
+refactor: extract plugin lifecycle into separate package
+docs: update API endpoint documentation
+test: add integration tests for Recon module
+chore: update golangci-lint to v1.62
+```
+
+- Keep the subject line under 72 characters
+- Use the imperative mood ("add", not "added" or "adds")
+- Reference issues when applicable: `fix: resolve scan timeout (#42)`
+
+## Licensing
+
+- Contributions to **core code** fall under BSL 1.1 (covered by the CLA)
+- Contributions to the **Plugin SDK** (`pkg/plugin/`, `pkg/roles/`, `pkg/models/`, `api/proto/`) fall under Apache 2.0
+- Do not introduce dependencies with GPL, AGPL, LGPL, or SSPL licenses

--- a/website/content/docs/contributing/development-setup.md
+++ b/website/content/docs/contributing/development-setup.md
@@ -1,0 +1,99 @@
+---
+title: Development Setup
+weight: 3
+---
+
+Set up your local environment to contribute code to NetVantage.
+
+## Prerequisites
+
+- **Go 1.25+** -- [download](https://go.dev/dl/)
+- **Make** -- build automation
+- **Git** -- version control
+
+## Clone and Build
+
+```bash
+# Fork the repository on GitHub, then:
+git clone https://github.com/YOUR_USERNAME/netvantage.git
+cd netvantage
+make build
+```
+
+## Run Tests
+
+```bash
+make test
+```
+
+## Run Linter
+
+```bash
+make lint
+```
+
+Uses [golangci-lint](https://golangci-lint.run/) with the project's `.golangci.yml` configuration.
+
+## Development Workflow
+
+1. **Fork** the repository and create a branch from `main`
+2. **Branch naming**: `feature/short-description`, `fix/short-description`, `refactor/short-description`
+3. Make your changes following the code style guidelines
+4. Write tests for new functionality
+5. Run checks: `make test && make lint`
+6. Commit using [Conventional Commits](/docs/contributing/#commit-conventions)
+7. Push and open a Pull Request against `main`
+
+## Code Style
+
+| Rule | Details |
+|------|---------|
+| Formatting | `gofmt` (enforced by CI) |
+| Linting | golangci-lint with project configuration |
+| Error handling | Return errors, don't panic. Wrap with context. |
+| Logging | `go.uber.org/zap` structured logging (never `fmt.Println`) |
+| Context | Pass `context.Context` as the first parameter |
+| Interfaces | Define in consumer package, not provider |
+| Tests | Table-driven. Use `testify` for assertions. |
+| SQL | Raw SQL with thin repository layer. No ORM. |
+| Comments | Only where logic isn't self-evident |
+
+## Project Structure
+
+```
+cmd/
+  netvantage/     Server entry point
+  scout/          Agent entry point
+internal/
+  config/         Configuration management
+  event/          In-memory event bus
+  registry/       Plugin lifecycle and dependency resolution
+  server/         HTTP server
+  version/        Build-time version injection
+  recon/          Network discovery module
+  pulse/          Monitoring module
+  dispatch/       Agent management module
+  vault/          Credential management module
+  gateway/        Remote access module
+  scout/          Agent core logic
+pkg/
+  plugin/         Public plugin SDK (Apache 2.0)
+  models/         Shared data types
+api/
+  proto/v1/       gRPC service definitions
+docs/
+  adr/            Architecture Decision Records
+  guides/         Developer guides
+  requirements/   Requirement specifications
+web/              React dashboard (TypeScript)
+```
+
+## Pull Request Process
+
+1. Fill out the [PR template](https://github.com/HerbHall/netvantage/blob/main/.github/pull_request_template.md) completely
+2. Ensure CI passes (build, test, lint, license check)
+3. Request review from a maintainer
+4. Address review feedback
+5. Squash or rebase as needed before merge
+
+For more details, see the full [CONTRIBUTING.md](https://github.com/HerbHall/netvantage/blob/main/CONTRIBUTING.md) in the repository.

--- a/website/content/docs/contributing/feature-requests.md
+++ b/website/content/docs/contributing/feature-requests.md
@@ -1,0 +1,39 @@
+---
+title: Feature Requests
+weight: 2
+---
+
+Have an idea for NetVantage? We'd love to hear it.
+
+## Before Requesting
+
+1. **Check the roadmap** -- your idea may already be planned. See the [Roadmap](/#roadmap) for upcoming phases.
+2. **Search existing issues** -- check [open issues](https://github.com/HerbHall/netvantage/issues) for similar requests
+3. **Review the requirements** -- detailed planning docs are in [docs/requirements/](https://github.com/HerbHall/netvantage/tree/main/docs/requirements)
+
+## How to Request
+
+Use the [Feature Request template](https://github.com/HerbHall/netvantage/issues/new?template=feature_request.md) on GitHub.
+
+A good feature request includes:
+
+- **Problem statement** -- what are you trying to accomplish?
+- **Proposed solution** -- how do you envision this working?
+- **Alternatives considered** -- have you tried other approaches?
+- **Use case** -- who benefits and in what scenario?
+
+## Plugin vs Core
+
+NetVantage has a plugin architecture. Consider whether your request:
+
+- **Fits as a plugin** -- self-contained functionality that extends the platform (e.g., a new notification channel, a custom discovery method, an integration with a third-party service)
+- **Fits in core** -- fundamental platform capability that other features depend on (e.g., authentication, database changes, API framework modifications)
+
+Plugin requests can often be implemented independently using the [Apache 2.0 licensed Plugin SDK](https://github.com/HerbHall/netvantage/tree/main/pkg/plugin).
+
+## What Happens Next
+
+1. A maintainer will review and label the request
+2. Community discussion may follow to refine the idea
+3. Accepted features are added to the appropriate milestone
+4. You'll be credited in the issue when the feature ships

--- a/website/content/docs/contributing/reporting-bugs.md
+++ b/website/content/docs/contributing/reporting-bugs.md
@@ -1,0 +1,39 @@
+---
+title: Reporting Bugs
+weight: 1
+---
+
+Found a bug? We appreciate your help in improving NetVantage.
+
+## Before Reporting
+
+1. **Search existing issues** -- check [open issues](https://github.com/HerbHall/netvantage/issues) to see if the bug has already been reported
+2. **Reproduce the issue** -- confirm you can reproduce it reliably
+3. **Update to latest** -- verify the bug exists on the latest version of `main`
+
+## How to Report
+
+Use the [Bug Report template](https://github.com/HerbHall/netvantage/issues/new?template=bug_report.md) on GitHub.
+
+Include the following information:
+
+### Required
+- **What happened** -- clear description of the bug
+- **What you expected** -- what should have happened instead
+- **Steps to reproduce** -- numbered steps to trigger the bug
+- **Environment** -- OS, Go version, NetVantage version
+
+### Helpful
+- **Logs** -- relevant server or agent log output
+- **Configuration** -- relevant sections of your config file (redact credentials)
+- **Screenshots** -- if the bug involves the dashboard UI
+
+## Security Vulnerabilities
+
+If you've found a security vulnerability, **do not open a public issue**. Instead, follow the [Security Policy](https://github.com/HerbHall/netvantage/blob/main/SECURITY.md) for responsible disclosure.
+
+## What Happens Next
+
+1. A maintainer will triage the issue and add appropriate labels
+2. The issue will be prioritized based on severity and impact
+3. You'll be notified when work begins and when a fix is available

--- a/website/content/docs/faq/_index.md
+++ b/website/content/docs/faq/_index.md
@@ -1,0 +1,84 @@
+---
+title: FAQ
+weight: 4
+---
+
+Frequently asked questions about NetVantage.
+
+## General
+
+### What is NetVantage?
+
+NetVantage is a modular, self-hosted network monitoring and management platform. It combines device discovery, monitoring, remote access, credential management, and IoT awareness in a single application.
+
+### Who is NetVantage for?
+
+- Home lab enthusiasts
+- Prosumers managing home networks
+- Small business IT administrators
+- Managed service providers (MSPs)
+
+### What's the current status?
+
+NetVantage is in **Phase 1: Foundation** development. The core server, HTTP API, plugin registry, and SQLite database are implemented. See the [Roadmap](/#roadmap) for details on upcoming phases.
+
+### Is there a hosted/cloud version?
+
+No. NetVantage is self-hosted by design. Your data stays on your hardware. There are no plans for a SaaS offering.
+
+## Licensing
+
+### Is NetVantage free?
+
+Yes, for personal, home-lab, educational, and non-competing production use. The core is licensed under [Business Source License 1.1](https://github.com/HerbHall/netvantage/blob/main/LICENSE) with an Additional Use Grant covering these use cases.
+
+### What does the BSL 1.1 license mean?
+
+- **Free** for personal, home-lab, educational, and non-competing production use
+- **Commercial license required** if you're competing with NetVantage as a product
+- **Automatically converts to Apache 2.0** four years after each release
+- This is the same model used by HashiCorp, MariaDB, CockroachDB, and Sentry
+
+### Can I build plugins?
+
+Yes. The Plugin SDK (`pkg/plugin/`, `pkg/roles/`, `pkg/models/`, `api/proto/`) is licensed under **Apache 2.0** with no restrictions. You can build and distribute commercial or open-source plugins freely.
+
+### Can I use NetVantage at my company?
+
+Yes, as long as you're not building a competing network monitoring product. Using NetVantage to monitor your company's infrastructure is an explicitly permitted use case.
+
+## Technical
+
+### What languages/frameworks does NetVantage use?
+
+- **Server**: Go 1.25+
+- **Dashboard**: React + TypeScript
+- **Agent communication**: gRPC
+- **Database**: SQLite (with optional PostgreSQL upgrade path)
+- **API**: RESTful JSON with RFC 7807 error responses
+
+### What protocols does NetVantage support?
+
+Currently planned: SNMP (v1/v2c/v3), ICMP, ARP, mDNS, UPnP, and MQTT. Protocol support is being added progressively through the phased roadmap.
+
+### Can I run it on Windows?
+
+Yes. NetVantage compiles and runs on Windows, Linux, and macOS. CI tests run across all three platforms.
+
+### How does the plugin system work?
+
+Every major feature is a plugin that implements role interfaces defined in the SDK. Plugins are registered at startup and managed through a lifecycle system with dependency resolution. See the [Architecture](/docs/architecture) page for details.
+
+## Contributing
+
+### How do I contribute?
+
+See the [Contributing](/docs/contributing) section for guides on reporting bugs, requesting features, and setting up a development environment.
+
+### Do I need to sign a CLA?
+
+Yes. All contributors must sign the Contributor License Agreement before their first PR can be merged. This is automated through a GitHub bot. The CLA ensures a clean IP chain for the project's split licensing model.
+
+### What dependencies are blocked?
+
+GPL, AGPL, LGPL, and SSPL licensed dependencies are not permitted. The CI pipeline includes a license check that enforces this. See `make license-check`.

--- a/website/content/docs/getting-started/_index.md
+++ b/website/content/docs/getting-started/_index.md
@@ -1,0 +1,62 @@
+---
+title: Getting Started
+weight: 1
+---
+
+Get NetVantage running in under 10 minutes.
+
+## Prerequisites
+
+- **Go 1.25+** (for building from source)
+- **Make** (optional but recommended)
+- **Git** (for cloning the repository)
+
+## Build from Source
+
+```bash
+git clone https://github.com/HerbHall/netvantage.git
+cd netvantage
+make build
+```
+
+This produces two binaries in `bin/`:
+- `netvantage` -- the server
+- `scout` -- the agent
+
+## Run the Server
+
+```bash
+./bin/netvantage
+```
+
+Or with a custom configuration file:
+
+```bash
+./bin/netvantage -config configs/netvantage.example.yaml
+```
+
+The server starts on `http://localhost:8080` by default.
+
+## Verify It's Running
+
+```bash
+curl http://localhost:8080/api/v1/health
+```
+
+You should see a JSON response with system health status.
+
+## Run the Scout Agent
+
+On remote machines you want to monitor:
+
+```bash
+./bin/scout -server localhost:9090 -interval 30
+```
+
+The agent connects to the server via gRPC and reports metrics at the configured interval.
+
+## What's Next?
+
+- [Installation options](installation) -- binary, Docker, Docker Compose
+- [Configuration reference](configuration) -- all YAML keys, environment variables, and defaults
+- [Architecture overview](/docs/architecture) -- how the system fits together

--- a/website/content/docs/getting-started/configuration.md
+++ b/website/content/docs/getting-started/configuration.md
@@ -1,0 +1,55 @@
+---
+title: Configuration
+weight: 2
+---
+
+NetVantage uses a YAML configuration file with sensible defaults. The server runs out of the box with no configuration required.
+
+## Configuration File
+
+By default, NetVantage looks for configuration in:
+
+1. `./netvantage.yaml` (current directory)
+2. `$HOME/.config/netvantage/netvantage.yaml`
+3. `/etc/netvantage/netvantage.yaml`
+
+Or specify a path explicitly:
+
+```bash
+./bin/netvantage -config /path/to/netvantage.yaml
+```
+
+## Example Configuration
+
+An example configuration file is included in the repository:
+
+```bash
+cp configs/netvantage.example.yaml netvantage.yaml
+```
+
+## Environment Variables
+
+All configuration values can be overridden via environment variables using the `NETVANTAGE_` prefix with underscore-separated paths.
+
+| YAML Path | Environment Variable | Default |
+|-----------|---------------------|---------|
+| `server.http.port` | `NETVANTAGE_SERVER_HTTP_PORT` | `8080` |
+| `server.grpc.port` | `NETVANTAGE_SERVER_GRPC_PORT` | `9090` |
+| `database.path` | `NETVANTAGE_DATABASE_PATH` | `./data/netvantage.db` |
+| `log.level` | `NETVANTAGE_LOG_LEVEL` | `info` |
+| `log.format` | `NETVANTAGE_LOG_FORMAT` | `json` |
+
+## API Endpoints
+
+Once running, the following endpoints are available:
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /api/v1/health` | Aggregated health status from all plugins |
+| `GET /api/v1/plugins` | List of registered plugins and their status |
+
+All API responses include the `X-NetVantage-Version` header.
+
+{{< callout type="info" >}}
+Configuration options will expand as new modules are implemented. This page reflects the current Phase 1 configuration surface. See the [full requirements](https://github.com/HerbHall/netvantage/tree/main/docs/requirements) for planned configuration options.
+{{< /callout >}}

--- a/website/content/docs/getting-started/installation.md
+++ b/website/content/docs/getting-started/installation.md
@@ -1,0 +1,73 @@
+---
+title: Installation
+weight: 1
+---
+
+NetVantage can be installed from source, as a standalone binary, or via Docker.
+
+## From Source
+
+Requires Go 1.25+ and Make.
+
+```bash
+git clone https://github.com/HerbHall/netvantage.git
+cd netvantage
+make build
+```
+
+Binaries are output to the `bin/` directory.
+
+## Standalone Binary
+
+Download the latest release from [GitHub Releases](https://github.com/HerbHall/netvantage/releases).
+
+{{< callout type="info" >}}
+Pre-built binaries will be available starting with the first tagged release. NetVantage is currently in Phase 1 development -- building from source is the recommended method.
+{{< /callout >}}
+
+## Docker
+
+```bash
+docker run -d \
+  --name netvantage \
+  -p 8080:8080 \
+  -p 9090:9090 \
+  -v netvantage-data:/data \
+  ghcr.io/herbhall/netvantage:latest
+```
+
+## Docker Compose
+
+```yaml
+version: '3.8'
+services:
+  netvantage:
+    image: ghcr.io/herbhall/netvantage:latest
+    ports:
+      - "8080:8080"   # HTTP API + Dashboard
+      - "9090:9090"   # gRPC (Scout agents)
+    volumes:
+      - netvantage-data:/data
+    restart: unless-stopped
+
+volumes:
+  netvantage-data:
+```
+
+{{< callout type="info" >}}
+Docker images will be published starting with the first tagged release. The above examples show the intended deployment method.
+{{< /callout >}}
+
+## System Requirements
+
+| Component | Minimum | Recommended |
+|-----------|---------|-------------|
+| CPU | 1 core | 2+ cores |
+| RAM | 256 MB | 512 MB+ |
+| Disk | 100 MB + data | 1 GB+ |
+| OS | Linux, Windows, macOS | Linux (production) |
+
+## Next Steps
+
+- [Configuration reference](../configuration) -- customize ports, database, logging
+- [Architecture overview](/docs/architecture) -- understand the system design

--- a/website/go.mod
+++ b/website/go.mod
@@ -1,0 +1,5 @@
+module github.com/HerbHall/netvantage/website
+
+go 1.22.0
+
+require github.com/imfing/hextra v0.9.3 // indirect

--- a/website/hugo.yaml
+++ b/website/hugo.yaml
@@ -1,0 +1,89 @@
+baseURL: https://netvantage.net/
+languageCode: en-us
+title: NetVantage
+
+# Theme via Hugo Modules
+module:
+  imports:
+    - path: github.com/imfing/hextra
+
+enableRobotsTXT: true
+enableGitInfo: true
+
+markup:
+  goldmark:
+    renderer:
+      unsafe: true
+  highlight:
+    noClasses: false
+
+# Main navigation
+menu:
+  main:
+    - name: Docs
+      pageRef: /docs
+      weight: 1
+    - name: Blog
+      pageRef: /blog
+      weight: 2
+    - name: GitHub
+      url: https://github.com/HerbHall/netvantage
+      weight: 3
+      params:
+        icon: github
+    - name: Search
+      weight: 4
+      params:
+        type: search
+
+  sidebar:
+    - name: More
+      params:
+        type: separator
+      weight: 1
+    - name: GitHub Repository
+      url: https://github.com/HerbHall/netvantage
+      weight: 2
+    - name: Report an Issue
+      url: https://github.com/HerbHall/netvantage/issues/new/choose
+      weight: 3
+
+params:
+  description: Modular, self-hosted network monitoring and management platform.
+
+  theme:
+    default: dark
+    displayToggle: true
+
+  navbar:
+    displayTitle: true
+    displayLogo: true
+    logo:
+      path: images/logo.svg
+      dark: images/logo.svg
+      link: /
+      width: 40
+      height: 20
+
+  page:
+    width: wide
+
+  editURL:
+    enable: true
+    base: https://github.com/HerbHall/netvantage/edit/main/website/content
+
+  search:
+    enable: true
+    type: flexsearch
+    flexsearch:
+      index: content
+
+  footer:
+    displayCopyright: true
+    displayPoweredBy: false
+
+  blog:
+    list:
+      displayTags: true
+
+copyright: "Copyright &copy; {year} Herb Hall. NetVantage is licensed under BSL 1.1."

--- a/website/layouts/shortcodes/architecture-diagram.html
+++ b/website/layouts/shortcodes/architecture-diagram.html
@@ -1,0 +1,23 @@
+<div class="architecture-diagram">
+<pre>
+                    +------------------+
+                    |    Dashboard     |
+                    | (React + TS)     |
+                    +--------+---------+
+                             |
+                    REST / WebSocket
+                             |
++----------+       +---------+---------+       +----------+
+|  Scout   | gRPC  |   NetVantage      |       | Network  |
+|  Agent   +------&gt;+   Server (Go)     +------&gt;+ Devices  |
+|          |       |                   | ICMP/  | (SNMP,   |
++----------+       | +------+ +------+ | SNMP/  |  mDNS,   |
+                   | |Recon | |Pulse | | ARP/   |  UPnP)   |
+                   | +------+ +------+ | mDNS   +----------+
+                   | |Dsptch | Vault | |
+                   | +------+ +------+ |
+                   | |Gatway |        |
+                   | +------+         |
+                   +-------------------+
+</pre>
+</div>

--- a/website/layouts/shortcodes/roadmap.html
+++ b/website/layouts/shortcodes/roadmap.html
@@ -1,0 +1,37 @@
+<div class="roadmap-timeline">
+  <div class="roadmap-phase completed">
+    <h3>Phase 0: Pre-Development Infrastructure</h3>
+    <span class="phase-status completed">Complete</span>
+    <p>Project infrastructure, tooling, CI/CD pipelines, documentation framework, and development processes.</p>
+  </div>
+
+  <div class="roadmap-phase active">
+    <h3>Phase 1: Foundation</h3>
+    <span class="phase-status active">In Progress</span>
+    <p>Server + dashboard + agentless scanning. HTTP API with health endpoints, plugin registry, SQLite database, React dashboard shell. <strong>Time to First Value under 10 minutes.</strong></p>
+  </div>
+
+  <div class="roadmap-phase">
+    <h3>Phase 1b: Windows Scout Agent</h3>
+    <span class="phase-status planned">Planned</span>
+    <p>First Scout agent deployment targeting Windows endpoints. gRPC communication with the server for metrics reporting and remote management.</p>
+  </div>
+
+  <div class="roadmap-phase">
+    <h3>Phase 2: Core Monitoring + Multi-Tenancy</h3>
+    <span class="phase-status planned">Planned</span>
+    <p>SNMP, mDNS, and UPnP discovery. Comprehensive monitoring with alerting. Linux agent. MSP-ready multi-tenancy support.</p>
+  </div>
+
+  <div class="roadmap-phase">
+    <h3>Phase 3: Remote Access + Credential Vault</h3>
+    <span class="phase-status planned">Planned</span>
+    <p>Browser-based SSH, RDP, and HTTP proxy access. Encrypted credential vault with zero-knowledge architecture. macOS agent.</p>
+  </div>
+
+  <div class="roadmap-phase">
+    <h3>Phase 4: Extended Platform</h3>
+    <span class="phase-status planned">Planned</span>
+    <p>MQTT/IoT awareness, cross-platform agent expansion, third-party API integrations, and ecosystem growth.</p>
+  </div>
+</div>

--- a/website/static/CNAME
+++ b/website/static/CNAME
@@ -1,0 +1,1 @@
+netvantage.net

--- a/website/static/images/logo.svg
+++ b/website/static/images/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 40" fill="none">
+  <text x="2" y="30" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, sans-serif" font-size="28" font-weight="700" fill="#4ade80">N</text>
+  <text x="24" y="30" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, sans-serif" font-size="28" font-weight="400" fill="#f5f0e8">etVantage</text>
+</svg>


### PR DESCRIPTION
## Summary

Closes #19

Set up a product website for NetVantage using Hugo (Hextra theme) deployed to GitHub Pages via GitHub Actions with the custom domain netvantage.net.

- **Landing page**: hero section, feature grid (5 modules), architecture diagram, roadmap timeline, sponsor links
- **Documentation**: getting started (install, config), contributing (bugs, features, dev setup), architecture overview, FAQ
- **Blog**: initial "Introducing NetVantage" post
- **Infrastructure**: GitHub Actions workflow with path filtering, CNAME for custom domain, NetVantage brand dark theme CSS
- **ADR-0005**: documents the Hugo + GitHub Pages + Hextra decision

### Files added/modified
- `website/` -- entire Hugo site (20 files)
- `.github/workflows/website.yml` -- deployment workflow
- `docs/adr/0005-hugo-website-github-pages.md` -- architecture decision record
- `.gitignore` -- Hugo build artifact entries
- `README.md` -- website badge

### Theme: Hextra
- MIT licensed, actively maintained
- Zero npm/Node.js dependencies
- Built-in landing page, documentation, and blog layouts
- Dark mode with custom CSS color overrides
- FlexSearch for full-text documentation search

### No conflicts with other branches
The `website/` directory and `.github/workflows/website.yml` do not overlap with any application code files. This PR can merge independently of Issue #14 or any other feature work.

## Manual steps required before/after merge

### Before merge: Enable GitHub Pages
1. Go to **Settings > Pages** in the repo
2. Under "Build and deployment" > Source: select **GitHub Actions**
3. Save

### After merge: Configure DNS at Cloudflare
1. In Cloudflare dashboard, add DNS records:
   - `CNAME` | `netvantage.net` | `herbhall.github.io`
   - `CNAME` | `www` | `herbhall.github.io`
2. In GitHub repo **Settings > Pages > Custom domain**: enter `netvantage.net`, check "Enforce HTTPS"

## Test plan

- [ ] Enable GitHub Pages (Settings > Pages > Source: GitHub Actions)
- [ ] Merge PR -- website workflow triggers automatically
- [ ] Verify site loads at `https://herbhall.github.io/netvantage/` (before custom domain)
- [ ] Configure Cloudflare DNS records
- [ ] Set custom domain in GitHub Pages settings
- [ ] Verify site loads at `https://netvantage.net`
- [ ] Verify landing page renders with dark theme and green accents
- [ ] Verify documentation sidebar navigation works
- [ ] Verify blog post is listed
- [ ] Verify search works within docs