### PR TITLE
feat: add device type icon mapping

### DIFF
--- a/pkg/models/device_icons.go
+++ b/pkg/models/device_icons.go
@@ -1,0 +1,25 @@
+package models
+
+// DeviceIcon maps a DeviceType to its icon identifier.
+// Identifiers use Lucide icon names (https://lucide.dev) for
+// compatibility with the React dashboard.
+var DeviceIcon = map[DeviceType]string{
+	DeviceTypeServer:  "server",
+	DeviceTypeDesktop: "monitor",
+	DeviceTypeLaptop:  "laptop",
+	DeviceTypeMobile:  "smartphone",
+	DeviceTypeRouter:  "router",
+	DeviceTypeSwitch:  "network",
+	DeviceTypePrinter: "printer",
+	DeviceTypeIoT:     "cpu",
+	DeviceTypeUnknown: "help-circle",
+}
+
+// Icon returns the icon identifier for a DeviceType.
+// Returns "help-circle" for unrecognised types.
+func (dt DeviceType) Icon() string {
+	if icon, ok := DeviceIcon[dt]; ok {
+		return icon
+	}
+	return DeviceIcon[DeviceTypeUnknown]
+}

--- a/pkg/models/device_icons_test.go
+++ b/pkg/models/device_icons_test.go
@@ -1,0 +1,25 @@
+package models
+
+import "testing"
+
+func TestDeviceIconCoverage(t *testing.T) {
+	knownTypes := []DeviceType{
+		DeviceTypeServer, DeviceTypeDesktop, DeviceTypeLaptop,
+		DeviceTypeMobile, DeviceTypeRouter, DeviceTypeSwitch,
+		DeviceTypePrinter, DeviceTypeIoT, DeviceTypeUnknown,
+	}
+	for _, dt := range knownTypes {
+		icon := dt.Icon()
+		if icon == "" {
+			t.Errorf("DeviceType %q has empty icon", dt)
+		}
+	}
+}
+
+func TestDeviceIconUnknownFallback(t *testing.T) {
+	got := DeviceType("nonexistent").Icon()
+	want := "help-circle"
+	if got != want {
+		t.Errorf("unknown device type icon = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a `DeviceIcon` map in `pkg/models/` that maps each `DeviceType` to a Lucide icon identifier
- Adds an `Icon()` method on `DeviceType` with fallback to `help-circle` for unknown types
- Includes table-driven tests for full coverage and unknown-type fallback

Closes #15

## Icon mapping

| Device Type | Icon ID |
|------------|---------|
| server | `server` |
| desktop | `monitor` |
| laptop | `laptop` |
| mobile | `smartphone` |
| router | `router` |
| switch | `network` |
| printer | `printer` |
| iot | `cpu` |
| unknown | `help-circle` |

## Test plan
- [x] `go test ./pkg/models/...` passes
- [x] `go vet ./pkg/models/...` clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)