### PR TITLE
feat: add test infrastructure with shared helpers

### DIFF
--- a/internal/testutil/bus.go
+++ b/internal/testutil/bus.go
@@ -1,0 +1,64 @@
+package testutil
+
+import (
+	"context"
+	"sync"
+
+	"github.com/HerbHall/netvantage/pkg/plugin"
+)
+
+// Compile-time interface check.
+var _ plugin.EventBus = (*MockBus)(nil)
+
+// MockBus is a thread-safe in-memory event bus that records all published
+// events for later inspection.
+type MockBus struct {
+	mu     sync.Mutex
+	events []plugin.Event
+}
+
+// NewMockBus returns a new MockBus.
+func NewMockBus() *MockBus {
+	return &MockBus{}
+}
+
+// Publish records an event synchronously.
+func (b *MockBus) Publish(_ context.Context, event plugin.Event) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.events = append(b.events, event)
+	return nil
+}
+
+// PublishAsync records an event (same as Publish in tests).
+func (b *MockBus) PublishAsync(_ context.Context, event plugin.Event) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.events = append(b.events, event)
+}
+
+// Subscribe is a no-op that returns a no-op unsubscribe function.
+func (b *MockBus) Subscribe(_ string, _ plugin.EventHandler) func() {
+	return func() {}
+}
+
+// SubscribeAll is a no-op that returns a no-op unsubscribe function.
+func (b *MockBus) SubscribeAll(_ plugin.EventHandler) func() {
+	return func() {}
+}
+
+// Events returns a copy of all recorded events.
+func (b *MockBus) Events() []plugin.Event {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]plugin.Event, len(b.events))
+	copy(out, b.events)
+	return out
+}
+
+// Reset clears all recorded events.
+func (b *MockBus) Reset() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.events = nil
+}

--- a/internal/testutil/clock.go
+++ b/internal/testutil/clock.go
@@ -1,0 +1,44 @@
+package testutil
+
+import (
+	"sync"
+	"time"
+)
+
+// Clock provides a controllable time source for tests.
+type Clock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+// NewClock returns a Clock initialized to the given time.
+// If no time is provided, it defaults to a fixed point:
+// 2025-01-01 00:00:00 UTC.
+func NewClock(now ...time.Time) *Clock {
+	t := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	if len(now) > 0 {
+		t = now[0]
+	}
+	return &Clock{now: t}
+}
+
+// Now returns the clock's current time.
+func (c *Clock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+// Advance moves the clock forward by d.
+func (c *Clock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
+// Set overrides the clock's current time.
+func (c *Clock) Set(t time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = t
+}

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -1,0 +1,59 @@
+package testutil
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/HerbHall/netvantage/pkg/models"
+)
+
+// NewDevice returns a Device with sensible defaults, suitable for test fixtures.
+// Override individual fields after creation as needed.
+func NewDevice(opts ...func(*models.Device)) models.Device {
+	d := models.Device{
+		ID:              uuid.New().String(),
+		Hostname:        "test-device",
+		IPAddresses:     []string{"192.168.1.100"},
+		MACAddress:      "00:11:22:33:44:55",
+		DeviceType:      models.DeviceTypeDesktop,
+		Status:          models.DeviceStatusOnline,
+		DiscoveryMethod: models.DiscoveryICMP,
+		FirstSeen:       time.Now().UTC(),
+		LastSeen:        time.Now().UTC(),
+	}
+	for _, opt := range opts {
+		opt(&d)
+	}
+	return d
+}
+
+// WithHostname sets the device hostname.
+func WithHostname(name string) func(*models.Device) {
+	return func(d *models.Device) { d.Hostname = name }
+}
+
+// WithIP sets the device's IP address list.
+func WithIP(ips ...string) func(*models.Device) {
+	return func(d *models.Device) { d.IPAddresses = ips }
+}
+
+// WithMAC sets the device's MAC address.
+func WithMAC(mac string) func(*models.Device) {
+	return func(d *models.Device) { d.MACAddress = mac }
+}
+
+// WithStatus sets the device status.
+func WithStatus(s models.DeviceStatus) func(*models.Device) {
+	return func(d *models.Device) { d.Status = s }
+}
+
+// WithLastSeen sets the device's last_seen timestamp.
+func WithLastSeen(t time.Time) func(*models.Device) {
+	return func(d *models.Device) { d.LastSeen = t }
+}
+
+// WithDeviceType sets the device type.
+func WithDeviceType(dt models.DeviceType) func(*models.Device) {
+	return func(d *models.Device) { d.DeviceType = dt }
+}

--- a/internal/testutil/logger.go
+++ b/internal/testutil/logger.go
@@ -1,0 +1,14 @@
+// Package testutil provides shared test helpers for NetVantage packages.
+package testutil
+
+import "go.uber.org/zap"
+
+// Logger returns a development Zap logger for use in tests.
+// Panics on construction failure (should never happen in tests).
+func Logger() *zap.Logger {
+	l, err := zap.NewDevelopment()
+	if err != nil {
+		panic("testutil.Logger: " + err.Error())
+	}
+	return l
+}

--- a/internal/testutil/store.go
+++ b/internal/testutil/store.go
@@ -1,0 +1,19 @@
+package testutil
+
+import (
+	"testing"
+
+	"github.com/HerbHall/netvantage/internal/store"
+)
+
+// NewStore creates an in-memory SQLiteStore for testing.
+// The store is automatically closed when the test completes.
+func NewStore(t *testing.T) *store.SQLiteStore {
+	t.Helper()
+	db, err := store.New(":memory:")
+	if err != nil {
+		t.Fatalf("testutil.NewStore: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -1,0 +1,105 @@
+package testutil
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/HerbHall/netvantage/pkg/models"
+	"github.com/HerbHall/netvantage/pkg/plugin"
+)
+
+func TestLogger_NotNil(t *testing.T) {
+	l := Logger()
+	if l == nil {
+		t.Fatal("expected non-nil logger")
+	}
+}
+
+func TestNewStore_Usable(t *testing.T) {
+	db := NewStore(t)
+	if db == nil {
+		t.Fatal("expected non-nil store")
+	}
+	if err := db.DB().PingContext(context.Background()); err != nil {
+		t.Fatalf("PingContext: %v", err)
+	}
+}
+
+func TestMockBus_RecordsEvents(t *testing.T) {
+	bus := NewMockBus()
+
+	ev := plugin.Event{Topic: "test.topic", Source: "test"}
+	if err := bus.Publish(context.Background(), ev); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	bus.PublishAsync(context.Background(), plugin.Event{Topic: "test.async", Source: "test"})
+
+	events := bus.Events()
+	if len(events) != 2 {
+		t.Fatalf("Events len = %d, want 2", len(events))
+	}
+	if events[0].Topic != "test.topic" {
+		t.Errorf("events[0].Topic = %q, want test.topic", events[0].Topic)
+	}
+	if events[1].Topic != "test.async" {
+		t.Errorf("events[1].Topic = %q, want test.async", events[1].Topic)
+	}
+}
+
+func TestMockBus_Reset(t *testing.T) {
+	bus := NewMockBus()
+	_ = bus.Publish(context.Background(), plugin.Event{Topic: "a"})
+	bus.Reset()
+	if len(bus.Events()) != 0 {
+		t.Error("expected empty events after Reset")
+	}
+}
+
+func TestClock_Advance(t *testing.T) {
+	c := NewClock()
+	start := c.Now()
+	c.Advance(5 * time.Minute)
+	if got := c.Now().Sub(start); got != 5*time.Minute {
+		t.Errorf("Advance: elapsed = %v, want 5m", got)
+	}
+}
+
+func TestClock_Set(t *testing.T) {
+	c := NewClock()
+	target := time.Date(2030, 6, 15, 12, 0, 0, 0, time.UTC)
+	c.Set(target)
+	if !c.Now().Equal(target) {
+		t.Errorf("Set: got %v, want %v", c.Now(), target)
+	}
+}
+
+func TestNewDevice_Defaults(t *testing.T) {
+	d := NewDevice()
+	if d.ID == "" {
+		t.Error("expected non-empty ID")
+	}
+	if d.Status != models.DeviceStatusOnline {
+		t.Errorf("Status = %q, want online", d.Status)
+	}
+	if d.Hostname != "test-device" {
+		t.Errorf("Hostname = %q, want test-device", d.Hostname)
+	}
+}
+
+func TestNewDevice_WithOptions(t *testing.T) {
+	d := NewDevice(
+		WithHostname("myhost"),
+		WithIP("10.0.0.1"),
+		WithStatus(models.DeviceStatusOffline),
+	)
+	if d.Hostname != "myhost" {
+		t.Errorf("Hostname = %q, want myhost", d.Hostname)
+	}
+	if len(d.IPAddresses) != 1 || d.IPAddresses[0] != "10.0.0.1" {
+		t.Errorf("IPAddresses = %v, want [10.0.0.1]", d.IPAddresses)
+	}
+	if d.Status != models.DeviceStatusOffline {
+		t.Errorf("Status = %q, want offline", d.Status)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `internal/testutil/` package with reusable test helpers
- `Logger()` - shared development Zap logger (replaces 4 duplicated `testLogger()` functions)
- `NewStore(t)` - in-memory SQLiteStore with auto-cleanup (replaces 6+ duplicated store setups)
- `MockBus` - thread-safe event bus mock that records published events (replaces 3+ mock implementations)
- `Clock` - controllable time source for time-dependent tests
- `NewDevice()` - device fixture factory with functional options (`WithHostname`, `WithIP`, `WithStatus`, etc.)
- Includes 8 tests verifying all helpers

Closes #38

## Test plan
- [x] All 8 testutil tests pass
- [x] `go vet ./internal/testutil/...` clean
- [x] `go build ./cmd/netvantage/...` full build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)