### PR TITLE
feat(dashboard): build device detail page with enhanced features

### DIFF
--- a/web/src/api/devices.ts
+++ b/web/src/api/devices.ts
@@ -1,11 +1,52 @@
 import { api } from './client'
-import type { TopologyGraph, Scan } from './types'
+import type { TopologyGraph, Scan, Device } from './types'
 
 /**
  * Fetch the network topology (devices + connections).
  */
 export async function getTopology(): Promise<TopologyGraph> {
   return api.get<TopologyGraph>('/recon/topology')
+}
+
+/**
+ * Get a single device by ID.
+ */
+export async function getDevice(id: string): Promise<Device> {
+  return api.get<Device>(`/devices/${id}`)
+}
+
+/**
+ * Update device notes and tags.
+ */
+export async function updateDevice(
+  id: string,
+  data: { notes?: string; tags?: string[] }
+): Promise<Device> {
+  return api.put<Device>(`/devices/${id}`, data)
+}
+
+/**
+ * Get status history for a device.
+ */
+export interface DeviceStatusEvent {
+  id: string
+  device_id: string
+  status: 'online' | 'offline' | 'degraded' | 'unknown'
+  timestamp: string
+}
+
+export async function getDeviceStatusHistory(
+  id: string,
+  limit = 50
+): Promise<DeviceStatusEvent[]> {
+  return api.get<DeviceStatusEvent[]>(`/devices/${id}/status-history?limit=${limit}`)
+}
+
+/**
+ * Get scan history for a device (scans that discovered/updated this device).
+ */
+export async function getDeviceScanHistory(id: string): Promise<Scan[]> {
+  return api.get<Scan[]>(`/devices/${id}/scans`)
 }
 
 /**

--- a/web/src/pages/devices/[id].test.tsx
+++ b/web/src/pages/devices/[id].test.tsx
@@ -1,0 +1,412 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { DeviceDetailPage } from './[id]'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render } from '@testing-library/react'
+import type { Device, Scan } from '@/api/types'
+import type { DeviceStatusEvent } from '@/api/devices'
+
+// Mock device API
+vi.mock('@/api/devices', () => ({
+  getDevice: vi.fn(),
+  updateDevice: vi.fn(),
+  getDeviceStatusHistory: vi.fn(),
+  getDeviceScanHistory: vi.fn(),
+}))
+
+const mockDevice: Device = {
+  id: 'device-123',
+  hostname: 'test-server',
+  ip_addresses: ['192.168.1.100', '192.168.1.101'],
+  mac_address: 'AA:BB:CC:DD:EE:FF',
+  manufacturer: 'Test Manufacturer',
+  device_type: 'server',
+  os: 'Ubuntu 22.04',
+  status: 'online',
+  discovery_method: 'icmp',
+  first_seen: '2024-01-15T10:30:00Z',
+  last_seen: '2024-01-20T15:45:00Z',
+  notes: 'Production web server',
+  tags: ['production', 'web-server'],
+}
+
+const mockStatusHistory: DeviceStatusEvent[] = [
+  { id: 'event-1', device_id: 'device-123', status: 'online', timestamp: '2024-01-20T15:45:00Z' },
+  { id: 'event-2', device_id: 'device-123', status: 'offline', timestamp: '2024-01-20T14:30:00Z' },
+  { id: 'event-3', device_id: 'device-123', status: 'online', timestamp: '2024-01-20T10:00:00Z' },
+]
+
+const mockScanHistory: Scan[] = [
+  {
+    id: 'scan-1',
+    status: 'completed',
+    target_cidr: '192.168.1.0/24',
+    started_at: '2024-01-20T15:00:00Z',
+    completed_at: '2024-01-20T15:05:00Z',
+    devices_found: 10,
+  },
+  {
+    id: 'scan-2',
+    status: 'completed',
+    target_cidr: '192.168.1.0/24',
+    started_at: '2024-01-19T12:00:00Z',
+    completed_at: '2024-01-19T12:03:00Z',
+    devices_found: 8,
+  },
+]
+
+function renderWithProviders(deviceId = 'device-123') {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[`/devices/${deviceId}`]}>
+        <Routes>
+          <Route path="/devices/:id" element={<DeviceDetailPage />} />
+          <Route path="/devices" element={<div>Device List</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+describe('DeviceDetailPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows loading skeleton while fetching device', async () => {
+    const { getDevice, getDeviceStatusHistory, getDeviceScanHistory } = await import(
+      '@/api/devices'
+    )
+    vi.mocked(getDevice).mockImplementation(() => new Promise(() => {})) // Never resolves
+    vi.mocked(getDeviceStatusHistory).mockResolvedValue([])
+    vi.mocked(getDeviceScanHistory).mockResolvedValue([])
+
+    renderWithProviders()
+
+    // Should show skeleton (animated pulse elements)
+    expect(document.querySelector('.animate-pulse')).toBeInTheDocument()
+  })
+
+  it('displays device information correctly', async () => {
+    const { getDevice, getDeviceStatusHistory, getDeviceScanHistory } = await import(
+      '@/api/devices'
+    )
+    vi.mocked(getDevice).mockResolvedValue(mockDevice)
+    vi.mocked(getDeviceStatusHistory).mockResolvedValue(mockStatusHistory)
+    vi.mocked(getDeviceScanHistory).mockResolvedValue(mockScanHistory)
+
+    renderWithProviders()
+
+    await waitFor(() => {
+      expect(screen.getByText('test-server')).toBeInTheDocument()
+    })
+
+    // Check header information - use getAllByText since "Server" appears multiple times
+    const serverLabels = screen.getAllByText('Server')
+    expect(serverLabels.length).toBeGreaterThan(0)
+
+    // Check network information
+    expect(screen.getByText('192.168.1.100')).toBeInTheDocument()
+    expect(screen.getByText('192.168.1.101')).toBeInTheDocument()
+    expect(screen.getByText('AA:BB:CC:DD:EE:FF')).toBeInTheDocument()
+
+    // Check device info
+    expect(screen.getByText('Test Manufacturer')).toBeInTheDocument()
+    expect(screen.getByText('Ubuntu 22.04')).toBeInTheDocument()
+  })
+
+  it('displays first_seen and last_seen timestamps', async () => {
+    const { getDevice, getDeviceStatusHistory, getDeviceScanHistory } = await import(
+      '@/api/devices'
+    )
+    vi.mocked(getDevice).mockResolvedValue(mockDevice)
+    vi.mocked(getDeviceStatusHistory).mockResolvedValue([])
+    vi.mocked(getDeviceScanHistory).mockResolvedValue([])
+
+    renderWithProviders()
+
+    await waitFor(() => {
+      expect(screen.getByText('test-server')).toBeInTheDocument()
+    })
+
+    // Check that first seen and last seen sections exist
+    expect(screen.getByText('First Seen')).toBeInTheDocument()
+    expect(screen.getByText('Last Seen')).toBeInTheDocument()
+  })
+
+  it('displays notes and tags', async () => {
+    const { getDevice, getDeviceStatusHistory, getDeviceScanHistory } = await import(
+      '@/api/devices'
+    )
+    vi.mocked(getDevice).mockResolvedValue(mockDevice)
+    vi.mocked(getDeviceStatusHistory).mockResolvedValue([])
+    vi.mocked(getDeviceScanHistory).mockResolvedValue([])
+
+    renderWithProviders()
+
+    await waitFor(() => {
+      expect(screen.getByText('test-server')).toBeInTheDocument()
+    })
+
+    // Check notes
+    expect(screen.getByText('Production web server')).toBeInTheDocument()
+
+    // Check tags
+    expect(screen.getByText('production')).toBeInTheDocument()
+    expect(screen.getByText('web-server')).toBeInTheDocument()
+  })
+
+  it('displays status timeline', async () => {
+    const { getDevice, getDeviceStatusHistory, getDeviceScanHistory } = await import(
+      '@/api/devices'
+    )
+    vi.mocked(getDevice).mockResolvedValue(mockDevice)
+    vi.mocked(getDeviceStatusHistory).mockResolvedValue(mockStatusHistory)
+    vi.mocked(getDeviceScanHistory).mockResolvedValue([])
+
+    renderWithProviders()
+
+    await waitFor(() => {
+      expect(screen.getByText('test-server')).toBeInTheDocument()
+    })
+
+    // Check status timeline section exists
+    expect(screen.getByText('Status Timeline')).toBeInTheDocument()
+
+    // Check status history entries (there should be multiple "Online" and one "Offline")
+    const statusCards = screen.getAllByText(/Online|Offline/)
+    expect(statusCards.length).toBeGreaterThan(1)
+  })
+
+  it('displays scan history', async () => {
+    const { getDevice, getDeviceStatusHistory, getDeviceScanHistory } = await import(
+      '@/api/devices'
+    )
+    vi.mocked(getDevice).mockResolvedValue(mockDevice)
+    vi.mocked(getDeviceStatusHistory).mockResolvedValue([])
+    vi.mocked(getDeviceScanHistory).mockResolvedValue(mockScanHistory)
+
+    renderWithProviders()
+
+    await waitFor(() => {
+      expect(screen.getByText('test-server')).toBeInTheDocument()
+    })
+
+    // Check scan history section exists
+    expect(screen.getByText('Scan History')).toBeInTheDocument()
+
+    // Check scan history entries
+    const cidrElements = screen.getAllByText('192.168.1.0/24')
+    expect(cidrElements.length).toBe(2)
+  })
+
+  it('shows empty state for status timeline when no history', async () => {
+    const { getDevice, getDeviceStatusHistory, getDeviceScanHistory } = await import(
+      '@/api/devices'
+    )
+    vi.mocked(getDevice).mockResolvedValue(mockDevice)
+    vi.mocked(getDeviceStatusHistory).mockResolvedValue([])
+    vi.mocked(getDeviceScanHistory).mockResolvedValue([])
+
+    renderWithProviders()
+
+    await waitFor(() => {
+      expect(screen.getByText('test-server')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('No status history available yet.')).toBeInTheDocument()
+  })
+
+  it('shows empty state for scan history when no scans', async () => {
+    const { getDevice, getDeviceStatusHistory, getDeviceScanHistory } = await import(
+      '@/api/devices'
+    )
+    vi.mocked(getDevice).mockResolvedValue(mockDevice)
+    vi.mocked(getDeviceStatusHistory).mockResolvedValue([])
+    vi.mocked(getDeviceScanHistory).mockResolvedValue([])
+
+    renderWithProviders()
+
+    await waitFor(() => {
+      expect(screen.getByText('test-server')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('No scan history available yet.')).toBeInTheDocument()
+  })
+
+  it('shows error state when device not found', async () => {
+    const { getDevice, getDeviceStatusHistory, getDeviceScanHistory } = await import(
+      '@/api/devices'
+    )
+    vi.mocked(getDevice).mockRejectedValue(new Error('Device not found'))
+    vi.mocked(getDeviceStatusHistory).mockResolvedValue([])
+    vi.mocked(getDeviceScanHistory).mockResolvedValue([])
+
+    renderWithProviders()
+
+    await waitFor(() => {
+      expect(screen.getByText('Device not found')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('Return to Device List')).toBeInTheDocument()
+  })
+
+  it('has back navigation to device list', async () => {
+    const { getDevice, getDeviceStatusHistory, getDeviceScanHistory } = await import(
+      '@/api/devices'
+    )
+    vi.mocked(getDevice).mockResolvedValue(mockDevice)
+    vi.mocked(getDeviceStatusHistory).mockResolvedValue([])
+    vi.mocked(getDeviceScanHistory).mockResolvedValue([])
+
+    renderWithProviders()
+
+    await waitFor(() => {
+      expect(screen.getByText('test-server')).toBeInTheDocument()
+    })
+
+    const backLink = screen.getByText('Back to Devices')
+    expect(backLink).toBeInTheDocument()
+    expect(backLink.closest('a')).toHaveAttribute('href', '/devices')
+  })
+
+  it('displays hostname in header when available', async () => {
+    const { getDevice, getDeviceStatusHistory, getDeviceScanHistory } = await import(
+      '@/api/devices'
+    )
+    vi.mocked(getDevice).mockResolvedValue(mockDevice)
+    vi.mocked(getDeviceStatusHistory).mockResolvedValue([])
+    vi.mocked(getDeviceScanHistory).mockResolvedValue([])
+
+    renderWithProviders()
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('test-server')
+    })
+  })
+
+  it('displays IP address in header when no hostname', async () => {
+    const { getDevice, getDeviceStatusHistory, getDeviceScanHistory } = await import(
+      '@/api/devices'
+    )
+    const deviceWithoutHostname = { ...mockDevice, hostname: '' }
+    vi.mocked(getDevice).mockResolvedValue(deviceWithoutHostname)
+    vi.mocked(getDeviceStatusHistory).mockResolvedValue([])
+    vi.mocked(getDeviceScanHistory).mockResolvedValue([])
+
+    renderWithProviders()
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('192.168.1.100')
+    })
+  })
+
+  it('allows entering edit mode for notes', async () => {
+    const user = userEvent.setup()
+    const { getDevice, getDeviceStatusHistory, getDeviceScanHistory, updateDevice } = await import(
+      '@/api/devices'
+    )
+    vi.mocked(getDevice).mockResolvedValue(mockDevice)
+    vi.mocked(getDeviceStatusHistory).mockResolvedValue([])
+    vi.mocked(getDeviceScanHistory).mockResolvedValue([])
+    vi.mocked(updateDevice).mockResolvedValue(mockDevice)
+
+    renderWithProviders()
+
+    await waitFor(() => {
+      expect(screen.getByText('test-server')).toBeInTheDocument()
+    })
+
+    // Find the Edit button in the Notes section
+    const notesCard = screen.getByText('Notes').closest('.rounded-lg') as HTMLElement
+    expect(notesCard).toBeInTheDocument()
+
+    const editButtons = within(notesCard).getAllByRole('button', { name: /edit/i })
+    await user.click(editButtons[0])
+
+    // Should show textarea with current notes
+    expect(screen.getByPlaceholderText('Add notes about this device...')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
+  })
+
+  it('allows entering edit mode for tags', async () => {
+    const user = userEvent.setup()
+    const { getDevice, getDeviceStatusHistory, getDeviceScanHistory, updateDevice } = await import(
+      '@/api/devices'
+    )
+    vi.mocked(getDevice).mockResolvedValue(mockDevice)
+    vi.mocked(getDeviceStatusHistory).mockResolvedValue([])
+    vi.mocked(getDeviceScanHistory).mockResolvedValue([])
+    vi.mocked(updateDevice).mockResolvedValue(mockDevice)
+
+    renderWithProviders()
+
+    await waitFor(() => {
+      expect(screen.getByText('test-server')).toBeInTheDocument()
+    })
+
+    // Find the Tags section (it's after Notes)
+    const tagsCard = screen.getByText('Tags').closest('.rounded-lg') as HTMLElement
+    expect(tagsCard).toBeInTheDocument()
+
+    const editButtons = within(tagsCard).getAllByRole('button', { name: /edit/i })
+    await user.click(editButtons[0])
+
+    // Should show input for tags
+    expect(
+      screen.getByPlaceholderText(
+        'Enter tags separated by commas (e.g., production, critical, web-server)'
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('shows quick access buttons for device with IP', async () => {
+    const { getDevice, getDeviceStatusHistory, getDeviceScanHistory } = await import(
+      '@/api/devices'
+    )
+    vi.mocked(getDevice).mockResolvedValue(mockDevice)
+    vi.mocked(getDeviceStatusHistory).mockResolvedValue([])
+    vi.mocked(getDeviceScanHistory).mockResolvedValue([])
+
+    renderWithProviders()
+
+    await waitFor(() => {
+      expect(screen.getByText('test-server')).toBeInTheDocument()
+    })
+
+    // Check Quick Access section
+    expect(screen.getByText('Quick Access')).toBeInTheDocument()
+    expect(screen.getByText('HTTP (192.168.1.100)')).toBeInTheDocument()
+    expect(screen.getByText('HTTPS (192.168.1.100)')).toBeInTheDocument()
+  })
+
+  it('shows device type icon in header', async () => {
+    const { getDevice, getDeviceStatusHistory, getDeviceScanHistory } = await import(
+      '@/api/devices'
+    )
+    vi.mocked(getDevice).mockResolvedValue(mockDevice)
+    vi.mocked(getDeviceStatusHistory).mockResolvedValue([])
+    vi.mocked(getDeviceScanHistory).mockResolvedValue([])
+
+    renderWithProviders()
+
+    await waitFor(() => {
+      expect(screen.getByText('test-server')).toBeInTheDocument()
+    })
+
+    // Check for Server type label (appears multiple times on page)
+    const serverLabels = screen.getAllByText('Server')
+    expect(serverLabels.length).toBeGreaterThan(0)
+  })
+})

--- a/web/src/pages/devices/[id].tsx
+++ b/web/src/pages/devices/[id].tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useParams, Link } from 'react-router-dom'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   ArrowLeft,
   Server,
@@ -23,12 +24,25 @@ import {
   ExternalLink,
   Copy,
   Check,
+  History,
+  Activity,
+  Edit2,
+  Save,
+  X,
+  Radar,
   type LucideIcon,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { getTopology } from '@/api/devices'
-import type { TopologyNode, DeviceType, DeviceStatus } from '@/api/types'
+import { Input } from '@/components/ui/input'
+import {
+  getDevice,
+  updateDevice,
+  getDeviceStatusHistory,
+  getDeviceScanHistory,
+  type DeviceStatusEvent,
+} from '@/api/devices'
+import type { DeviceType, DeviceStatus, Scan } from '@/api/types'
 import { cn } from '@/lib/utils'
 
 // Device type icons (shared with device-card)
@@ -75,52 +89,123 @@ const statusConfig: Record<DeviceStatus, { bg: string; text: string; label: stri
 
 export function DeviceDetailPage() {
   const { id } = useParams<{ id: string }>()
-  const [device, setDevice] = useState<TopologyNode | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const [copiedIp, setCopiedIp] = useState<string | null>(null)
+  const queryClient = useQueryClient()
+  const [copiedText, setCopiedText] = useState<string | null>(null)
+  const [isEditingNotes, setIsEditingNotes] = useState(false)
+  const [isEditingTags, setIsEditingTags] = useState(false)
+  const [editedNotes, setEditedNotes] = useState('')
+  const [editedTags, setEditedTags] = useState('')
 
-  useEffect(() => {
-    async function fetchDevice() {
-      if (!id) return
-      setLoading(true)
-      setError(null)
-      try {
-        const topology = await getTopology()
-        const found = topology.nodes?.find((n) => n.id === id)
-        if (found) {
-          setDevice(found)
-        } else {
-          setError('Device not found')
-        }
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to fetch device')
-      } finally {
-        setLoading(false)
-      }
-    }
-    fetchDevice()
-  }, [id])
+  // Fetch device details
+  const {
+    data: device,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ['device', id],
+    queryFn: () => getDevice(id!),
+    enabled: !!id,
+  })
+
+  // Fetch status history
+  const { data: statusHistory } = useQuery({
+    queryKey: ['device-status-history', id],
+    queryFn: () => getDeviceStatusHistory(id!),
+    enabled: !!id,
+  })
+
+  // Fetch scan history
+  const { data: scanHistory } = useQuery({
+    queryKey: ['device-scan-history', id],
+    queryFn: () => getDeviceScanHistory(id!),
+    enabled: !!id,
+  })
+
+  // Update device mutation
+  const updateMutation = useMutation({
+    mutationFn: (data: { notes?: string; tags?: string[] }) =>
+      updateDevice(id!, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['device', id] })
+      setIsEditingNotes(false)
+      setIsEditingTags(false)
+    },
+  })
 
   async function copyToClipboard(text: string) {
     await navigator.clipboard.writeText(text)
-    setCopiedIp(text)
-    setTimeout(() => setCopiedIp(null), 2000)
+    setCopiedText(text)
+    setTimeout(() => setCopiedText(null), 2000)
   }
 
-  if (loading) {
+  function startEditNotes() {
+    setEditedNotes(device?.notes || '')
+    setIsEditingNotes(true)
+  }
+
+  function saveNotes() {
+    updateMutation.mutate({ notes: editedNotes })
+  }
+
+  function cancelEditNotes() {
+    setIsEditingNotes(false)
+    setEditedNotes('')
+  }
+
+  function startEditTags() {
+    setEditedTags(device?.tags?.join(', ') || '')
+    setIsEditingTags(true)
+  }
+
+  function saveTags() {
+    const tags = editedTags
+      .split(',')
+      .map((t) => t.trim())
+      .filter((t) => t.length > 0)
+    updateMutation.mutate({ tags })
+  }
+
+  function cancelEditTags() {
+    setIsEditingTags(false)
+    setEditedTags('')
+  }
+
+  function formatTimestamp(timestamp: string) {
+    return new Date(timestamp).toLocaleString()
+  }
+
+  function formatRelativeTime(timestamp: string) {
+    const date = new Date(timestamp)
+    const now = new Date()
+    const diff = now.getTime() - date.getTime()
+    const minutes = Math.floor(diff / 60000)
+    const hours = Math.floor(minutes / 60)
+    const days = Math.floor(hours / 24)
+
+    if (days > 0) return `${days} day${days > 1 ? 's' : ''} ago`
+    if (hours > 0) return `${hours} hour${hours > 1 ? 's' : ''} ago`
+    if (minutes > 0) return `${minutes} minute${minutes > 1 ? 's' : ''} ago`
+    return 'Just now'
+  }
+
+  if (isLoading) {
     return <DeviceDetailSkeleton />
   }
 
   if (error || !device) {
     return (
       <div className="space-y-4">
-        <Link to="/devices" className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground">
+        <Link
+          to="/devices"
+          className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
+        >
           <ArrowLeft className="h-4 w-4" />
           Back to Devices
         </Link>
         <div className="rounded-lg border border-red-200 bg-red-50 dark:bg-red-950/20 dark:border-red-900 p-6 text-center">
-          <p className="text-red-600 dark:text-red-400">{error || 'Device not found'}</p>
+          <p className="text-red-600 dark:text-red-400">
+            {error instanceof Error ? error.message : 'Device not found'}
+          </p>
           <Button variant="outline" size="sm" asChild className="mt-4">
             <Link to="/devices">Return to Device List</Link>
           </Button>
@@ -137,7 +222,10 @@ export function DeviceDetailPage() {
   return (
     <div className="space-y-6">
       {/* Back link */}
-      <Link to="/devices" className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors">
+      <Link
+        to="/devices"
+        className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+      >
         <ArrowLeft className="h-4 w-4" />
         Back to Devices
       </Link>
@@ -149,10 +237,12 @@ export function DeviceDetailPage() {
             <Icon className={cn('h-8 w-8', status.text)} />
           </div>
           <div>
-            <h1 className="text-2xl font-semibold">{device.label || 'Unnamed Device'}</h1>
+            <h1 className="text-2xl font-semibold">
+              {device.hostname || primaryIp || 'Unnamed Device'}
+            </h1>
             <div className="flex items-center gap-3 mt-1">
               <span className="text-sm text-muted-foreground">{typeLabel}</span>
-              <span className="text-muted-foreground">•</span>
+              <span className="text-muted-foreground">|</span>
               <div className="flex items-center gap-1.5">
                 <span className={cn('h-2 w-2 rounded-full', status.bg)} />
                 <span className={cn('text-sm font-medium', status.text)}>{status.label}</span>
@@ -193,7 +283,9 @@ export function DeviceDetailPage() {
           <CardContent className="space-y-3">
             {/* IP Addresses */}
             <div>
-              <p className="text-xs text-muted-foreground mb-1">IP Address{device.ip_addresses?.length > 1 ? 'es' : ''}</p>
+              <p className="text-xs text-muted-foreground mb-1">
+                IP Address{device.ip_addresses?.length > 1 ? 'es' : ''}
+              </p>
               <div className="space-y-1">
                 {device.ip_addresses?.map((ip) => (
                   <div key={ip} className="flex items-center gap-2">
@@ -203,7 +295,7 @@ export function DeviceDetailPage() {
                       className="text-muted-foreground hover:text-foreground transition-colors"
                       title="Copy to clipboard"
                     >
-                      {copiedIp === ip ? (
+                      {copiedText === ip ? (
                         <Check className="h-3.5 w-3.5 text-green-500" />
                       ) : (
                         <Copy className="h-3.5 w-3.5" />
@@ -219,13 +311,15 @@ export function DeviceDetailPage() {
               <div>
                 <p className="text-xs text-muted-foreground mb-1">MAC Address</p>
                 <div className="flex items-center gap-2">
-                  <code className="text-sm font-mono bg-muted px-2 py-0.5 rounded">{device.mac_address}</code>
+                  <code className="text-sm font-mono bg-muted px-2 py-0.5 rounded">
+                    {device.mac_address}
+                  </code>
                   <button
                     onClick={() => copyToClipboard(device.mac_address)}
                     className="text-muted-foreground hover:text-foreground transition-colors"
                     title="Copy to clipboard"
                   >
-                    {copiedIp === device.mac_address ? (
+                    {copiedText === device.mac_address ? (
                       <Check className="h-3.5 w-3.5 text-green-500" />
                     ) : (
                       <Copy className="h-3.5 w-3.5" />
@@ -258,6 +352,18 @@ export function DeviceDetailPage() {
               </div>
             )}
 
+            {device.os && (
+              <div>
+                <p className="text-xs text-muted-foreground mb-1">Operating System</p>
+                <p className="text-sm">{device.os}</p>
+              </div>
+            )}
+
+            <div>
+              <p className="text-xs text-muted-foreground mb-1">Discovery Method</p>
+              <p className="text-sm capitalize">{device.discovery_method || 'Unknown'}</p>
+            </div>
+
             <div>
               <p className="text-xs text-muted-foreground mb-1">Device ID</p>
               <code className="text-xs font-mono text-muted-foreground">{device.id}</code>
@@ -283,12 +389,170 @@ export function DeviceDetailPage() {
             </div>
 
             <div>
+              <p className="text-xs text-muted-foreground mb-1">First Seen</p>
+              <p className="text-sm">
+                {device.first_seen ? formatTimestamp(device.first_seen) : 'Unknown'}
+              </p>
+            </div>
+
+            <div>
               <p className="text-xs text-muted-foreground mb-1">Last Seen</p>
-              <p className="text-sm text-muted-foreground">Recently</p>
+              <p className="text-sm">
+                {device.last_seen
+                  ? `${formatTimestamp(device.last_seen)} (${formatRelativeTime(device.last_seen)})`
+                  : 'Unknown'}
+              </p>
             </div>
           </CardContent>
         </Card>
       </div>
+
+      {/* Notes Section */}
+      <Card>
+        <CardHeader className="pb-3">
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-sm font-medium flex items-center gap-2">
+              <Edit2 className="h-4 w-4 text-muted-foreground" />
+              Notes
+            </CardTitle>
+            {!isEditingNotes && (
+              <Button variant="ghost" size="sm" onClick={startEditNotes} className="gap-2">
+                <Edit2 className="h-3.5 w-3.5" />
+                Edit
+              </Button>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent>
+          {isEditingNotes ? (
+            <div className="space-y-3">
+              <textarea
+                value={editedNotes}
+                onChange={(e) => setEditedNotes(e.target.value)}
+                className="w-full min-h-[100px] p-3 rounded-md border bg-background text-sm resize-y"
+                placeholder="Add notes about this device..."
+              />
+              <div className="flex items-center gap-2">
+                <Button
+                  size="sm"
+                  onClick={saveNotes}
+                  disabled={updateMutation.isPending}
+                  className="gap-2"
+                >
+                  <Save className="h-3.5 w-3.5" />
+                  {updateMutation.isPending ? 'Saving...' : 'Save'}
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={cancelEditNotes}
+                  disabled={updateMutation.isPending}
+                  className="gap-2"
+                >
+                  <X className="h-3.5 w-3.5" />
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              {device.notes || 'No notes added yet. Click Edit to add notes about this device.'}
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Tags Section */}
+      <Card>
+        <CardHeader className="pb-3">
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-sm font-medium flex items-center gap-2">
+              <Tag className="h-4 w-4 text-muted-foreground" />
+              Tags
+            </CardTitle>
+            {!isEditingTags && (
+              <Button variant="ghost" size="sm" onClick={startEditTags} className="gap-2">
+                <Edit2 className="h-3.5 w-3.5" />
+                Edit
+              </Button>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent>
+          {isEditingTags ? (
+            <div className="space-y-3">
+              <Input
+                value={editedTags}
+                onChange={(e) => setEditedTags(e.target.value)}
+                placeholder="Enter tags separated by commas (e.g., production, critical, web-server)"
+              />
+              <p className="text-xs text-muted-foreground">Separate tags with commas</p>
+              <div className="flex items-center gap-2">
+                <Button
+                  size="sm"
+                  onClick={saveTags}
+                  disabled={updateMutation.isPending}
+                  className="gap-2"
+                >
+                  <Save className="h-3.5 w-3.5" />
+                  {updateMutation.isPending ? 'Saving...' : 'Save'}
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={cancelEditTags}
+                  disabled={updateMutation.isPending}
+                  className="gap-2"
+                >
+                  <X className="h-3.5 w-3.5" />
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          ) : device.tags && device.tags.length > 0 ? (
+            <div className="flex flex-wrap gap-2">
+              {device.tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-primary/10 text-primary"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              No tags added yet. Click Edit to add tags.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Status Timeline */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm font-medium flex items-center gap-2">
+            <Activity className="h-4 w-4 text-muted-foreground" />
+            Status Timeline
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <StatusTimeline events={statusHistory || []} />
+        </CardContent>
+      </Card>
+
+      {/* Scan History */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm font-medium flex items-center gap-2">
+            <History className="h-4 w-4 text-muted-foreground" />
+            Scan History
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ScanHistoryList scans={scanHistory || []} />
+        </CardContent>
+      </Card>
 
       {/* Quick Access Section */}
       <Card>
@@ -333,6 +597,111 @@ export function DeviceDetailPage() {
   )
 }
 
+function StatusTimeline({ events }: { events: DeviceStatusEvent[] }) {
+  if (events.length === 0) {
+    return (
+      <div className="text-center py-6">
+        <Activity className="h-8 w-8 mx-auto text-muted-foreground mb-2" />
+        <p className="text-sm text-muted-foreground">No status history available yet.</p>
+        <p className="text-xs text-muted-foreground mt-1">
+          Status changes will appear here as the device is monitored.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      {events.slice(0, 10).map((event, index) => {
+        const config = statusConfig[event.status] || statusConfig.unknown
+        return (
+          <div key={event.id || index} className="flex items-start gap-3">
+            <div className="relative">
+              <span className={cn('h-2.5 w-2.5 rounded-full block mt-1.5', config.bg)} />
+              {index < events.length - 1 && (
+                <div className="absolute top-4 left-1 w-0.5 h-full -translate-x-1/2 bg-muted" />
+              )}
+            </div>
+            <div className="flex-1 pb-3">
+              <div className="flex items-center gap-2">
+                <span className={cn('text-sm font-medium', config.text)}>{config.label}</span>
+                <span className="text-xs text-muted-foreground">
+                  {new Date(event.timestamp).toLocaleString()}
+                </span>
+              </div>
+            </div>
+          </div>
+        )
+      })}
+      {events.length > 10 && (
+        <p className="text-xs text-muted-foreground text-center">
+          Showing latest 10 of {events.length} status changes
+        </p>
+      )}
+    </div>
+  )
+}
+
+function ScanHistoryList({ scans }: { scans: Scan[] }) {
+  if (scans.length === 0) {
+    return (
+      <div className="text-center py-6">
+        <Radar className="h-8 w-8 mx-auto text-muted-foreground mb-2" />
+        <p className="text-sm text-muted-foreground">No scan history available yet.</p>
+        <p className="text-xs text-muted-foreground mt-1">
+          Scans that discover or update this device will appear here.
+        </p>
+      </div>
+    )
+  }
+
+  const statusColors: Record<string, string> = {
+    completed: 'text-green-600 dark:text-green-400',
+    running: 'text-blue-600 dark:text-blue-400',
+    pending: 'text-amber-600 dark:text-amber-400',
+    failed: 'text-red-600 dark:text-red-400',
+    cancelled: 'text-gray-600 dark:text-gray-400',
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="rounded-lg border overflow-hidden">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/50">
+            <tr>
+              <th className="px-4 py-2 text-left font-medium">Started</th>
+              <th className="px-4 py-2 text-left font-medium">Target</th>
+              <th className="px-4 py-2 text-left font-medium">Status</th>
+              <th className="px-4 py-2 text-left font-medium">Devices Found</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y">
+            {scans.slice(0, 10).map((scan) => (
+              <tr key={scan.id} className="hover:bg-muted/30 transition-colors">
+                <td className="px-4 py-2 text-muted-foreground">
+                  {new Date(scan.started_at).toLocaleString()}
+                </td>
+                <td className="px-4 py-2 font-mono text-xs">{scan.target_cidr}</td>
+                <td className="px-4 py-2">
+                  <span className={cn('capitalize', statusColors[scan.status] || '')}>
+                    {scan.status}
+                  </span>
+                </td>
+                <td className="px-4 py-2">{scan.devices_found}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {scans.length > 10 && (
+        <p className="text-xs text-muted-foreground text-center">
+          Showing latest 10 of {scans.length} scans
+        </p>
+      )}
+    </div>
+  )
+}
+
 function DeviceDetailSkeleton() {
   return (
     <div className="space-y-6 animate-pulse">
@@ -356,6 +725,11 @@ function DeviceDetailSkeleton() {
             </div>
           </div>
         ))}
+      </div>
+
+      <div className="rounded-lg border bg-card p-6">
+        <div className="h-4 w-20 bg-muted rounded mb-4" />
+        <div className="h-20 w-full bg-muted rounded" />
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

- Enhanced device detail page at `/devices/:id` with comprehensive device information display
- Added scan history section showing scans that discovered/updated the device
- Added status timeline showing online/offline history
- Added editable notes and tags with inline editing capability
- Converted data fetching to TanStack Query for better state management
- Added first_seen and last_seen timestamps in Status card
- Created 16 comprehensive unit tests for the detail page components

## Changes

### New Features
- **Status Timeline**: Visual timeline showing device status changes (online/offline/degraded)
- **Scan History**: Table showing past network scans that touched this device
- **Notes Section**: Editable notes with save/cancel functionality
- **Tags Section**: Editable tags with comma-separated input
- **Enhanced Info Cards**: Network, Device Info, and Status cards with all device attributes

### API Additions
- `getDevice(id)` - Fetch single device by ID
- `updateDevice(id, data)` - Update device notes/tags
- `getDeviceStatusHistory(id)` - Fetch status change history
- `getDeviceScanHistory(id)` - Fetch scan history for device

### Testing
- 16 unit tests covering all acceptance criteria
- Tests for loading, error, and empty states
- Tests for edit functionality for notes and tags
- Tests for header display logic (hostname vs IP fallback)

## Test plan

- [ ] Navigate to `/devices/:id` and verify all device information displays
- [ ] Verify first_seen and last_seen timestamps appear in Status card
- [ ] Verify empty states for status timeline and scan history
- [ ] Test notes edit mode - click Edit, modify text, Save/Cancel
- [ ] Test tags edit mode - click Edit, add/remove tags, Save/Cancel
- [ ] Verify 404 handling for invalid device IDs
- [ ] Verify back navigation works
- [ ] Run `pnpm test` - all 53 tests should pass

Closes #48

---
Generated with [Claude Code](https://claude.com/claude-code)