### PR TITLE
feat: add ARM64 CI build target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,29 @@ jobs:
       - name: Build scout
         run: go build -v ./cmd/scout/...
 
+  build-arm64:
+    name: Build (linux/arm64)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.25'
+
+      - name: Build server (linux/arm64)
+        env:
+          GOOS: linux
+          GOARCH: arm64
+        run: go build -v ./cmd/netvantage/...
+
+      - name: Build scout (linux/arm64)
+        env:
+          GOOS: linux
+          GOARCH: arm64
+        run: go build -v ./cmd/scout/...
+
   test:
     name: Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds a dedicated `build-arm64` job to the CI workflow that cross-compiles both server and scout for `linux/arm64`
- Uses `GOOS=linux GOARCH=arm64` on an Ubuntu runner (no CGo dependencies, so cross-compilation works cleanly)
- Important for Raspberry Pi and Oracle Cloud ARM instance support

Closes #18

## Test plan
- [ ] Verify the new `build-arm64` job passes in CI
- [ ] Confirm existing build/test/lint jobs are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)