### PR TITLE
feat: add account lockout after failed login attempts

### DIFF
--- a/internal/auth/user.go
+++ b/internal/auth/user.go
@@ -25,16 +25,18 @@ var ValidRoles = map[Role]bool{
 
 // User represents a NetVantage user account.
 type User struct {
-	ID           string    `json:"id"`
-	Username     string    `json:"username"`
-	Email        string    `json:"email"`
-	PasswordHash string    `json:"-"` // Never serialized
-	Role         Role      `json:"role"`
-	AuthProvider string    `json:"auth_provider"`
-	OIDCSubject  string    `json:"oidc_subject,omitempty"`
-	CreatedAt    time.Time `json:"created_at"`
-	LastLogin    time.Time `json:"last_login,omitempty"`
-	Disabled     bool      `json:"disabled"`
+	ID                  string     `json:"id"`
+	Username            string     `json:"username"`
+	Email               string     `json:"email"`
+	PasswordHash        string     `json:"-"` // Never serialized
+	Role                Role       `json:"role"`
+	AuthProvider        string     `json:"auth_provider"`
+	OIDCSubject         string     `json:"oidc_subject,omitempty"`
+	CreatedAt           time.Time  `json:"created_at"`
+	LastLogin           time.Time  `json:"last_login,omitempty"`
+	Disabled            bool       `json:"disabled"`
+	FailedLoginAttempts int        `json:"-"`
+	LockedUntil         *time.Time `json:"locked_until,omitempty"`
 }
 
 // HashPassword creates a bcrypt hash of the given password.


### PR DESCRIPTION
## Summary
- Locks accounts after 5 consecutive failed login attempts for 15 minutes
- Lockout check runs before password verification to avoid timing side channels
- Failed attempt counter resets on successful login
- Adds migration v3 with `failed_login_attempts` and `locked_until` columns
- Adds 4 dedicated lockout tests covering: lockout trigger, lockout expiry, counter reset on success, lockout blocks correct password

Closes #34

## Test plan
- [x] All 46 auth tests pass (`go test ./internal/auth/... -count=1`)
- [x] `go vet ./internal/auth/...` clean
- [x] `go build ./cmd/netvantage/...` compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)