### PR TITLE
fix(release): add Docker buildx, GHCR login, and syft

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,19 @@ jobs:
         with:
           version: 10
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install syft
+        uses: anchore/sbom-action/download-syft@v0
+
       - name: Build frontend
         working-directory: web
         run: |


### PR DESCRIPTION
## Summary

- Add `docker/setup-buildx-action@v3` for multi-arch Docker image builds
- Add `docker/login-action@v3` for GHCR authentication  
- Add `anchore/sbom-action/download-syft@v0` for SBOM generation

## Problem

The v0.1.0-alpha release workflow built all 12 binaries and archives successfully but failed at the SBOM cataloging step because `syft` was not in PATH. Docker image push would also have failed without buildx setup and GHCR login.

## Test plan

- [ ] CI passes
- [ ] Re-tag v0.1.0-alpha after merge to verify full release pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)