### PR TITLE
feat: add webhook notifier plugin

### DIFF
--- a/cmd/netvantage/main.go
+++ b/cmd/netvantage/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/HerbHall/netvantage/internal/server"
 	"github.com/HerbHall/netvantage/internal/store"
 	"github.com/HerbHall/netvantage/internal/vault"
+	"github.com/HerbHall/netvantage/internal/webhook"
 	"github.com/HerbHall/netvantage/internal/version"
 	"github.com/HerbHall/netvantage/pkg/plugin"
 	"go.uber.org/zap"
@@ -95,6 +96,7 @@ func main() {
 		dispatch.New(),
 		vault.New(),
 		gateway.New(),
+		webhook.New(),
 	}
 	for _, m := range modules {
 		if err := reg.Register(m); err != nil {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -186,6 +186,17 @@ func (r *Registry) InitAll(ctx context.Context, depsFn func(name string) plugin.
 				r.disabled[name] = true
 			}
 		}
+
+		// Wire event subscriptions for EventSubscriber plugins.
+		if es, ok := p.(plugin.EventSubscriber); ok {
+			for _, sub := range es.Subscriptions() {
+				deps.Bus.Subscribe(sub.Topic, sub.Handler)
+				r.logger.Info("subscribed plugin to event",
+					zap.String("plugin", name),
+					zap.String("topic", sub.Topic),
+				)
+			}
+		}
 	}
 	return nil
 }

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -43,6 +43,9 @@ func LoadConfig(configPath string) (*viper.Viper, error) {
 	v.SetDefault("plugins.dispatch.enabled", true)
 	v.SetDefault("plugins.vault.enabled", true)
 	v.SetDefault("plugins.gateway.enabled", true)
+	v.SetDefault("plugins.webhook.enabled", true)
+	v.SetDefault("plugins.webhook.url", "")
+	v.SetDefault("plugins.webhook.timeout", "10s")
 
 	if configPath != "" {
 		v.SetConfigFile(configPath)

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -1,0 +1,171 @@
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/HerbHall/netvantage/internal/recon"
+	"github.com/HerbHall/netvantage/pkg/plugin"
+	"go.uber.org/zap"
+)
+
+// Compile-time interface guards.
+var (
+	_ plugin.Plugin          = (*Module)(nil)
+	_ plugin.EventSubscriber = (*Module)(nil)
+)
+
+// Config holds the webhook plugin configuration.
+type Config struct {
+	URL     string
+	Timeout time.Duration
+	Enabled bool
+}
+
+// Module implements the Webhook notifier plugin.
+type Module struct {
+	logger *zap.Logger
+	cfg    Config
+	client *http.Client
+}
+
+// New creates a new Webhook plugin instance.
+func New() *Module {
+	return &Module{}
+}
+
+func (m *Module) Info() plugin.PluginInfo {
+	return plugin.PluginInfo{
+		Name:        "webhook",
+		Version:     "0.1.0",
+		Description: "Sends HTTP POST notifications to a configurable webhook URL on device events",
+		Roles:       []string{"notification"},
+		APIVersion:  plugin.APIVersionCurrent,
+	}
+}
+
+func (m *Module) Init(_ context.Context, deps plugin.Dependencies) error {
+	m.logger = deps.Logger
+
+	// Defaults.
+	m.cfg = Config{
+		Timeout: 10 * time.Second,
+		Enabled: true,
+	}
+
+	if deps.Config != nil {
+		if u := deps.Config.GetString("url"); u != "" {
+			m.cfg.URL = u
+		}
+		if d := deps.Config.GetDuration("timeout"); d > 0 {
+			m.cfg.Timeout = d
+		}
+		if deps.Config.IsSet("enabled") {
+			m.cfg.Enabled = deps.Config.GetBool("enabled")
+		}
+	}
+
+	m.client = &http.Client{Timeout: m.cfg.Timeout}
+
+	if m.cfg.URL == "" {
+		m.logger.Warn("webhook URL not configured; notifications will be dropped",
+			zap.String("component", "webhook"),
+		)
+	}
+
+	m.logger.Info("webhook module initialized",
+		zap.String("url", m.cfg.URL),
+		zap.Duration("timeout", m.cfg.Timeout),
+		zap.Bool("enabled", m.cfg.Enabled),
+	)
+	return nil
+}
+
+func (m *Module) Start(_ context.Context) error {
+	m.logger.Info("webhook module started")
+	return nil
+}
+
+func (m *Module) Stop(_ context.Context) error {
+	m.logger.Info("webhook module stopped")
+	return nil
+}
+
+// Subscriptions implements plugin.EventSubscriber.
+func (m *Module) Subscriptions() []plugin.Subscription {
+	return []plugin.Subscription{
+		{Topic: recon.TopicDeviceDiscovered, Handler: m.handleEvent},
+		{Topic: recon.TopicDeviceUpdated, Handler: m.handleEvent},
+		{Topic: recon.TopicDeviceLost, Handler: m.handleEvent},
+	}
+}
+
+// WebhookPayload is the JSON body sent to the webhook URL.
+type WebhookPayload struct {
+	Event     string `json:"event"`
+	Source    string `json:"source"`
+	Timestamp string `json:"timestamp"`
+	Data      any    `json:"data"`
+}
+
+func (m *Module) handleEvent(ctx context.Context, event plugin.Event) {
+	if !m.cfg.Enabled || m.cfg.URL == "" {
+		return
+	}
+
+	payload := WebhookPayload{
+		Event:     event.Topic,
+		Source:    event.Source,
+		Timestamp: event.Timestamp.UTC().Format(time.RFC3339),
+		Data:      event.Payload,
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		m.logger.Error("failed to marshal webhook payload",
+			zap.String("topic", event.Topic),
+			zap.Error(err),
+		)
+		return
+	}
+
+	m.send(ctx, body, event.Topic)
+}
+
+func (m *Module) send(ctx context.Context, body []byte, topic string) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, m.cfg.URL, bytes.NewReader(body))
+	if err != nil {
+		m.logger.Error("failed to create webhook request", zap.Error(err))
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "NetVantage-Webhook/0.1")
+
+	resp, err := m.client.Do(req)
+	if err != nil {
+		m.logger.Warn("webhook delivery failed",
+			zap.String("url", m.cfg.URL),
+			zap.String("topic", topic),
+			zap.Error(err),
+		)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		m.logger.Warn("webhook endpoint returned error",
+			zap.String("url", m.cfg.URL),
+			zap.String("topic", topic),
+			zap.Int("status_code", resp.StatusCode),
+		)
+		return
+	}
+
+	m.logger.Debug("webhook delivered",
+		zap.String("topic", topic),
+		zap.Int("status_code", resp.StatusCode),
+	)
+}

--- a/internal/webhook/webhook_test.go
+++ b/internal/webhook/webhook_test.go
@@ -1,0 +1,196 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/HerbHall/netvantage/internal/recon"
+	"github.com/HerbHall/netvantage/pkg/plugin"
+	"github.com/HerbHall/netvantage/pkg/plugin/plugintest"
+	"go.uber.org/zap"
+)
+
+func TestContract(t *testing.T) {
+	plugintest.TestPluginContract(t, func() plugin.Plugin { return New() })
+}
+
+func TestSubscriptions_ReturnsExpectedTopics(t *testing.T) {
+	m := New()
+	if err := m.Init(context.Background(), plugin.Dependencies{Logger: zap.NewNop()}); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	subs := m.Subscriptions()
+	if len(subs) != 3 {
+		t.Fatalf("Subscriptions() returned %d, want 3", len(subs))
+	}
+
+	topics := make(map[string]bool)
+	for _, s := range subs {
+		topics[s.Topic] = true
+	}
+
+	expected := []string{
+		recon.TopicDeviceDiscovered,
+		recon.TopicDeviceUpdated,
+		recon.TopicDeviceLost,
+	}
+	for _, topic := range expected {
+		if !topics[topic] {
+			t.Errorf("missing subscription for topic %q", topic)
+		}
+	}
+}
+
+func TestHandleEvent_DeliversWebhook(t *testing.T) {
+	var mu sync.Mutex
+	var received []WebhookPayload
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", r.Header.Get("Content-Type"))
+		}
+		if r.Header.Get("User-Agent") != "NetVantage-Webhook/0.1" {
+			t.Errorf("User-Agent = %q, want NetVantage-Webhook/0.1", r.Header.Get("User-Agent"))
+		}
+		var p WebhookPayload
+		if err := json.NewDecoder(r.Body).Decode(&p); err != nil {
+			t.Errorf("decode: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		mu.Lock()
+		received = append(received, p)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	m := New()
+	m.Init(context.Background(), plugin.Dependencies{
+		Logger: zap.NewNop(),
+		Config: &testConfig{values: map[string]any{
+			"url":     srv.URL,
+			"timeout": 5 * time.Second,
+			"enabled": true,
+		}},
+	})
+
+	m.handleEvent(context.Background(), plugin.Event{
+		Topic:     recon.TopicDeviceDiscovered,
+		Source:    "recon",
+		Timestamp: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		Payload:   map[string]string{"ip": "192.168.1.1"},
+	})
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(received) != 1 {
+		t.Fatalf("received %d webhooks, want 1", len(received))
+	}
+	if received[0].Event != recon.TopicDeviceDiscovered {
+		t.Errorf("event = %q, want %q", received[0].Event, recon.TopicDeviceDiscovered)
+	}
+	if received[0].Source != "recon" {
+		t.Errorf("source = %q, want recon", received[0].Source)
+	}
+}
+
+func TestHandleEvent_SkipsWhenDisabled(t *testing.T) {
+	var called bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	m := New()
+	m.Init(context.Background(), plugin.Dependencies{
+		Logger: zap.NewNop(),
+		Config: &testConfig{values: map[string]any{
+			"url":     srv.URL,
+			"enabled": false,
+		}},
+	})
+
+	m.handleEvent(context.Background(), plugin.Event{
+		Topic:     recon.TopicDeviceDiscovered,
+		Source:    "recon",
+		Timestamp: time.Now(),
+	})
+
+	if called {
+		t.Error("expected webhook NOT to be called when disabled")
+	}
+}
+
+func TestHandleEvent_SkipsWhenNoURL(t *testing.T) {
+	m := New()
+	m.Init(context.Background(), plugin.Dependencies{Logger: zap.NewNop()})
+
+	// Should not panic when URL is empty.
+	m.handleEvent(context.Background(), plugin.Event{
+		Topic:     recon.TopicDeviceDiscovered,
+		Source:    "recon",
+		Timestamp: time.Now(),
+	})
+}
+
+func TestHandleEvent_LogsOnServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	m := New()
+	m.Init(context.Background(), plugin.Dependencies{
+		Logger: zap.NewNop(),
+		Config: &testConfig{values: map[string]any{
+			"url": srv.URL,
+		}},
+	})
+
+	// Should not panic; warning is logged.
+	m.handleEvent(context.Background(), plugin.Event{
+		Topic:     recon.TopicDeviceDiscovered,
+		Source:    "recon",
+		Timestamp: time.Now(),
+		Payload:   map[string]string{"test": "data"},
+	})
+}
+
+// testConfig is a minimal plugin.Config for tests.
+type testConfig struct {
+	values map[string]any
+}
+
+func (c *testConfig) Unmarshal(_ any) error    { return nil }
+func (c *testConfig) Get(key string) any       { return c.values[key] }
+func (c *testConfig) GetString(key string) string {
+	v, _ := c.values[key].(string)
+	return v
+}
+func (c *testConfig) GetInt(key string) int {
+	v, _ := c.values[key].(int)
+	return v
+}
+func (c *testConfig) GetBool(key string) bool {
+	v, _ := c.values[key].(bool)
+	return v
+}
+func (c *testConfig) GetDuration(key string) time.Duration {
+	v, _ := c.values[key].(time.Duration)
+	return v
+}
+func (c *testConfig) IsSet(key string) bool {
+	_, ok := c.values[key]
+	return ok
+}
+func (c *testConfig) Sub(_ string) plugin.Config {
+	return &testConfig{values: map[string]any{}}
+}


### PR DESCRIPTION
## Summary
- Wires `EventSubscriber` detection in registry `InitAll()` -- plugins implementing this interface now have their subscriptions automatically registered with the event bus
- Creates `internal/webhook/` plugin that sends HTTP POST notifications to a configurable webhook URL when devices are discovered, updated, or lost
- Registers webhook plugin in server startup with config defaults (`plugins.webhook.url`, `plugins.webhook.timeout`, `plugins.webhook.enabled`)

Closes #16

## Files Changed
- `internal/registry/registry.go` -- EventSubscriber wiring in InitAll
- `internal/registry/registry_test.go` -- Test for EventSubscriber wiring
- `internal/webhook/webhook.go` -- Webhook notifier plugin
- `internal/webhook/webhook_test.go` -- Contract test, delivery, disabled/no-url/error tests
- `cmd/netvantage/main.go` -- Register webhook plugin
- `internal/server/config.go` -- Webhook config defaults

## Test plan
- [ ] `go test ./internal/webhook/...` passes (6 tests including plugin contract)
- [ ] `go test ./internal/registry/...` passes (includes new EventSubscriber wiring test)
- [ ] `go build ./cmd/netvantage/...` compiles cleanly
- [ ] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)