### PR TITLE
feat(insight): add natural language query processor

### DIFF
--- a/internal/insight/nlquery.go
+++ b/internal/insight/nlquery.go
@@ -1,0 +1,150 @@
+package insight
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/HerbHall/subnetree/pkg/analytics"
+	"github.com/HerbHall/subnetree/pkg/llm"
+	"github.com/HerbHall/subnetree/pkg/plugin"
+	"github.com/HerbHall/subnetree/pkg/roles"
+)
+
+// intentParserSystemPrompt instructs the LLM to parse user queries into structured JSON intents.
+const intentParserSystemPrompt = `You are a query parser for a network monitoring system called SubNetree. Parse the user's natural language question into a structured JSON intent.
+
+Available intent types:
+- "list_anomalies": Show detected anomalies. Optional "device_id" to filter by device, optional "limit" (default 50).
+- "list_baselines": Show learned baselines for a device. Requires "device_id".
+- "list_forecasts": Show capacity forecasts for a device. Requires "device_id".
+- "list_correlations": Show active alert correlation groups. No parameters needed.
+- "list_devices": Show all discovered network devices. No parameters needed.
+- "device_status": Show comprehensive status for a specific device including anomalies, baselines, and forecasts. Requires "device_id".
+
+Output format — return ONLY valid JSON, no explanation:
+{"type":"<intent_type>","device_id":"<id_if_applicable>","limit":<number_if_applicable>}
+
+Examples:
+- "show me recent anomalies" → {"type":"list_anomalies","limit":10}
+- "any anomalies on router-01?" → {"type":"list_anomalies","device_id":"router-01"}
+- "what devices are on the network?" → {"type":"list_devices"}
+- "status of web-server-01" → {"type":"device_status","device_id":"web-server-01"}
+- "forecasts for db-primary" → {"type":"list_forecasts","device_id":"db-primary"}
+- "are there correlated alerts?" → {"type":"list_correlations"}
+- "baselines for switch-core" → {"type":"list_baselines","device_id":"switch-core"}`
+
+// responseFormatterTemplate is used for the second LLM call that converts structured data
+// into a natural language answer.
+const responseFormatterTemplate = `You are answering a user's question about their network monitoring system (SubNetree).
+
+User question: %s
+Query type: %s
+Data (JSON):
+%s
+
+Provide a clear, concise natural language answer based on the data above. If the data is empty or contains no items, say so politely. Focus on actionable insights rather than repeating raw numbers. Keep the response under 200 words.`
+
+// nlQueryProcessor handles natural language query translation and execution.
+type nlQueryProcessor struct {
+	llmProvider llm.Provider
+	store       *InsightStore
+	plugins     plugin.PluginResolver
+}
+
+// newNLQueryProcessor creates a processor by resolving the LLM plugin.
+// Returns nil if no LLM provider is available.
+func newNLQueryProcessor(plugins plugin.PluginResolver, store *InsightStore) *nlQueryProcessor {
+	if plugins == nil {
+		return nil
+	}
+
+	providers := plugins.ResolveByRole(roles.RoleLLM)
+	if len(providers) == 0 {
+		return nil
+	}
+
+	llmPlugin, ok := providers[0].(roles.LLMProvider)
+	if !ok {
+		return nil
+	}
+
+	return &nlQueryProcessor{
+		llmProvider: llmPlugin.Provider(),
+		store:       store,
+		plugins:     plugins,
+	}
+}
+
+// Process executes a natural language query through a two-phase LLM pipeline:
+// 1. Parse the user's question into a structured intent (low temperature).
+// 2. Execute the intent against the store/plugins.
+// 3. Format the results into a natural language answer (moderate temperature).
+func (p *nlQueryProcessor) Process(ctx context.Context, query string) (*analytics.NLQueryResponse, error) {
+	intent, model, err := p.parseIntent(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("parse intent: %w", err)
+	}
+
+	structured, err := intent.execute(ctx, p.store, p.plugins)
+	if err != nil {
+		return nil, fmt.Errorf("execute intent: %w", err)
+	}
+
+	answer, err := p.formatResponse(ctx, query, intent, structured)
+	if err != nil {
+		return nil, fmt.Errorf("format response: %w", err)
+	}
+
+	return &analytics.NLQueryResponse{
+		Query:      query,
+		Answer:     answer,
+		Structured: structured,
+		Model:      model,
+	}, nil
+}
+
+// parseIntent sends the user query to the LLM with a system prompt that instructs it
+// to return a JSON intent object.
+func (p *nlQueryProcessor) parseIntent(ctx context.Context, query string) (*queryIntent, string, error) {
+	messages := []llm.Message{
+		{Role: llm.RoleSystem, Content: intentParserSystemPrompt},
+		{Role: llm.RoleUser, Content: query},
+	}
+
+	resp, err := p.llmProvider.Chat(ctx, messages,
+		llm.WithTemperature(0.1),
+		llm.WithMaxTokens(256),
+	)
+	if err != nil {
+		return nil, "", err
+	}
+
+	var intent queryIntent
+	if err := json.Unmarshal([]byte(resp.Content), &intent); err != nil {
+		return nil, "", fmt.Errorf("LLM returned invalid JSON: %w", err)
+	}
+
+	return &intent, resp.Model, nil
+}
+
+// formatResponse sends a second LLM call to convert structured query results
+// into a natural language answer.
+func (p *nlQueryProcessor) formatResponse(ctx context.Context, query string, intent *queryIntent, data any) (string, error) {
+	dataJSON, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		dataJSON = []byte("[]")
+	}
+
+	prompt := fmt.Sprintf(responseFormatterTemplate, query, intent.Type, string(dataJSON))
+
+	resp, err := p.llmProvider.Generate(ctx, prompt,
+		llm.WithTemperature(0.7),
+		llm.WithMaxTokens(1024),
+	)
+	if err != nil {
+		return "", err
+	}
+
+	return resp.Content, nil
+}

--- a/internal/insight/nlquery_intent.go
+++ b/internal/insight/nlquery_intent.go
@@ -1,0 +1,177 @@
+package insight
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/HerbHall/subnetree/pkg/analytics"
+	"github.com/HerbHall/subnetree/pkg/models"
+	"github.com/HerbHall/subnetree/pkg/plugin"
+	"github.com/HerbHall/subnetree/pkg/roles"
+)
+
+// Supported intent types for the NL query parser.
+const (
+	IntentListAnomalies    = "list_anomalies"
+	IntentListBaselines    = "list_baselines"
+	IntentListForecasts    = "list_forecasts"
+	IntentListCorrelations = "list_correlations"
+	IntentListDevices      = "list_devices"
+	IntentDeviceStatus     = "device_status"
+)
+
+// queryIntent represents the structured output from the LLM intent parser.
+type queryIntent struct {
+	Type     string `json:"type"`
+	DeviceID string `json:"device_id,omitempty"`
+	Limit    int    `json:"limit,omitempty"`
+}
+
+// deviceStatusResult is the composite response for a device_status intent.
+type deviceStatusResult struct {
+	Device    *models.Device       `json:"device,omitempty"`
+	Anomalies []analytics.Anomaly  `json:"anomalies"`
+	Baselines []analytics.Baseline `json:"baselines"`
+	Forecasts []analytics.Forecast `json:"forecasts"`
+}
+
+// execute dispatches the intent to the appropriate handler.
+func (i *queryIntent) execute(ctx context.Context, store *InsightStore, plugins plugin.PluginResolver) (any, error) {
+	switch i.Type {
+	case IntentListAnomalies:
+		return i.executeListAnomalies(ctx, store)
+	case IntentListBaselines:
+		return i.executeListBaselines(ctx, store)
+	case IntentListForecasts:
+		return i.executeListForecasts(ctx, store)
+	case IntentListCorrelations:
+		return i.executeListCorrelations(ctx, store)
+	case IntentListDevices:
+		return i.executeListDevices(ctx, plugins)
+	case IntentDeviceStatus:
+		return i.executeDeviceStatus(ctx, store, plugins)
+	default:
+		return nil, fmt.Errorf("unsupported intent type: %s", i.Type)
+	}
+}
+
+func (i *queryIntent) executeListAnomalies(ctx context.Context, store *InsightStore) ([]analytics.Anomaly, error) {
+	if store == nil {
+		return []analytics.Anomaly{}, nil
+	}
+	limit := i.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+	anomalies, err := store.ListAnomalies(ctx, i.DeviceID, limit)
+	if err != nil {
+		return nil, err
+	}
+	if anomalies == nil {
+		return []analytics.Anomaly{}, nil
+	}
+	return anomalies, nil
+}
+
+func (i *queryIntent) executeListBaselines(ctx context.Context, store *InsightStore) ([]analytics.Baseline, error) {
+	if store == nil {
+		return []analytics.Baseline{}, nil
+	}
+	baselines, err := store.GetBaselines(ctx, i.DeviceID)
+	if err != nil {
+		return nil, err
+	}
+	if baselines == nil {
+		return []analytics.Baseline{}, nil
+	}
+	return baselines, nil
+}
+
+func (i *queryIntent) executeListForecasts(ctx context.Context, store *InsightStore) ([]analytics.Forecast, error) {
+	if store == nil {
+		return []analytics.Forecast{}, nil
+	}
+	forecasts, err := store.GetForecasts(ctx, i.DeviceID)
+	if err != nil {
+		return nil, err
+	}
+	if forecasts == nil {
+		return []analytics.Forecast{}, nil
+	}
+	return forecasts, nil
+}
+
+func (i *queryIntent) executeListCorrelations(ctx context.Context, store *InsightStore) ([]analytics.AlertGroup, error) {
+	if store == nil {
+		return []analytics.AlertGroup{}, nil
+	}
+	groups, err := store.ListActiveCorrelations(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if groups == nil {
+		return []analytics.AlertGroup{}, nil
+	}
+	return groups, nil
+}
+
+func (i *queryIntent) executeListDevices(ctx context.Context, plugins plugin.PluginResolver) ([]models.Device, error) {
+	if plugins == nil {
+		return []models.Device{}, nil
+	}
+	discoveryPlugins := plugins.ResolveByRole(roles.RoleDiscovery)
+	if len(discoveryPlugins) == 0 {
+		return []models.Device{}, nil
+	}
+	dp, ok := discoveryPlugins[0].(roles.DiscoveryProvider)
+	if !ok {
+		return []models.Device{}, nil
+	}
+	devices, err := dp.Devices(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if devices == nil {
+		return []models.Device{}, nil
+	}
+	return devices, nil
+}
+
+func (i *queryIntent) executeDeviceStatus(ctx context.Context, store *InsightStore, plugins plugin.PluginResolver) (*deviceStatusResult, error) {
+	if i.DeviceID == "" {
+		return nil, fmt.Errorf("device_id required for device_status intent")
+	}
+
+	result := &deviceStatusResult{
+		Anomalies: []analytics.Anomaly{},
+		Baselines: []analytics.Baseline{},
+		Forecasts: []analytics.Forecast{},
+	}
+
+	// Resolve device info from Discovery plugin.
+	if plugins != nil {
+		discoveryPlugins := plugins.ResolveByRole(roles.RoleDiscovery)
+		if len(discoveryPlugins) > 0 {
+			if dp, ok := discoveryPlugins[0].(roles.DiscoveryProvider); ok {
+				if device, err := dp.DeviceByID(ctx, i.DeviceID); err == nil && device != nil {
+					result.Device = device
+				}
+			}
+		}
+	}
+
+	// Gather analytics data from store.
+	if store != nil {
+		if anomalies, err := store.ListAnomalies(ctx, i.DeviceID, 10); err == nil && anomalies != nil {
+			result.Anomalies = anomalies
+		}
+		if baselines, err := store.GetBaselines(ctx, i.DeviceID); err == nil && baselines != nil {
+			result.Baselines = baselines
+		}
+		if forecasts, err := store.GetForecasts(ctx, i.DeviceID); err == nil && forecasts != nil {
+			result.Forecasts = forecasts
+		}
+	}
+
+	return result, nil
+}

--- a/internal/insight/nlquery_test.go
+++ b/internal/insight/nlquery_test.go
@@ -1,0 +1,445 @@
+package insight
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/HerbHall/subnetree/pkg/analytics"
+	"github.com/HerbHall/subnetree/pkg/llm"
+	"github.com/HerbHall/subnetree/pkg/models"
+	"github.com/HerbHall/subnetree/pkg/plugin"
+	"github.com/HerbHall/subnetree/pkg/roles"
+)
+
+// -- Mock implementations --
+
+// mockLLMProvider implements llm.Provider for testing.
+type mockLLMProvider struct {
+	chatFunc     func(ctx context.Context, messages []llm.Message, opts ...llm.CallOption) (*llm.Response, error)
+	generateFunc func(ctx context.Context, prompt string, opts ...llm.CallOption) (*llm.Response, error)
+}
+
+func (m *mockLLMProvider) Generate(ctx context.Context, prompt string, opts ...llm.CallOption) (*llm.Response, error) {
+	if m.generateFunc != nil {
+		return m.generateFunc(ctx, prompt, opts...)
+	}
+	return &llm.Response{Content: "mock answer", Model: "mock-model", Done: true}, nil
+}
+
+func (m *mockLLMProvider) Chat(ctx context.Context, messages []llm.Message, opts ...llm.CallOption) (*llm.Response, error) {
+	if m.chatFunc != nil {
+		return m.chatFunc(ctx, messages, opts...)
+	}
+	return &llm.Response{Content: `{"type":"list_anomalies"}`, Model: "mock-model", Done: true}, nil
+}
+
+// mockLLMPlugin implements plugin.Plugin + roles.LLMProvider.
+type mockLLMPlugin struct {
+	provider llm.Provider
+}
+
+func (m *mockLLMPlugin) Info() plugin.PluginInfo {
+	return plugin.PluginInfo{Name: "mock-llm", Roles: []string{roles.RoleLLM}}
+}
+
+func (m *mockLLMPlugin) Init(_ context.Context, _ plugin.Dependencies) error { return nil }
+func (m *mockLLMPlugin) Start(_ context.Context) error                       { return nil }
+func (m *mockLLMPlugin) Stop(_ context.Context) error                        { return nil }
+func (m *mockLLMPlugin) Provider() llm.Provider                              { return m.provider }
+
+// mockPluginResolver implements plugin.PluginResolver.
+type mockPluginResolver struct {
+	byRole map[string][]plugin.Plugin
+}
+
+func (m *mockPluginResolver) Resolve(_ string) (plugin.Plugin, bool) { return nil, false }
+
+func (m *mockPluginResolver) ResolveByRole(role string) []plugin.Plugin {
+	if m.byRole == nil {
+		return nil
+	}
+	return m.byRole[role]
+}
+
+// mockDiscoveryPlugin implements plugin.Plugin + roles.DiscoveryProvider.
+type mockDiscoveryPlugin struct {
+	devices []models.Device
+}
+
+func (m *mockDiscoveryPlugin) Info() plugin.PluginInfo {
+	return plugin.PluginInfo{Name: "mock-discovery", Roles: []string{roles.RoleDiscovery}}
+}
+
+func (m *mockDiscoveryPlugin) Init(_ context.Context, _ plugin.Dependencies) error { return nil }
+func (m *mockDiscoveryPlugin) Start(_ context.Context) error                       { return nil }
+func (m *mockDiscoveryPlugin) Stop(_ context.Context) error                        { return nil }
+
+func (m *mockDiscoveryPlugin) Devices(_ context.Context) ([]models.Device, error) {
+	return m.devices, nil
+}
+
+func (m *mockDiscoveryPlugin) DeviceByID(_ context.Context, id string) (*models.Device, error) {
+	for i := range m.devices {
+		if m.devices[i].ID == id {
+			return &m.devices[i], nil
+		}
+	}
+	return nil, nil
+}
+
+// -- Constructor tests --
+
+func TestNewNLQueryProcessor_NilPlugins(t *testing.T) {
+	proc := newNLQueryProcessor(nil, nil)
+	if proc != nil {
+		t.Fatal("expected nil processor when plugins is nil")
+	}
+}
+
+func TestNewNLQueryProcessor_NoLLMProvider(t *testing.T) {
+	resolver := &mockPluginResolver{byRole: map[string][]plugin.Plugin{}}
+	proc := newNLQueryProcessor(resolver, nil)
+	if proc != nil {
+		t.Fatal("expected nil processor when no LLM provider registered")
+	}
+}
+
+func TestNewNLQueryProcessor_InvalidLLMType(t *testing.T) {
+	// Register a plugin that doesn't implement roles.LLMProvider.
+	resolver := &mockPluginResolver{
+		byRole: map[string][]plugin.Plugin{
+			roles.RoleLLM: {&mockDiscoveryPlugin{}},
+		},
+	}
+	proc := newNLQueryProcessor(resolver, nil)
+	if proc != nil {
+		t.Fatal("expected nil processor when LLM plugin has wrong type")
+	}
+}
+
+func TestNewNLQueryProcessor_Success(t *testing.T) {
+	llmPlugin := &mockLLMPlugin{provider: &mockLLMProvider{}}
+	resolver := &mockPluginResolver{
+		byRole: map[string][]plugin.Plugin{
+			roles.RoleLLM: {llmPlugin},
+		},
+	}
+	proc := newNLQueryProcessor(resolver, nil)
+	if proc == nil {
+		t.Fatal("expected non-nil processor")
+	}
+	if proc.llmProvider == nil {
+		t.Fatal("expected llmProvider to be set")
+	}
+}
+
+// -- Process tests --
+
+func TestProcess_HappyPath(t *testing.T) {
+	s := testStore(t)
+
+	// Seed an anomaly.
+	ctx := context.Background()
+	_ = s.InsertAnomaly(ctx, &analytics.Anomaly{
+		ID: "a1", DeviceID: "dev-1", MetricName: "cpu",
+		Severity: "warning", Type: "zscore", Value: 95, Expected: 50,
+		DetectedAt: time.Now(), Description: "high cpu",
+	})
+
+	mockLLM := &mockLLMProvider{
+		chatFunc: func(_ context.Context, _ []llm.Message, _ ...llm.CallOption) (*llm.Response, error) {
+			return &llm.Response{
+				Content: `{"type":"list_anomalies","limit":10}`,
+				Model:   "test-model",
+				Done:    true,
+			}, nil
+		},
+		generateFunc: func(_ context.Context, _ string, _ ...llm.CallOption) (*llm.Response, error) {
+			return &llm.Response{
+				Content: "Found 1 anomaly on dev-1.",
+				Model:   "test-model",
+				Done:    true,
+			}, nil
+		},
+	}
+
+	llmPlugin := &mockLLMPlugin{provider: mockLLM}
+	resolver := &mockPluginResolver{
+		byRole: map[string][]plugin.Plugin{
+			roles.RoleLLM: {llmPlugin},
+		},
+	}
+
+	proc := newNLQueryProcessor(resolver, s)
+	resp, err := proc.Process(ctx, "show anomalies")
+	if err != nil {
+		t.Fatalf("Process() error: %v", err)
+	}
+
+	if resp.Query != "show anomalies" {
+		t.Errorf("Query = %q, want %q", resp.Query, "show anomalies")
+	}
+	if resp.Model != "test-model" {
+		t.Errorf("Model = %q, want %q", resp.Model, "test-model")
+	}
+	if resp.Answer != "Found 1 anomaly on dev-1." {
+		t.Errorf("Answer = %q", resp.Answer)
+	}
+	if resp.Structured == nil {
+		t.Error("Structured should not be nil")
+	}
+}
+
+func TestProcess_ParseIntentError(t *testing.T) {
+	mockLLM := &mockLLMProvider{
+		chatFunc: func(_ context.Context, _ []llm.Message, _ ...llm.CallOption) (*llm.Response, error) {
+			return &llm.Response{Content: "not valid json", Model: "m", Done: true}, nil
+		},
+	}
+
+	llmPlugin := &mockLLMPlugin{provider: mockLLM}
+	resolver := &mockPluginResolver{
+		byRole: map[string][]plugin.Plugin{roles.RoleLLM: {llmPlugin}},
+	}
+
+	proc := newNLQueryProcessor(resolver, nil)
+	_, err := proc.Process(context.Background(), "hello")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON response")
+	}
+}
+
+func TestProcess_LLMChatError(t *testing.T) {
+	mockLLM := &mockLLMProvider{
+		chatFunc: func(_ context.Context, _ []llm.Message, _ ...llm.CallOption) (*llm.Response, error) {
+			return nil, fmt.Errorf("connection refused")
+		},
+	}
+
+	llmPlugin := &mockLLMPlugin{provider: mockLLM}
+	resolver := &mockPluginResolver{
+		byRole: map[string][]plugin.Plugin{roles.RoleLLM: {llmPlugin}},
+	}
+
+	proc := newNLQueryProcessor(resolver, nil)
+	_, err := proc.Process(context.Background(), "hello")
+	if err == nil {
+		t.Fatal("expected error when Chat() fails")
+	}
+}
+
+func TestProcess_FormatResponseError(t *testing.T) {
+	mockLLM := &mockLLMProvider{
+		chatFunc: func(_ context.Context, _ []llm.Message, _ ...llm.CallOption) (*llm.Response, error) {
+			return &llm.Response{Content: `{"type":"list_anomalies"}`, Model: "m", Done: true}, nil
+		},
+		generateFunc: func(_ context.Context, _ string, _ ...llm.CallOption) (*llm.Response, error) {
+			return nil, fmt.Errorf("model overloaded")
+		},
+	}
+
+	llmPlugin := &mockLLMPlugin{provider: mockLLM}
+	resolver := &mockPluginResolver{
+		byRole: map[string][]plugin.Plugin{roles.RoleLLM: {llmPlugin}},
+	}
+
+	proc := newNLQueryProcessor(resolver, nil)
+	_, err := proc.Process(context.Background(), "anomalies")
+	if err == nil {
+		t.Fatal("expected error when Generate() fails")
+	}
+}
+
+// -- Intent execution tests --
+
+func TestExecuteListAnomalies_WithStore(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+	_ = s.InsertAnomaly(ctx, &analytics.Anomaly{
+		ID: "a1", DeviceID: "dev-1", MetricName: "cpu",
+		Severity: "warning", Type: "zscore", Value: 95, Expected: 50,
+		DetectedAt: time.Now(), Description: "test",
+	})
+
+	intent := &queryIntent{Type: IntentListAnomalies, Limit: 10}
+	result, err := intent.execute(ctx, s, nil)
+	if err != nil {
+		t.Fatalf("execute error: %v", err)
+	}
+	anomalies, ok := result.([]analytics.Anomaly)
+	if !ok {
+		t.Fatalf("expected []analytics.Anomaly, got %T", result)
+	}
+	if len(anomalies) != 1 {
+		t.Errorf("got %d anomalies, want 1", len(anomalies))
+	}
+}
+
+func TestExecuteListAnomalies_NilStore(t *testing.T) {
+	intent := &queryIntent{Type: IntentListAnomalies}
+	result, err := intent.execute(context.Background(), nil, nil)
+	if err != nil {
+		t.Fatalf("execute error: %v", err)
+	}
+	anomalies, ok := result.([]analytics.Anomaly)
+	if !ok {
+		t.Fatalf("expected []analytics.Anomaly, got %T", result)
+	}
+	if len(anomalies) != 0 {
+		t.Errorf("expected empty slice, got %d", len(anomalies))
+	}
+}
+
+func TestExecuteListDevices_WithDiscovery(t *testing.T) {
+	discovery := &mockDiscoveryPlugin{
+		devices: []models.Device{
+			{ID: "dev-1", Hostname: "web-01", Status: models.DeviceStatusOnline},
+			{ID: "dev-2", Hostname: "db-01", Status: models.DeviceStatusOnline},
+		},
+	}
+	resolver := &mockPluginResolver{
+		byRole: map[string][]plugin.Plugin{
+			roles.RoleDiscovery: {discovery},
+		},
+	}
+
+	intent := &queryIntent{Type: IntentListDevices}
+	result, err := intent.execute(context.Background(), nil, resolver)
+	if err != nil {
+		t.Fatalf("execute error: %v", err)
+	}
+	devices, ok := result.([]models.Device)
+	if !ok {
+		t.Fatalf("expected []models.Device, got %T", result)
+	}
+	if len(devices) != 2 {
+		t.Errorf("got %d devices, want 2", len(devices))
+	}
+}
+
+func TestExecuteListDevices_NilPlugins(t *testing.T) {
+	intent := &queryIntent{Type: IntentListDevices}
+	result, err := intent.execute(context.Background(), nil, nil)
+	if err != nil {
+		t.Fatalf("execute error: %v", err)
+	}
+	devices, ok := result.([]models.Device)
+	if !ok {
+		t.Fatalf("expected []models.Device, got %T", result)
+	}
+	if len(devices) != 0 {
+		t.Errorf("expected empty slice, got %d", len(devices))
+	}
+}
+
+func TestExecuteDeviceStatus(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	// Seed data for dev-1.
+	_ = s.InsertAnomaly(ctx, &analytics.Anomaly{
+		ID: "a1", DeviceID: "dev-1", MetricName: "cpu",
+		Severity: "warning", Type: "zscore", Value: 95, Expected: 50,
+		DetectedAt: time.Now(), Description: "high cpu",
+	})
+	_ = s.UpsertBaseline(ctx, &analytics.Baseline{
+		DeviceID: "dev-1", MetricName: "cpu", Algorithm: "ewma",
+		Mean: 50, StdDev: 5, Samples: 200, Stable: true, UpdatedAt: time.Now(),
+	})
+
+	discovery := &mockDiscoveryPlugin{
+		devices: []models.Device{
+			{ID: "dev-1", Hostname: "web-01", Status: models.DeviceStatusOnline},
+		},
+	}
+	resolver := &mockPluginResolver{
+		byRole: map[string][]plugin.Plugin{
+			roles.RoleDiscovery: {discovery},
+		},
+	}
+
+	intent := &queryIntent{Type: IntentDeviceStatus, DeviceID: "dev-1"}
+	result, err := intent.execute(ctx, s, resolver)
+	if err != nil {
+		t.Fatalf("execute error: %v", err)
+	}
+	status, ok := result.(*deviceStatusResult)
+	if !ok {
+		t.Fatalf("expected *deviceStatusResult, got %T", result)
+	}
+	if status.Device == nil {
+		t.Error("expected Device to be set")
+	}
+	if status.Device != nil && status.Device.Hostname != "web-01" {
+		t.Errorf("Device.Hostname = %q, want %q", status.Device.Hostname, "web-01")
+	}
+	if len(status.Anomalies) != 1 {
+		t.Errorf("got %d anomalies, want 1", len(status.Anomalies))
+	}
+	if len(status.Baselines) != 1 {
+		t.Errorf("got %d baselines, want 1", len(status.Baselines))
+	}
+}
+
+func TestExecuteDeviceStatus_MissingDeviceID(t *testing.T) {
+	intent := &queryIntent{Type: IntentDeviceStatus}
+	_, err := intent.execute(context.Background(), nil, nil)
+	if err == nil {
+		t.Fatal("expected error for missing device_id")
+	}
+}
+
+func TestExecuteUnsupportedIntent(t *testing.T) {
+	intent := &queryIntent{Type: "unknown_type"}
+	_, err := intent.execute(context.Background(), nil, nil)
+	if err == nil {
+		t.Fatal("expected error for unsupported intent type")
+	}
+}
+
+func TestExecuteListBaselines_NilStore(t *testing.T) {
+	intent := &queryIntent{Type: IntentListBaselines, DeviceID: "dev-1"}
+	result, err := intent.execute(context.Background(), nil, nil)
+	if err != nil {
+		t.Fatalf("execute error: %v", err)
+	}
+	baselines, ok := result.([]analytics.Baseline)
+	if !ok {
+		t.Fatalf("expected []analytics.Baseline, got %T", result)
+	}
+	if len(baselines) != 0 {
+		t.Errorf("expected empty, got %d", len(baselines))
+	}
+}
+
+func TestExecuteListForecasts_NilStore(t *testing.T) {
+	intent := &queryIntent{Type: IntentListForecasts, DeviceID: "dev-1"}
+	result, err := intent.execute(context.Background(), nil, nil)
+	if err != nil {
+		t.Fatalf("execute error: %v", err)
+	}
+	forecasts, ok := result.([]analytics.Forecast)
+	if !ok {
+		t.Fatalf("expected []analytics.Forecast, got %T", result)
+	}
+	if len(forecasts) != 0 {
+		t.Errorf("expected empty, got %d", len(forecasts))
+	}
+}
+
+func TestExecuteListCorrelations_NilStore(t *testing.T) {
+	intent := &queryIntent{Type: IntentListCorrelations}
+	result, err := intent.execute(context.Background(), nil, nil)
+	if err != nil {
+		t.Fatalf("execute error: %v", err)
+	}
+	groups, ok := result.([]analytics.AlertGroup)
+	if !ok {
+		t.Fatalf("expected []analytics.AlertGroup, got %T", result)
+	}
+	if len(groups) != 0 {
+		t.Errorf("expected empty, got %d", len(groups))
+	}
+}


### PR DESCRIPTION
## Summary

- Wires the `POST /api/v1/insight/query` endpoint to a two-phase LLM pipeline that parses user queries into structured intents and formats results as natural language
- Supports 6 intent types: `list_anomalies`, `list_baselines`, `list_forecasts`, `list_correlations`, `list_devices`, `device_status`
- Gracefully degrades: 503 when no LLM provider, empty arrays when store/discovery unavailable

Completes Stage 6 of the Insight plugin (PRs #104 + #105 + this).

## Test plan

- [x] 16 new tests covering constructor, process pipeline, all intent types, and error paths
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./internal/insight/... -count=1` -- all pass
- [x] Swagger spec unchanged (endpoint annotations already existed)
- [ ] All 12 CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)