### PR TITLE
feat(ai): add LLM dev tools with Ollama MCP integration

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "ollama": {
+      "command": "npx",
+      "args": ["-y", "ollama-mcp"],
+      "env": {
+        "OLLAMA_HOST": "http://127.0.0.1:11434"
+      }
+    }
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-server build-scout build-dashboard dev-dashboard lint-dashboard test test-race test-coverage lint run-server run-scout proto swagger clean license-check
+.PHONY: build build-server build-scout build-dashboard dev-dashboard lint-dashboard test test-race test-coverage lint run-server run-scout proto swagger clean license-check ai-review ai-test ai-doc
 
 # Binary names
 SERVER_BIN=subnetree
@@ -81,6 +81,23 @@ license-check:
 
 license-report:
 	@go-licenses report ./... --template=csv 2>/dev/null || go-licenses csv ./... 2>/dev/null
+
+# AI dev tools (requires Ollama on localhost:11434)
+OLLAMA_HOST ?= http://127.0.0.1:11434
+
+ai-review:
+	@bash tools/ai-review.sh
+
+ai-review-all:
+	@bash tools/ai-review.sh --all
+
+ai-test:
+	@test -n "$(FILE)" || (echo "Usage: make ai-test FILE=path/to/file.go" && exit 1)
+	@bash tools/ai-test.sh $(FILE)
+
+ai-doc:
+	@test -n "$(FILE)" || (echo "Usage: make ai-doc FILE=path/to/file.go" && exit 1)
+	@bash tools/ai-doc.sh $(FILE)
 
 clean:
 	rm -rf bin/ $(WEB_DIR)/dist $(WEB_DIR)/node_modules/.cache internal/dashboard/dist

--- a/tools/ai-doc.sh
+++ b/tools/ai-doc.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# ai-doc.sh -- Generate godoc comments for exported functions using local Ollama.
+# Requires: curl, python, Ollama running on localhost:11434
+#
+# Usage:
+#   ./tools/ai-doc.sh internal/recon/scanner.go
+#   OLLAMA_MODEL=llama3.1 ./tools/ai-doc.sh pkg/llm/provider.go
+
+set -euo pipefail
+
+OLLAMA_HOST="${OLLAMA_HOST:-http://127.0.0.1:11434}"
+OLLAMA_MODEL="${OLLAMA_MODEL:-qwen2.5:32b}"
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <go-file>" >&2
+    exit 1
+fi
+
+file="$1"
+if [[ ! -f "$file" ]]; then
+    echo "Error: File not found: $file" >&2
+    exit 1
+fi
+
+# Find python (Windows Store aliases can shadow real python)
+PYTHON=""
+for p in python3 python py "/c/Program Files/Python39/python" "/c/Program Files/Python312/python"; do
+    if "$p" --version &>/dev/null 2>&1; then PYTHON="$p"; break; fi
+done
+if [[ -z "$PYTHON" ]]; then echo "Error: python is required." >&2; exit 1; fi
+
+# Check Ollama is reachable
+if ! curl -s "${OLLAMA_HOST}/api/tags" &>/dev/null; then
+    echo "Error: Ollama not reachable at ${OLLAMA_HOST}" >&2
+    exit 1
+fi
+
+echo "Generating docs for ${file} with ${OLLAMA_MODEL}..."
+echo "---"
+
+$PYTHON -c "
+import json, urllib.request, sys
+
+content = sys.stdin.read()
+prompt = '''You are an expert Go developer. Generate godoc-style comments for all exported types, functions, and methods in this Go file. Follow these conventions:
+- Start each comment with the name of the identifier
+- Be concise but informative (1-2 sentences)
+- Mention parameters and return values where helpful
+- Follow official Go documentation conventions
+- Output the FULL file with comments added (preserve all existing code)
+
+File: ${file}
+
+\`\`\`go
+''' + content + '''
+\`\`\`'''
+
+payload = json.dumps({'model': '${OLLAMA_MODEL}', 'prompt': prompt, 'stream': False}).encode()
+req = urllib.request.Request('${OLLAMA_HOST}/api/generate', data=payload, headers={'Content-Type': 'application/json'})
+try:
+    resp = urllib.request.urlopen(req, timeout=300)
+    result = json.loads(resp.read())
+    print(result.get('response', 'Error: No response from model'))
+except Exception as e:
+    print(f'Error: {e}', file=sys.stderr)
+    sys.exit(1)
+" < "$file"

--- a/tools/ai-review.sh
+++ b/tools/ai-review.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# ai-review.sh -- Send staged git diff to local Ollama for code review.
+# Requires: curl, python, Ollama running on localhost:11434
+#
+# Usage:
+#   ./tools/ai-review.sh              # Review staged changes
+#   ./tools/ai-review.sh --all        # Review all uncommitted changes
+#   OLLAMA_MODEL=llama3.1 ./tools/ai-review.sh  # Use specific model
+
+set -euo pipefail
+
+OLLAMA_HOST="${OLLAMA_HOST:-http://127.0.0.1:11434}"
+OLLAMA_MODEL="${OLLAMA_MODEL:-qwen2.5:32b}"
+
+# Find python (Windows Store aliases can shadow real python)
+PYTHON=""
+for p in python3 python py "/c/Program Files/Python39/python" "/c/Program Files/Python312/python"; do
+    if "$p" --version &>/dev/null 2>&1; then PYTHON="$p"; break; fi
+done
+if [[ -z "$PYTHON" ]]; then echo "Error: python is required." >&2; exit 1; fi
+
+# Check Ollama is reachable
+if ! curl -s "${OLLAMA_HOST}/api/tags" &>/dev/null; then
+    echo "Error: Ollama not reachable at ${OLLAMA_HOST}" >&2
+    echo "Start it with: ollama serve" >&2
+    exit 1
+fi
+
+# Get the diff
+if [[ "${1:-}" == "--all" ]]; then
+    diff=$(git diff)
+else
+    diff=$(git diff --staged)
+fi
+
+if [[ -z "$diff" ]]; then
+    echo "No changes to review."
+    [[ "${1:-}" != "--all" ]] && echo "Tip: stage changes first (git add) or use --all for unstaged."
+    exit 0
+fi
+
+# Truncate very large diffs
+max_chars=12000
+if [[ ${#diff} -gt $max_chars ]]; then
+    diff="${diff:0:$max_chars}
+
+... [truncated at ${max_chars} chars -- review remaining changes manually]"
+fi
+
+echo "Reviewing with ${OLLAMA_MODEL}..."
+echo "---"
+
+# Use python for JSON escaping and response parsing
+$PYTHON -c "
+import json, urllib.request, sys
+
+diff = sys.stdin.read()
+prompt = '''You are an expert code reviewer for a Go + React/TypeScript project. Review this diff for:
+1. Bugs or logic errors
+2. Security issues (injection, XSS, credential leaks)
+3. Performance concerns
+4. Go/TypeScript best practice violations
+
+Be concise. Only flag real issues, not style preferences. Output a numbered list of findings, or \"No issues found.\" if the code looks good.
+
+Diff:
+\`\`\`
+''' + diff + '''
+\`\`\`'''
+
+payload = json.dumps({'model': '${OLLAMA_MODEL}', 'prompt': prompt, 'stream': False}).encode()
+req = urllib.request.Request('${OLLAMA_HOST}/api/generate', data=payload, headers={'Content-Type': 'application/json'})
+try:
+    resp = urllib.request.urlopen(req, timeout=300)
+    result = json.loads(resp.read())
+    print(result.get('response', 'Error: No response from model'))
+except Exception as e:
+    print(f'Error: {e}', file=sys.stderr)
+    sys.exit(1)
+" <<< "$diff"

--- a/tools/ai-test.sh
+++ b/tools/ai-test.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# ai-test.sh -- Generate Go test skeletons for a file using local Ollama.
+# Requires: curl, python, Ollama running on localhost:11434
+#
+# Usage:
+#   ./tools/ai-test.sh internal/recon/scanner.go
+#   OLLAMA_MODEL=llama3.1 ./tools/ai-test.sh pkg/llm/provider.go
+
+set -euo pipefail
+
+OLLAMA_HOST="${OLLAMA_HOST:-http://127.0.0.1:11434}"
+OLLAMA_MODEL="${OLLAMA_MODEL:-qwen2.5:32b}"
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <go-file>" >&2
+    exit 1
+fi
+
+file="$1"
+if [[ ! -f "$file" ]]; then
+    echo "Error: File not found: $file" >&2
+    exit 1
+fi
+
+# Find python (Windows Store aliases can shadow real python)
+PYTHON=""
+for p in python3 python py "/c/Program Files/Python39/python" "/c/Program Files/Python312/python"; do
+    if "$p" --version &>/dev/null 2>&1; then PYTHON="$p"; break; fi
+done
+if [[ -z "$PYTHON" ]]; then echo "Error: python is required." >&2; exit 1; fi
+
+# Check Ollama is reachable
+if ! curl -s "${OLLAMA_HOST}/api/tags" &>/dev/null; then
+    echo "Error: Ollama not reachable at ${OLLAMA_HOST}" >&2
+    exit 1
+fi
+
+echo "Generating tests for ${file} with ${OLLAMA_MODEL}..."
+echo "---"
+
+$PYTHON -c "
+import json, urllib.request, sys
+
+content = sys.stdin.read()
+prompt = '''You are an expert Go developer. Generate table-driven test skeletons for the exported functions in this Go file. Follow these conventions:
+- Use testing.T and subtests (t.Run)
+- Use table-driven tests with []struct{name string; ...}
+- Include edge cases and error cases
+- Do NOT mock external dependencies -- just create the test structure
+- Output ONLY the Go test code, no explanation
+
+File: ${file}
+
+\`\`\`go
+''' + content + '''
+\`\`\`'''
+
+payload = json.dumps({'model': '${OLLAMA_MODEL}', 'prompt': prompt, 'stream': False}).encode()
+req = urllib.request.Request('${OLLAMA_HOST}/api/generate', data=payload, headers={'Content-Type': 'application/json'})
+try:
+    resp = urllib.request.urlopen(req, timeout=300)
+    result = json.loads(resp.read())
+    print(result.get('response', 'Error: No response from model'))
+except Exception as e:
+    print(f'Error: {e}', file=sys.stderr)
+    sys.exit(1)
+" < "$file"


### PR DESCRIPTION
## Summary

- Add three Ollama-powered CLI scripts (`tools/ai-review.sh`, `tools/ai-doc.sh`, `tools/ai-test.sh`) for local LLM-assisted development
- Add `.mcp.json` for Ollama MCP server integration with Claude Code IDE
- Add Makefile targets (`ai-review`, `ai-review-all`, `ai-test`, `ai-doc`) as convenience wrappers

This is **Stage 1** of the LLM integration plan. All tools are optional dev helpers -- they require Ollama running locally with `qwen2.5:32b` (configurable via `OLLAMA_MODEL`).

Scripts handle Windows MSYS quirks: Python path detection (Store alias workaround), Python-based JSON instead of jq, and Ollama connectivity checks before requests.

## Test plan

- [x] Verified Ollama connectivity (v0.15.5, `qwen2.5:32b` loaded)
- [x] Verified MCP connector (`npx ollama-mcp`) resolves and starts
- [x] Tested `ai-review.sh --all` -- reviewed uncommitted diff successfully
- [x] Tested `ai-doc.sh` on `internal/version/version.go` -- generated clean godoc comments
- [x] Tested `ai-test.sh` on `internal/version/version.go` -- generated table-driven test skeleton

🤖 Generated with [Claude Code](https://claude.com/claude-code)