### PR TITLE
docs: sync documentation with shipped features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SubNetree
 
+[![CI](https://github.com/HerbHall/subnetree/actions/workflows/ci.yml/badge.svg)](https://github.com/HerbHall/subnetree/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/HerbHall/subnetree?include_prereleases)](https://github.com/HerbHall/subnetree/releases)
 [![Go Report Card](https://goreportcard.com/badge/github.com/HerbHall/subnetree)](https://goreportcard.com/report/github.com/HerbHall/subnetree)
 [![codecov](https://codecov.io/gh/HerbHall/subnetree/branch/main/graph/badge.svg)](https://codecov.io/gh/HerbHall/subnetree)
 [![License](https://img.shields.io/badge/license-BSL%201.1-blue)](LICENSE)
@@ -12,7 +14,7 @@
 
 Homelabbers juggle dozens of tools: UnRAID for storage, Proxmox for VMs, Home Assistant for automation, plus routers, NAS boxes, and random IoT devices. SubNetree doesn't replace any of them -- it's your **dashboard and aggregator** that:
 
-- **Discovers everything** on your LAN automatically (ARP, ICMP, mDNS, SNMP)
+- **Discovers everything** on your LAN automatically (ARP, ICMP -- with mDNS, SNMP, UPnP planned)
 - **Shows status at a glance** from multiple platforms in one place
 - **Launches anything** with one click -- web UIs, SSH, RDP -- credentials handled
 - **Extends via plugins** to monitor whatever you need
@@ -28,10 +30,12 @@ Homelabbers juggle dozens of tools: UnRAID for storage, Proxmox for VMs, Home As
 - **Real-Time Updates**: WebSocket-powered scan progress with live device feed
 - **Authentication**: JWT-based auth with first-run setup wizard
 - **Backup/Restore**: CLI commands for data safety
+- **AI Integration**: Optional Ollama-powered LLM provider (query interface coming)
 - **Docker**: Multi-stage builds with health checks
 
 ### Coming Next
 
+- AI-powered network insights (query interface for the shipped Ollama integration)
 - Monitoring & alerting (Pulse module)
 - Scout agents for detailed host metrics
 - Credential vault for stored passwords
@@ -90,7 +94,7 @@ docker-compose up -d
 
 ### Discovery & Mapping
 
-- LAN scanning with ARP, ICMP, mDNS, SNMP, UPnP
+- LAN scanning with ARP and ICMP (mDNS, SNMP, UPnP in Phase 2)
 - Automatic device identification (OS, manufacturer, type)
 - Network topology visualization
 
@@ -140,8 +144,10 @@ docker-compose up -d
                    | +------+ +------+ | mDNS   +----------+
                    | |Dispatch|Vault | |
                    | +------+ +------+ |
-                   | |Gateway|        |
-                   | +------+         |
+                   | |Gateway|Webhook| |
+                   | +------+ +------+ |
+                   | | LLM  |        |
+                   | +------+        |
                    +-------------------+
 ```
 
@@ -154,6 +160,8 @@ docker-compose up -d
 | **Dispatch** | Scout agent enrollment and management |
 | **Vault** | Encrypted credential storage |
 | **Gateway** | Browser-based remote access (SSH, RDP, HTTP proxy) |
+| **Webhook** | Event-driven webhook notifications |
+| **LLM** | AI provider integration (Ollama, optional) |
 
 ## Building from Source
 
@@ -209,9 +217,13 @@ internal/
   dispatch/       Agent management module
   vault/          Credential management module
   gateway/        Remote access module
+  webhook/        Webhook notification module
+  llm/            LLM plugin (Ollama provider)
 web/              React dashboard (Vite + shadcn/ui)
 pkg/
   plugin/         Public plugin SDK (Apache 2.0)
+  llm/            LLM provider interface (Apache 2.0)
+  roles/          Plugin role definitions (Apache 2.0)
   models/         Shared data types
 api/
   proto/v1/       gRPC service definitions
@@ -219,7 +231,7 @@ api/
 
 ## Roadmap
 
-- **Phase 1** (Current): Server + dashboard + agentless scanning
+- **Phase 1** (v0.1.0-alpha shipped): Server + dashboard + agentless scanning + LLM integration
 - **Phase 1b**: Windows Scout agent
 - **Phase 2**: Enhanced discovery (SNMP, mDNS, UPnP) + monitoring + Linux agent
 - **Phase 3**: Remote access (SSH, RDP) + credential vault

--- a/docs/requirements/02-architecture-overview.md
+++ b/docs/requirements/02-architecture-overview.md
@@ -19,6 +19,8 @@ Each module fills one or more **roles** (abstract capabilities). Alternative imp
 | Agent Management | **Dispatch** | `agent_management` | Scout agent enrollment, check-in, command dispatch, status tracking |
 | Credentials | **Vault** | `credential_store` | Encrypted credential storage, per-device credential assignment |
 | Remote Access | **Gateway** | `remote_access` | Browser-based SSH, RDP (via Guacamole), HTTP/HTTPS reverse proxy, VNC |
+| Notifications | **Webhook** | `webhook` | Event-driven webhook notifications to external services |
+| AI Provider | **LLM** | `llm` | LLM provider integration (Ollama); optional, product works without it |
 | Overlay Network | **Tailscale** | `overlay_network` | Tailscale tailnet device discovery, overlay IP enrichment, subnet route awareness |
 
 ### Communication
@@ -47,10 +49,13 @@ Tailscale (requires: credential_store for API key/OAuth storage)
   |
   +---> Recon (optional: overlay_network for Tailscale-discovered devices)
   +---> Gateway (optional: overlay_network for Tailscale IP connectivity)
+
+Webhook (no deps, provides webhook notifications)
+LLM (no deps, provides llm; Required: false)
 ```
 
-**Topological Startup Order:** Vault -> Dispatch -> Tailscale -> Recon -> Pulse -> Gateway
-**Shutdown Order (reverse):** Gateway -> Pulse -> Recon -> Tailscale -> Dispatch -> Vault
+**Topological Startup Order:** Vault -> Dispatch -> Webhook -> LLM -> Tailscale -> Recon -> Pulse -> Gateway
+**Shutdown Order (reverse):** Gateway -> Pulse -> Recon -> Tailscale -> LLM -> Webhook -> Dispatch -> Vault
 
 ### Go Architecture Conventions
 

--- a/docs/requirements/21-phased-roadmap.md
+++ b/docs/requirements/21-phased-roadmap.md
@@ -61,6 +61,8 @@
 
 ### Phase 1: Foundation (Server + Dashboard + Discovery + Topology)
 
+**Status:** v0.1.0-alpha shipped 2026-02-07. Core scanning, dashboard, topology, and LLM integration are functional.
+
 **Goal:** Functional web-based network scanner with topology visualization. Validate architecture. Time to First Value under 10 minutes.
 
 #### Pre-Phase Tooling Research
@@ -126,7 +128,7 @@
 - [ ] Tailscale Funnel/Serve guide: exposing dashboard without port forwarding
 
 #### Operations
-- [ ] Backup/restore CLI commands (`subnetree backup`, `subnetree restore`)
+- [x] Backup/restore CLI commands (`subnetree backup`, `subnetree restore`)
 - [ ] Data retention configuration with automated purge job
 - [x] Security headers middleware (CSP, X-Frame-Options, HSTS, etc.)
 - [x] Account lockout after failed login attempts
@@ -136,7 +138,7 @@
 - [x] Test infrastructure: `internal/testutil/` with mocks, fixtures, helpers, mock clock
 - [ ] Test infrastructure: `testdata/` directory with SNMP fixtures, test configs, migration snapshots
 - [x] Plugin contract tests: table-driven tests for `Plugin` interface and all optional interfaces
-- [ ] Plugin isolation tests: panic recovery in Init, Start, Stop, and HTTP handlers
+- [x] Plugin isolation tests: panic recovery in Init, Start, Stop, and HTTP handlers
 - [x] Plugin lifecycle tests: full Init → Start → Stop cycle, dependency ordering, cascade disable
 - [x] Plugin API version validation tests: too old, too new, exact match, backward-compatible range
 - [x] API endpoint tests: `httptest.NewRecorder()` for all routes (status codes, content types, RFC 7807 errors)
@@ -165,22 +167,22 @@
 - [x] GitHub Dependabot: enable automated dependency vulnerability alerts
 - [ ] GitHub Insights: establish baseline tracking cadence (weekly traffic review)
 - [ ] Release download tracking: GoReleaser generates checksums, GitHub Releases API provides download counts
-- [ ] Docker image pull count tracking: publish to GitHub Container Registry (GHCR) or Docker Hub
+- [x] Docker image pull count tracking: publish to GitHub Container Registry (GHCR) or Docker Hub
 - [ ] README badges: CI build, coverage, Go Report Card, Go version, license, latest release, Docker pulls (see Success Metrics)
 
 #### Community & Launch Readiness
 - [x] CONTRIBUTING.md: development setup, code style, PR process, testing expectations, CLA explanation
 - [x] Pull request template (`.github/pull_request_template.md`) with checklist (tests, lint, description)
-- [ ] First tagged release: `v0.1.0-alpha` with pre-built binaries (GoReleaser) and GitHub Release notes
+- [x] First tagged release: `v0.1.0-alpha` with pre-built binaries (GoReleaser) and GitHub Release notes
 - [x] Dockerfile: multi-stage build (builder + distroless/alpine runtime), multi-arch (`linux/amd64`, `linux/arm64`)
 - [x] docker-compose.yml: one-command deployment matching the spec in Deployment section
-- [ ] README: "Why SubNetree?" section -- value proposition, feature comparison table (discovery + monitoring + remote access + vault + IoT in one tool), clear differentiation from Zabbix/LibreNMS/Uptime Kuma
+- [x] README: "Why SubNetree?" section -- value proposition, feature comparison table (discovery + monitoring + remote access + vault + IoT in one tool), clear differentiation from Zabbix/LibreNMS/Uptime Kuma
 - [ ] README: status badges (CI build, Go version, license, latest release, Docker pulls)
 - [x] README: Docker quickstart section (`docker run` one-liner + docker-compose snippet)
 - [ ] README: screenshots/GIF of dashboard (blocked on dashboard implementation -- placeholder with architecture diagram until then)
-- [ ] README: "Current Status" section -- honest about what works today vs. what's planned, links to roadmap
+- [x] README: "Current Status" section -- honest about what works today vs. what's planned, links to roadmap
 - [x] README: clarify licensing wording to "free for personal, home-lab, and non-competing production use"
-- [ ] Seed GitHub Issues: 5–10 issues labeled `good first issue` and `help wanted` (e.g., "add device type icon mapping", "write Prometheus exporter example plugin", "add ARM64 CI build target")
+- [x] Seed GitHub Issues: 5–10 issues labeled `good first issue` and `help wanted` (e.g., "add device type icon mapping", "write Prometheus exporter example plugin", "add ARM64 CI build target")
 - [ ] Seed GitHub Discussions: introductory post, roadmap discussion thread, "plugin ideas" thread, "show your setup" thread
 - [ ] Community channel: create Discord server (or Matrix space) for real-time contributor discussion, linked from README and CONTRIBUTING.md
 - [ ] Blog post / announcement: publish initial announcement on personal blog, r/homelab, r/selfhosted, Hacker News (after v0.1.0-alpha has working dashboard + discovery)
@@ -303,7 +305,7 @@
 - [ ] Benchmark AES-256-GCM envelope encryption libraries in Go
 - [ ] Benchmark Argon2id key derivation across target platforms (cost parameter tuning)
 - [ ] Evaluate memguard for in-memory secret protection (Go compatibility, platform support)
-- [ ] Research LLM provider SDKs: OpenAI Go client, Anthropic SDK, Ollama local API
+- [x] Research LLM provider SDKs: OpenAI Go client, Anthropic SDK, Ollama local API (Ollama provider shipped in v0.1.0-alpha; OpenAI/Anthropic deferred)
 - [ ] Evaluate data anonymization approaches for LLM context (PII stripping, metric-only summaries)
 
 - [ ] Gateway: SSH-in-browser via xterm.js


### PR DESCRIPTION
## Summary
- Check off 8 completed roadmap items that were still marked as pending (backup/restore, panic recovery, GHCR publishing, v0.1.0-alpha release, README sections, good-first-issues, LLM SDK research)
- Add Webhook and LLM modules to README modules table, architecture diagram, project structure, and architecture overview
- Fix aspirational mDNS/SNMP/UPnP claims in README to clarify these are Phase 2 planned features
- Add CI build and release version badges to README
- Add v0.1.0-alpha shipped status note to Phase 1 roadmap header
- Add LLM "What Works Today" bullet and "Coming Next" entry

## Test plan
- [ ] Markdown renders correctly on GitHub (badges, tables, code blocks)
- [ ] CI passes (no code changes, docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)