### PR TITLE
feat(dashboard): refactor to TanStack Query with enhanced features

### DIFF
--- a/web/src/pages/dashboard.tsx
+++ b/web/src/pages/dashboard.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   Monitor,
   Wifi,
@@ -12,47 +13,105 @@ import {
   Router,
   HardDrive,
   Activity,
+  Clock,
+  CheckCircle2,
+  XCircle,
+  Loader2,
+  Pause,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { DeviceCardCompact } from '@/components/device-card'
-import { getTopology, triggerScan } from '@/api/devices'
-import type { TopologyNode } from '@/api/types'
+import { getTopology, triggerScan, listScans } from '@/api/devices'
+import type { Scan, ScanStatus } from '@/api/types'
 import { cn } from '@/lib/utils'
 
+const REFRESH_OPTIONS = [
+  { label: '15s', value: 15 * 1000 },
+  { label: '30s', value: 30 * 1000 },
+  { label: '1m', value: 60 * 1000 },
+  { label: '5m', value: 5 * 60 * 1000 },
+]
+
 export function DashboardPage() {
-  const [devices, setDevices] = useState<TopologyNode[]>([])
-  const [loading, setLoading] = useState(true)
-  const [scanning, setScanning] = useState(false)
+  const [autoRefresh, setAutoRefresh] = useState(true)
+  const [refreshInterval, setRefreshInterval] = useState(30 * 1000) // Default 30s
+  const [countdown, setCountdown] = useState(30)
+  const [activeScanId, setActiveScanId] = useState<string | null>(null)
+  const queryClient = useQueryClient()
 
+  // Countdown timer effect
   useEffect(() => {
-    fetchDevices()
-  }, [])
-
-  async function fetchDevices() {
-    setLoading(true)
-    try {
-      const topology = await getTopology()
-      setDevices(topology.nodes || [])
-    } catch {
-      // Silently fail on dashboard - devices page will show errors
-    } finally {
-      setLoading(false)
+    if (!autoRefresh) {
+      setCountdown(Math.floor(refreshInterval / 1000))
+      return
     }
-  }
 
-  async function handleScan() {
-    setScanning(true)
-    try {
-      await triggerScan()
+    const intervalSeconds = Math.floor(refreshInterval / 1000)
+    setCountdown(intervalSeconds)
+
+    const timer = setInterval(() => {
+      setCountdown((prev) => {
+        if (prev <= 1) {
+          return intervalSeconds
+        }
+        return prev - 1
+      })
+    }, 1000)
+
+    return () => clearInterval(timer)
+  }, [autoRefresh, refreshInterval])
+
+  // Fetch topology data with auto-refresh
+  const {
+    data: topology,
+    isLoading: topologyLoading,
+    error: topologyError,
+  } = useQuery({
+    queryKey: ['topology'],
+    queryFn: getTopology,
+    refetchInterval: autoRefresh ? refreshInterval : false,
+  })
+
+  // Fetch recent scans with auto-refresh
+  const {
+    data: recentScans,
+    isLoading: scansLoading,
+  } = useQuery({
+    queryKey: ['scans', 'recent'],
+    queryFn: () => listScans(5, 0),
+    refetchInterval: autoRefresh ? refreshInterval : false,
+  })
+
+  // Poll active scan status
+  const { data: activeScan } = useQuery({
+    queryKey: ['scan', activeScanId],
+    queryFn: () => (activeScanId ? import('@/api/devices').then((m) => m.getScan(activeScanId)) : null),
+    enabled: !!activeScanId,
+    refetchInterval: activeScanId ? 2000 : false,
+  })
+
+  // Clear active scan when completed
+  useEffect(() => {
+    if (activeScan && (activeScan.status === 'completed' || activeScan.status === 'failed')) {
       setTimeout(() => {
-        fetchDevices()
-        setScanning(false)
-      }, 2000)
-    } catch {
-      setScanning(false)
+        setActiveScanId(null)
+        queryClient.invalidateQueries({ queryKey: ['topology'] })
+        queryClient.invalidateQueries({ queryKey: ['scans'] })
+      }, 1500)
     }
-  }
+  }, [activeScan, queryClient])
+
+  // Scan mutation
+  const scanMutation = useMutation({
+    mutationFn: () => triggerScan(),
+    onSuccess: (scan) => {
+      setActiveScanId(scan.id)
+    },
+  })
+
+  const devices = topology?.nodes || []
+  const loading = topologyLoading
 
   // Calculate stats
   const stats = {
@@ -71,7 +130,7 @@ export function DashboardPage() {
     {} as Record<string, number>
   )
 
-  // Recent devices (just show first 5 for now - would sort by last_seen if available)
+  // Recent devices (first 5)
   const recentDevices = devices.slice(0, 5)
 
   return (
@@ -80,20 +139,92 @@ export function DashboardPage() {
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-2xl font-semibold">Dashboard</h1>
-          <p className="text-sm text-muted-foreground mt-1">Network overview and quick actions</p>
+          <p className="text-sm text-muted-foreground mt-1">
+            Network overview and quick actions
+          </p>
         </div>
 
-        <div className="flex items-center gap-2">
-          <Button onClick={handleScan} disabled={scanning} className="gap-2">
-            {scanning ? (
+        <div className="flex flex-wrap items-center gap-2">
+          {/* Auto-refresh controls */}
+          <div className="flex items-center gap-1 rounded-md border bg-muted/30 p-1">
+            <Button
+              variant={autoRefresh ? 'secondary' : 'ghost'}
+              size="sm"
+              onClick={() => setAutoRefresh(!autoRefresh)}
+              className="h-7 px-2 gap-1"
+            >
+              {autoRefresh ? (
+                <RefreshCw className="h-3.5 w-3.5" />
+              ) : (
+                <Pause className="h-3.5 w-3.5" />
+              )}
+              <span className="text-xs">
+                {autoRefresh ? `${countdown}s` : 'Paused'}
+              </span>
+            </Button>
+            {autoRefresh && (
+              <div className="flex">
+                {REFRESH_OPTIONS.map((opt) => (
+                  <Button
+                    key={opt.value}
+                    variant={refreshInterval === opt.value ? 'secondary' : 'ghost'}
+                    size="sm"
+                    onClick={() => setRefreshInterval(opt.value)}
+                    className="h-7 px-2 text-xs"
+                  >
+                    {opt.label}
+                  </Button>
+                ))}
+              </div>
+            )}
+          </div>
+          <Button
+            onClick={() => scanMutation.mutate()}
+            disabled={scanMutation.isPending || !!activeScanId}
+            className="gap-2"
+          >
+            {scanMutation.isPending || activeScanId ? (
               <RefreshCw className="h-4 w-4 animate-spin" />
             ) : (
               <Radar className="h-4 w-4" />
             )}
-            {scanning ? 'Scanning...' : 'Scan Network'}
+            {activeScanId ? 'Scanning...' : 'Scan Network'}
           </Button>
         </div>
       </div>
+
+      {/* Scan Progress Indicator */}
+      {activeScan && (activeScan.status === 'pending' || activeScan.status === 'running') && (
+        <Card className="border-blue-500/50 bg-blue-500/10">
+          <CardContent className="p-4">
+            <div className="flex items-center gap-3">
+              <Loader2 className="h-5 w-5 text-blue-500 animate-spin" />
+              <div className="flex-1">
+                <p className="text-sm font-medium text-blue-400">
+                  Scanning {activeScan.target_cidr}...
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {activeScan.devices_found} devices found so far
+                </p>
+              </div>
+              <div className="text-right">
+                <span className="text-xs px-2 py-1 rounded bg-blue-500/20 text-blue-400">
+                  {activeScan.status}
+                </span>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Error State */}
+      {topologyError && (
+        <Card className="border-red-500/50 bg-red-500/10">
+          <CardContent className="p-4 text-sm text-red-400">
+            Failed to load network data. Please try again.
+          </CardContent>
+        </Card>
+      )}
 
       {/* Stats Cards */}
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
@@ -132,6 +263,41 @@ export function DashboardPage() {
 
       {/* Main Content Grid */}
       <div className="grid gap-6 lg:grid-cols-3">
+        {/* Recent Scans */}
+        <Card className="lg:col-span-1">
+          <CardHeader className="pb-3">
+            <CardTitle className="text-sm font-medium">Recent Scans</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {scansLoading ? (
+              <div className="space-y-3">
+                {[...Array(4)].map((_, i) => (
+                  <div key={i} className="h-12 rounded-lg bg-muted/30 animate-pulse" />
+                ))}
+              </div>
+            ) : !recentScans || recentScans.length === 0 ? (
+              <div className="text-center py-6">
+                <Clock className="h-8 w-8 mx-auto text-muted-foreground mb-2" />
+                <p className="text-sm text-muted-foreground">No scans yet</p>
+                <Button
+                  size="sm"
+                  className="mt-3"
+                  onClick={() => scanMutation.mutate()}
+                  disabled={scanMutation.isPending}
+                >
+                  Run First Scan
+                </Button>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                {recentScans.map((scan) => (
+                  <ScanHistoryRow key={scan.id} scan={scan} />
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
         {/* Device Types Breakdown */}
         <Card className="lg:col-span-1">
           <CardHeader className="pb-3">
@@ -156,7 +322,11 @@ export function DashboardPage() {
                 <DeviceTypeRow
                   icon={Router}
                   label="Routers & Switches"
-                  count={(typeCounts.router || 0) + (typeCounts.switch || 0) + (typeCounts.access_point || 0)}
+                  count={
+                    (typeCounts.router || 0) +
+                    (typeCounts.switch || 0) +
+                    (typeCounts.access_point || 0)
+                  }
                 />
                 <DeviceTypeRow
                   icon={Server}
@@ -186,7 +356,7 @@ export function DashboardPage() {
         </Card>
 
         {/* Recent Devices */}
-        <Card className="lg:col-span-2">
+        <Card className="lg:col-span-1">
           <CardHeader className="pb-3 flex flex-row items-center justify-between">
             <CardTitle className="text-sm font-medium">Recent Devices</CardTitle>
             <Button variant="ghost" size="sm" asChild className="gap-1 text-xs">
@@ -207,8 +377,12 @@ export function DashboardPage() {
               <div className="text-center py-8">
                 <Radar className="h-10 w-10 mx-auto text-muted-foreground mb-3" />
                 <p className="text-sm text-muted-foreground mb-3">No devices discovered yet</p>
-                <Button size="sm" onClick={handleScan} disabled={scanning}>
-                  {scanning ? 'Scanning...' : 'Run First Scan'}
+                <Button
+                  size="sm"
+                  onClick={() => scanMutation.mutate()}
+                  disabled={scanMutation.isPending}
+                >
+                  {scanMutation.isPending ? 'Scanning...' : 'Run First Scan'}
                 </Button>
               </div>
             ) : (
@@ -319,6 +493,49 @@ function StatCard({
   }
 
   return content
+}
+
+// Scan history row
+function ScanHistoryRow({ scan }: { scan: Scan }) {
+  const statusConfig: Record<ScanStatus, { icon: React.ElementType; color: string }> = {
+    completed: { icon: CheckCircle2, color: 'text-green-500' },
+    running: { icon: Loader2, color: 'text-blue-500' },
+    pending: { icon: Clock, color: 'text-muted-foreground' },
+    failed: { icon: XCircle, color: 'text-red-500' },
+    cancelled: { icon: XCircle, color: 'text-muted-foreground' },
+  }
+
+  const config = statusConfig[scan.status]
+  const Icon = config.icon
+  const isRunning = scan.status === 'running'
+
+  const formatTime = (dateStr: string) => {
+    const date = new Date(dateStr)
+    const now = new Date()
+    const diffMs = now.getTime() - date.getTime()
+    const diffMins = Math.floor(diffMs / 60000)
+    const diffHours = Math.floor(diffMins / 60)
+    const diffDays = Math.floor(diffHours / 24)
+
+    if (diffMins < 1) return 'Just now'
+    if (diffMins < 60) return `${diffMins}m ago`
+    if (diffHours < 24) return `${diffHours}h ago`
+    return `${diffDays}d ago`
+  }
+
+  return (
+    <div className="flex items-center gap-3 p-2 rounded-lg hover:bg-muted/50 transition-colors">
+      <Icon className={cn('h-4 w-4', config.color, isRunning && 'animate-spin')} />
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium truncate">{scan.target_cidr}</p>
+        <p className="text-xs text-muted-foreground">{formatTime(scan.started_at)}</p>
+      </div>
+      <div className="text-right">
+        <p className="text-sm font-medium">{scan.devices_found}</p>
+        <p className="text-xs text-muted-foreground">devices</p>
+      </div>
+    </div>
+  )
 }
 
 // Device type row for breakdown


### PR DESCRIPTION
## Summary

- Refactors dashboard from useState/useEffect to TanStack Query
- Adds configurable auto-refresh with countdown timer
- Adds Recent Scans widget and scan progress indicator

## Changes

- **TanStack Query**: Proper data fetching with `useQuery` and `useMutation`
- **Auto-refresh controls**: Toggle on/off + interval selector (15s, 30s, 1m, 5m)
- **Countdown timer**: Live countdown showing seconds until next refresh
- **Recent Scans widget**: Shows last 5 scans with status, target CIDR, device count
- **Scan progress banner**: Real-time progress during active scans with polling
- **Error handling**: Displays error state when topology fetch fails

## Acceptance Criteria

- [x] Dashboard page renders at `/dashboard` route
- [x] Summary cards: total devices, online, offline, degraded
- [x] Recent scan history widget (last 5 scans)
- [x] Quick action: "Start Scan" button triggers network scan
- [x] Quick action: "View Devices" links to device list
- [x] Data fetched via TanStack Query with loading and error states
- [x] Auto-refresh interval (configurable, default 30 seconds)
- [x] Responsive grid layout
- [ ] Unit tests (deferred to #62)
- [x] No new linting warnings

## Test plan

- [ ] Dashboard loads with stats cards
- [ ] Auto-refresh countdown ticks down and refreshes data
- [ ] Pause/Resume toggle works
- [ ] Interval selector changes refresh rate
- [ ] Scan button triggers scan and shows progress banner
- [ ] Recent Scans widget updates after scan completes
- [ ] Mobile responsive layout works

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)