### PR TITLE
feat(llm): add LLM plugin wrapper for Ollama provider

### DIFF
--- a/cmd/subnetree/main.go
+++ b/cmd/subnetree/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/HerbHall/subnetree/internal/dispatch"
 	"github.com/HerbHall/subnetree/internal/event"
 	"github.com/HerbHall/subnetree/internal/gateway"
+	"github.com/HerbHall/subnetree/internal/llm"
 	"github.com/HerbHall/subnetree/internal/pulse"
 	"github.com/HerbHall/subnetree/internal/recon"
 	"github.com/HerbHall/subnetree/internal/registry"
@@ -128,6 +129,7 @@ func main() {
 		vault.New(),
 		gateway.New(),
 		webhook.New(),
+		llm.New(),
 	}
 	for _, m := range modules {
 		if err := reg.Register(m); err != nil {

--- a/internal/llm/plugin.go
+++ b/internal/llm/plugin.go
@@ -1,0 +1,104 @@
+package llm
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/HerbHall/subnetree/internal/llm/ollama"
+	pkgllm "github.com/HerbHall/subnetree/pkg/llm"
+	"github.com/HerbHall/subnetree/pkg/plugin"
+	"github.com/HerbHall/subnetree/pkg/roles"
+	"go.uber.org/zap"
+)
+
+// Compile-time interface guards.
+var (
+	_ plugin.Plugin        = (*Module)(nil)
+	_ plugin.HealthChecker = (*Module)(nil)
+	_ roles.LLMProvider    = (*Module)(nil)
+)
+
+// Module implements the LLM plugin, wrapping an Ollama provider.
+type Module struct {
+	logger   *zap.Logger
+	provider *ollama.Provider
+}
+
+// New creates a new LLM plugin instance.
+func New() *Module {
+	return &Module{}
+}
+
+func (m *Module) Info() plugin.PluginInfo {
+	return plugin.PluginInfo{
+		Name:        "llm",
+		Version:     "0.1.0",
+		Description: "LLM provider integration (Ollama)",
+		Roles:       []string{roles.RoleLLM},
+		Required:    false,
+		APIVersion:  plugin.APIVersionCurrent,
+	}
+}
+
+func (m *Module) Init(_ context.Context, deps plugin.Dependencies) error {
+	m.logger = deps.Logger
+
+	cfg := ollama.DefaultConfig()
+	if deps.Config != nil {
+		if err := deps.Config.Unmarshal(&cfg); err != nil {
+			return fmt.Errorf("unmarshal llm config: %w", err)
+		}
+	}
+
+	provider, err := ollama.New(cfg, m.logger)
+	if err != nil {
+		return fmt.Errorf("create ollama provider: %w", err)
+	}
+	m.provider = provider
+
+	m.logger.Info("llm plugin initialized",
+		zap.String("provider", "ollama"),
+		zap.String("url", cfg.URL),
+		zap.String("model", cfg.Model),
+	)
+	return nil
+}
+
+func (m *Module) Start(ctx context.Context) error {
+	if err := m.provider.Heartbeat(ctx); err != nil {
+		m.logger.Warn("ollama not reachable; LLM features will be unavailable until it comes online",
+			zap.Error(err),
+		)
+		return nil
+	}
+
+	models, err := m.provider.ListModels(ctx)
+	if err != nil {
+		m.logger.Warn("failed to list ollama models", zap.Error(err))
+		return nil
+	}
+
+	m.logger.Info("ollama connected", zap.Strings("models", models))
+	return nil
+}
+
+func (m *Module) Stop(_ context.Context) error {
+	m.logger.Info("llm plugin stopped")
+	return nil
+}
+
+// Health implements plugin.HealthChecker.
+func (m *Module) Health(ctx context.Context) plugin.HealthStatus {
+	if err := m.provider.Heartbeat(ctx); err != nil {
+		return plugin.HealthStatus{
+			Status:  "unhealthy",
+			Message: err.Error(),
+		}
+	}
+	return plugin.HealthStatus{Status: "healthy"}
+}
+
+// Provider implements roles.LLMProvider.
+func (m *Module) Provider() pkgllm.Provider {
+	return m.provider
+}

--- a/internal/llm/plugin_test.go
+++ b/internal/llm/plugin_test.go
@@ -1,0 +1,143 @@
+package llm
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/HerbHall/subnetree/internal/config"
+	"github.com/HerbHall/subnetree/pkg/plugin"
+	"github.com/HerbHall/subnetree/pkg/plugin/plugintest"
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+)
+
+func TestPluginContract(t *testing.T) {
+	plugintest.TestPluginContract(t, func() plugin.Plugin { return New() })
+}
+
+func TestInit_WithConfig(t *testing.T) {
+	srv := mockHeartbeat(t)
+
+	v := viper.New()
+	v.Set("url", srv.URL)
+	v.Set("model", "test-model")
+	v.Set("timeout", "30s")
+
+	m := New()
+	err := m.Init(context.Background(), plugin.Dependencies{
+		Logger: zap.NewNop(),
+		Config: config.New(v),
+	})
+	if err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	if m.provider == nil {
+		t.Fatal("provider is nil after Init")
+	}
+}
+
+func TestInit_NilConfig(t *testing.T) {
+	m := New()
+	err := m.Init(context.Background(), plugin.Dependencies{
+		Logger: zap.NewNop(),
+	})
+	if err != nil {
+		t.Fatalf("Init() with nil config error = %v", err)
+	}
+	if m.provider == nil {
+		t.Fatal("provider is nil after Init with nil config")
+	}
+}
+
+func TestStart_HeartbeatFails(t *testing.T) {
+	// Point at a closed server -- Start should succeed with a warning, not error.
+	srv := httptest.NewServer(http.NotFoundHandler())
+	srv.Close()
+
+	v := viper.New()
+	v.Set("url", srv.URL)
+	v.Set("timeout", "1s")
+
+	m := New()
+	if err := m.Init(context.Background(), plugin.Dependencies{
+		Logger: zap.NewNop(),
+		Config: config.New(v),
+	}); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	if err := m.Start(context.Background()); err != nil {
+		t.Fatalf("Start() should succeed even when Ollama is unreachable, got error = %v", err)
+	}
+}
+
+func TestHealth_Healthy(t *testing.T) {
+	srv := mockHeartbeat(t)
+
+	v := viper.New()
+	v.Set("url", srv.URL)
+	v.Set("timeout", "5s")
+
+	m := New()
+	if err := m.Init(context.Background(), plugin.Dependencies{
+		Logger: zap.NewNop(),
+		Config: config.New(v),
+	}); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	status := m.Health(context.Background())
+	if status.Status != "healthy" {
+		t.Errorf("Health().Status = %q, want %q", status.Status, "healthy")
+	}
+}
+
+func TestHealth_Unhealthy(t *testing.T) {
+	srv := httptest.NewServer(http.NotFoundHandler())
+	srv.Close()
+
+	v := viper.New()
+	v.Set("url", srv.URL)
+	v.Set("timeout", "1s")
+
+	m := New()
+	if err := m.Init(context.Background(), plugin.Dependencies{
+		Logger: zap.NewNop(),
+		Config: config.New(v),
+	}); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	status := m.Health(context.Background())
+	if status.Status != "unhealthy" {
+		t.Errorf("Health().Status = %q, want %q", status.Status, "unhealthy")
+	}
+	if status.Message == "" {
+		t.Error("Health().Message should not be empty for unhealthy status")
+	}
+}
+
+func TestProvider_ReturnsNonNil(t *testing.T) {
+	m := New()
+	if err := m.Init(context.Background(), plugin.Dependencies{
+		Logger: zap.NewNop(),
+	}); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	if m.Provider() == nil {
+		t.Error("Provider() returned nil after Init")
+	}
+}
+
+// mockHeartbeat returns an httptest server that responds 200 OK on GET /.
+func mockHeartbeat(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -46,6 +46,9 @@ func LoadConfig(configPath string) (*viper.Viper, error) {
 	v.SetDefault("plugins.webhook.enabled", true)
 	v.SetDefault("plugins.webhook.url", "")
 	v.SetDefault("plugins.webhook.timeout", "10s")
+	v.SetDefault("plugins.llm.url", "http://localhost:11434")
+	v.SetDefault("plugins.llm.model", "qwen2.5:32b")
+	v.SetDefault("plugins.llm.timeout", "5m")
 
 	if configPath != "" {
 		v.SetConfigFile(configPath)


### PR DESCRIPTION
## Summary

- Wraps the Ollama provider (from PR #98) as a `plugin.Plugin` in the registry
- `Required: false` -- product works without AI; logs warning if Ollama unreachable
- Implements `plugin.HealthChecker` for health endpoint and `roles.LLMProvider` for role-based discovery
- Adds `plugins.llm.*` config defaults (url, model, timeout) to server config
- 7 new tests (plugin contract + health + config + graceful degradation)

LLM Stage 4 of 6.

## Test plan

- [x] `go build ./...` compiles
- [x] `go vet ./...` clean
- [x] `go test ./internal/llm/... -v` -- all 24 tests pass (7 plugin + 17 ollama)
- [ ] CI: all 13 checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)