### PR TITLE
feat: define role interfaces in pkg/roles/

### DIFF
--- a/pkg/roles/roles.go
+++ b/pkg/roles/roles.go
@@ -1,0 +1,71 @@
+// Package roles defines typed contracts for plugin roles.
+// Plugins that fill a role (declared via PluginInfo.Roles) should implement
+// the corresponding interface so callers can use type-safe access via
+// PluginResolver.ResolveByRole followed by a type assertion.
+//
+// This package is Apache 2.0 licensed, part of the public plugin SDK.
+package roles
+
+import (
+	"context"
+
+	"github.com/HerbHall/netvantage/pkg/models"
+)
+
+// Role name constants match the strings used in PluginInfo.Roles.
+const (
+	RoleDiscovery       = "discovery"
+	RoleMonitoring      = "monitoring"
+	RoleCredentialStore = "credential_store"
+	RoleAgentManagement = "agent_management"
+	RoleNotification    = "notification"
+	RoleRemoteAccess    = "remote_access"
+)
+
+// DiscoveryProvider is implemented by plugins that discover network devices.
+type DiscoveryProvider interface {
+	// Devices returns all discovered devices.
+	Devices(ctx context.Context) ([]models.Device, error)
+
+	// DeviceByID returns a single device by its ID.
+	DeviceByID(ctx context.Context, id string) (*models.Device, error)
+}
+
+// MonitoringProvider is implemented by plugins that monitor device health.
+type MonitoringProvider interface {
+	// Status returns the current monitoring status for a device.
+	Status(ctx context.Context, deviceID string) (*MonitorStatus, error)
+}
+
+// CredentialProvider is implemented by plugins that store and retrieve
+// credentials for managed devices.
+type CredentialProvider interface {
+	// Credential retrieves a credential by ID.
+	Credential(ctx context.Context, id string) (*Credential, error)
+
+	// CredentialsForDevice returns all credentials associated with a device.
+	CredentialsForDevice(ctx context.Context, deviceID string) ([]Credential, error)
+}
+
+// AgentManager is implemented by plugins that manage Scout agents.
+type AgentManager interface {
+	// Agents returns all registered agents.
+	Agents(ctx context.Context) ([]models.AgentInfo, error)
+
+	// AgentByID returns a single agent by its ID.
+	AgentByID(ctx context.Context, id string) (*models.AgentInfo, error)
+}
+
+// Notifier is implemented by plugins that send notifications (webhooks,
+// email, Slack, etc.).
+type Notifier interface {
+	// Notify sends a notification with the given payload.
+	Notify(ctx context.Context, notification Notification) error
+}
+
+// RemoteAccessProvider is implemented by plugins that provide remote access
+// to managed devices (SSH tunnels, Tailscale, etc.).
+type RemoteAccessProvider interface {
+	// Available reports whether remote access is available for a device.
+	Available(ctx context.Context, deviceID string) (bool, error)
+}

--- a/pkg/roles/types.go
+++ b/pkg/roles/types.go
@@ -1,0 +1,27 @@
+package roles
+
+import "time"
+
+// MonitorStatus represents the health/monitoring state of a device.
+type MonitorStatus struct {
+	DeviceID  string    `json:"device_id"`
+	Healthy   bool      `json:"healthy"`
+	Message   string    `json:"message,omitempty"`
+	CheckedAt time.Time `json:"checked_at"`
+}
+
+// Credential represents a stored credential (opaque to callers).
+type Credential struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Type     string `json:"type"` // "ssh", "snmp_v2", "snmp_v3", "api_key", etc.
+	DeviceID string `json:"device_id,omitempty"`
+}
+
+// Notification represents a message to be delivered by a Notifier.
+type Notification struct {
+	Topic   string         `json:"topic"`
+	Summary string         `json:"summary"`
+	Body    string         `json:"body,omitempty"`
+	Meta    map[string]any `json:"meta,omitempty"`
+}


### PR DESCRIPTION
## Summary
- Adds typed role contracts: `DiscoveryProvider`, `MonitoringProvider`, `CredentialProvider`, `AgentManager`, `Notifier`, `RemoteAccessProvider`
- Adds supporting types: `MonitorStatus`, `Credential`, `Notification`
- Adds role name constants (`RoleDiscovery`, `RoleMonitoring`, etc.) matching `PluginInfo.Roles` strings
- Part of the public plugin SDK (Apache 2.0)

Closes #36

## Test plan
- [x] `go build ./pkg/roles/...` compiles
- [x] `go vet ./pkg/roles/...` clean
- [x] `go build ./cmd/netvantage/...` full build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)