### PR TITLE
chore(ci): add GoReleaser config validation job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,3 +257,16 @@ jobs:
       - name: Check licenses
         run: |
           go-licenses check ./... 2>&1 | grep -E "GPL|AGPL|LGPL|SSPL" && exit 1 || echo "No blocked licenses found"
+
+  goreleaser-check:
+    name: GoReleaser Config Check
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run GoReleaser check
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: '~> v2'
+          args: check


### PR DESCRIPTION
## Summary
- Adds a `goreleaser-check` job to the CI workflow that validates `.goreleaser.yaml` syntax and configuration
- Only runs on pull requests (not pushes to main) since it is a validation-only step
- Uses `goreleaser/goreleaser-action@v6` with `goreleaser check` (config-only, no Go setup or frontend artifacts needed)

## Test plan
- [ ] CI passes on this PR (the new goreleaser-check job itself runs and validates the config)
- [ ] Existing CI jobs remain unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)