### PR TITLE
feat(dashboard): implement first-run setup wizard

### DIFF
--- a/web/src/api/auth.ts
+++ b/web/src/api/auth.ts
@@ -57,3 +57,25 @@ export async function logoutApi(refreshToken: string): Promise<void> {
     body: JSON.stringify({ refresh_token: refreshToken }),
   })
 }
+
+/**
+ * Check if initial setup is required (no users exist).
+ * Returns true if setup is needed, false if setup is complete.
+ */
+export async function checkSetupRequired(): Promise<boolean> {
+  const res = await fetch(`${BASE_URL}/auth/setup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: '', email: '', password: '' }),
+  })
+  // 409 Conflict means setup is already complete
+  if (res.status === 409) {
+    return false
+  }
+  // 400 Bad Request means setup is available (validation failed on empty fields)
+  if (res.status === 400) {
+    return true
+  }
+  // Any other response, assume setup not required
+  return false
+}

--- a/web/src/pages/login.tsx
+++ b/web/src/pages/login.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { useAuthStore } from '@/stores/auth'
+import { checkSetupRequired } from '@/api/auth'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -11,11 +12,22 @@ export function LoginPage() {
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
+  const [checkingSetup, setCheckingSetup] = useState(true)
   const login = useAuthStore((s) => s.login)
   const navigate = useNavigate()
   const location = useLocation()
 
   const from = (location.state as { from?: { pathname: string } })?.from?.pathname || '/dashboard'
+
+  useEffect(() => {
+    checkSetupRequired()
+      .then((required) => {
+        if (required) {
+          navigate('/setup', { replace: true })
+        }
+      })
+      .finally(() => setCheckingSetup(false))
+  }, [navigate])
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -29,6 +41,16 @@ export function LoginPage() {
     } finally {
       setLoading(false)
     }
+  }
+
+  if (checkingSetup) {
+    return (
+      <Card>
+        <CardContent className="py-8 text-center text-muted-foreground">
+          Checking setup status...
+        </CardContent>
+      </Card>
+    )
   }
 
   return (

--- a/web/src/pages/setup.tsx
+++ b/web/src/pages/setup.tsx
@@ -1,16 +1,384 @@
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { useState, useMemo } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useAuthStore } from '@/stores/auth'
+import { setupApi, loginApi } from '@/api/auth'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+
+type Step = 1 | 2 | 3
+
+interface FormData {
+  username: string
+  email: string
+  password: string
+  confirmPassword: string
+}
+
+interface FormErrors {
+  username?: string
+  email?: string
+  password?: string
+  confirmPassword?: string
+}
+
+function getPasswordStrength(password: string): {
+  score: number
+  label: string
+  color: string
+} {
+  let score = 0
+  if (password.length >= 8) score++
+  if (password.length >= 12) score++
+  if (/[a-z]/.test(password) && /[A-Z]/.test(password)) score++
+  if (/\d/.test(password)) score++
+  if (/[^a-zA-Z0-9]/.test(password)) score++
+
+  if (score <= 1) return { score, label: 'Weak', color: 'bg-red-500' }
+  if (score <= 2) return { score, label: 'Fair', color: 'bg-orange-500' }
+  if (score <= 3) return { score, label: 'Good', color: 'bg-yellow-500' }
+  if (score <= 4) return { score, label: 'Strong', color: 'bg-green-500' }
+  return { score, label: 'Very Strong', color: 'bg-green-600' }
+}
+
+function StepIndicator({ currentStep }: { currentStep: Step }) {
+  const steps = [
+    { num: 1, label: 'Account' },
+    { num: 2, label: 'Network' },
+    { num: 3, label: 'Complete' },
+  ]
+
+  return (
+    <div className="flex items-center justify-center gap-2 mb-6">
+      {steps.map((step, idx) => (
+        <div key={step.num} className="flex items-center">
+          <div
+            className={`flex h-8 w-8 items-center justify-center rounded-full text-sm font-medium transition-colors ${
+              currentStep >= step.num
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-muted text-muted-foreground'
+            }`}
+          >
+            {step.num}
+          </div>
+          <span
+            className={`ml-2 text-sm hidden sm:inline ${
+              currentStep >= step.num ? 'text-foreground' : 'text-muted-foreground'
+            }`}
+          >
+            {step.label}
+          </span>
+          {idx < steps.length - 1 && (
+            <div
+              className={`mx-3 h-px w-8 sm:w-12 ${
+                currentStep > step.num ? 'bg-primary' : 'bg-muted'
+              }`}
+            />
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}
 
 export function SetupPage() {
+  const [step, setStep] = useState<Step>(1)
+  const [formData, setFormData] = useState<FormData>({
+    username: '',
+    email: '',
+    password: '',
+    confirmPassword: '',
+  })
+  const [errors, setErrors] = useState<FormErrors>({})
+  const [apiError, setApiError] = useState('')
+  const [loading, setLoading] = useState(false)
+  const setTokens = useAuthStore((s) => s.setTokens)
+  const navigate = useNavigate()
+
+  const passwordStrength = useMemo(
+    () => getPasswordStrength(formData.password),
+    [formData.password]
+  )
+
+  function updateField<K extends keyof FormData>(key: K, value: FormData[K]) {
+    setFormData((prev) => ({ ...prev, [key]: value }))
+    if (errors[key]) {
+      setErrors((prev) => ({ ...prev, [key]: undefined }))
+    }
+  }
+
+  function validateStep1(): boolean {
+    const newErrors: FormErrors = {}
+
+    if (!formData.username.trim()) {
+      newErrors.username = 'Username is required'
+    } else if (!/^[a-zA-Z0-9_-]+$/.test(formData.username)) {
+      newErrors.username = 'Username can only contain letters, numbers, underscores, and dashes'
+    }
+
+    if (!formData.email.trim()) {
+      newErrors.email = 'Email is required'
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email)) {
+      newErrors.email = 'Please enter a valid email address'
+    }
+
+    if (!formData.password) {
+      newErrors.password = 'Password is required'
+    } else if (formData.password.length < 8) {
+      newErrors.password = 'Password must be at least 8 characters'
+    }
+
+    if (!formData.confirmPassword) {
+      newErrors.confirmPassword = 'Please confirm your password'
+    } else if (formData.password !== formData.confirmPassword) {
+      newErrors.confirmPassword = 'Passwords do not match'
+    }
+
+    setErrors(newErrors)
+    return Object.keys(newErrors).length === 0
+  }
+
+  function handleNext() {
+    setApiError('')
+    if (step === 1 && validateStep1()) {
+      setStep(2)
+    } else if (step === 2) {
+      setStep(3)
+    }
+  }
+
+  function handleBack() {
+    setApiError('')
+    if (step === 2) setStep(1)
+    else if (step === 3) setStep(2)
+  }
+
+  async function handleComplete() {
+    setApiError('')
+    setLoading(true)
+    try {
+      await setupApi(formData.username, formData.email, formData.password)
+      const tokens = await loginApi(formData.username, formData.password)
+      setTokens(tokens.access_token, tokens.refresh_token)
+      navigate('/dashboard', { replace: true })
+    } catch (err) {
+      setApiError(err instanceof Error ? err.message : 'Setup failed')
+    } finally {
+      setLoading(false)
+    }
+  }
+
   return (
-    <Card>
+    <Card className="w-full max-w-lg">
       <CardHeader>
         <CardTitle>Welcome to SubNetree</CardTitle>
-        <CardDescription>First-run setup wizard will be implemented in Issue #45.</CardDescription>
+        <CardDescription>
+          {step === 1 && 'Create your administrator account to get started.'}
+          {step === 2 && 'Configure network scanning settings.'}
+          {step === 3 && 'Review your settings and complete setup.'}
+        </CardDescription>
       </CardHeader>
       <CardContent>
-        <p className="text-sm text-muted-foreground">
-          Create your admin account, configure your network, and run your first scan.
-        </p>
+        <StepIndicator currentStep={step} />
+
+        {apiError && (
+          <div
+            role="alert"
+            className="mb-4 rounded-md bg-red-900/20 p-3 text-sm text-red-400"
+          >
+            {apiError}
+          </div>
+        )}
+
+        {step === 1 && (
+          <form
+            onSubmit={(e) => {
+              e.preventDefault()
+              handleNext()
+            }}
+            className="space-y-4"
+          >
+            <div className="space-y-2">
+              <Label htmlFor="username">Username</Label>
+              <Input
+                id="username"
+                value={formData.username}
+                onChange={(e) => updateField('username', e.target.value)}
+                placeholder="admin"
+                autoFocus
+                autoComplete="username"
+              />
+              {errors.username && (
+                <p className="text-sm text-red-400">{errors.username}</p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="email">Email</Label>
+              <Input
+                id="email"
+                type="email"
+                value={formData.email}
+                onChange={(e) => updateField('email', e.target.value)}
+                placeholder="admin@example.com"
+                autoComplete="email"
+              />
+              {errors.email && (
+                <p className="text-sm text-red-400">{errors.email}</p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="password">Password</Label>
+              <Input
+                id="password"
+                type="password"
+                value={formData.password}
+                onChange={(e) => updateField('password', e.target.value)}
+                autoComplete="new-password"
+              />
+              {formData.password && (
+                <div className="space-y-1">
+                  <div className="flex gap-1">
+                    {[1, 2, 3, 4, 5].map((i) => (
+                      <div
+                        key={i}
+                        className={`h-1 flex-1 rounded-full transition-colors ${
+                          i <= passwordStrength.score
+                            ? passwordStrength.color
+                            : 'bg-muted'
+                        }`}
+                      />
+                    ))}
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Password strength: {passwordStrength.label}
+                  </p>
+                </div>
+              )}
+              {errors.password && (
+                <p className="text-sm text-red-400">{errors.password}</p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="confirmPassword">Confirm Password</Label>
+              <Input
+                id="confirmPassword"
+                type="password"
+                value={formData.confirmPassword}
+                onChange={(e) => updateField('confirmPassword', e.target.value)}
+                autoComplete="new-password"
+              />
+              {errors.confirmPassword && (
+                <p className="text-sm text-red-400">{errors.confirmPassword}</p>
+              )}
+            </div>
+
+            <Button type="submit" className="w-full">
+              Next
+            </Button>
+          </form>
+        )}
+
+        {step === 2 && (
+          <div className="space-y-4">
+            <div className="rounded-lg border border-dashed border-muted-foreground/25 p-6 text-center">
+              <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+                <svg
+                  className="h-6 w-6 text-muted-foreground"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2zM9 9h6v6H9V9z"
+                  />
+                </svg>
+              </div>
+              <h3 className="font-medium text-foreground">Network Configuration</h3>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Network interface selection will be available in a future update.
+                For now, SubNetree will auto-detect available interfaces.
+              </p>
+            </div>
+
+            <p className="text-sm text-muted-foreground">
+              You can configure network settings later in{' '}
+              <span className="font-medium text-foreground">Settings → Network</span>.
+            </p>
+
+            <div className="flex gap-3">
+              <Button type="button" variant="outline" onClick={handleBack} className="flex-1">
+                Back
+              </Button>
+              <Button type="button" onClick={handleNext} className="flex-1">
+                Next
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {step === 3 && (
+          <div className="space-y-4">
+            <div className="rounded-lg bg-muted/50 p-4 space-y-3">
+              <h3 className="font-medium text-foreground">Setup Summary</h3>
+              <div className="space-y-2 text-sm">
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Username</span>
+                  <span className="font-medium">{formData.username}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Email</span>
+                  <span className="font-medium">{formData.email}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Role</span>
+                  <span className="font-medium">Administrator</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Network</span>
+                  <span className="font-medium text-muted-foreground">Auto-detect</span>
+                </div>
+              </div>
+            </div>
+
+            <p className="text-sm text-muted-foreground">
+              Click Complete to create your account and start using SubNetree.
+              You'll be automatically signed in.
+            </p>
+
+            <div className="flex gap-3">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleBack}
+                className="flex-1"
+                disabled={loading}
+              >
+                Back
+              </Button>
+              <Button
+                type="button"
+                onClick={handleComplete}
+                className="flex-1"
+                disabled={loading}
+              >
+                {loading ? 'Creating account...' : 'Complete Setup'}
+              </Button>
+            </div>
+          </div>
+        )}
       </CardContent>
     </Card>
   )


### PR DESCRIPTION
## Summary

- Implements 3-step first-run setup wizard for admin account creation
- Adds password strength indicator with 5-level visual feedback
- Auto-redirects from login to setup when no users exist
- Auto-logs in user after successful setup completion

## Changes

- `web/src/pages/setup.tsx` - Complete wizard implementation with:
  - Step 1: Admin account form (username, email, password, confirm)
  - Step 2: Network config placeholder (deferred to #61)
  - Step 3: Summary and completion
- `web/src/pages/login.tsx` - Adds setup detection, redirects if needed
- `web/src/api/auth.ts` - Adds `checkSetupRequired()` function

## Acceptance Criteria

- [x] Wizard appears automatically when no users exist
- [x] Step 1: Create admin account with strength indicator
- [x] Step 2: Network config (placeholder, full impl in #61)
- [x] Step 3: Confirm settings and complete
- [x] Password validation (8+ chars)
- [x] Auto-login after completion
- [x] Subsequent visits redirect to dashboard
- [x] Responsive layout
- [ ] Unit tests (deferred to #62)
- [x] No new linting warnings

## Test plan

- [ ] Navigate to `/login` with fresh database → redirects to `/setup`
- [ ] Complete wizard steps → creates admin, auto-logs in
- [ ] Navigate to `/login` after setup → shows login form
- [ ] Password strength meter shows correct levels
- [ ] Form validation prevents invalid submissions
- [ ] Mobile responsive layout works

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)