### PR TITLE
feat(recon): add hostname resolution in scan progress

### DIFF
--- a/internal/recon/scanner_test.go
+++ b/internal/recon/scanner_test.go
@@ -307,6 +307,24 @@ func TestScanOrchestrator_InvalidSubnet(t *testing.T) {
 	}
 }
 
+func TestScanOrchestrator_ResolveHostname(t *testing.T) {
+	orch, _, _ := setupOrchestrator(t,
+		&mockPingScanner{}, &mockARPReader{}, &mockOUI{table: map[string]string{}})
+
+	// Private IP with no reverse DNS entry returns empty string.
+	got := orch.resolveHostname("192.0.2.1") // TEST-NET-1, guaranteed no PTR record
+	if got != "" {
+		t.Errorf("resolveHostname(192.0.2.1) = %q, want empty", got)
+	}
+
+	// Localhost should resolve (platform-dependent, so just verify no panic
+	// and the trailing dot is trimmed).
+	name := orch.resolveHostname("127.0.0.1")
+	if name != "" && name[len(name)-1] == '.' {
+		t.Errorf("resolveHostname(127.0.0.1) = %q, trailing dot not trimmed", name)
+	}
+}
+
 func TestExpandSubnet(t *testing.T) {
 	tests := []struct {
 		cidr      string


### PR DESCRIPTION
## Summary
- Adds reverse DNS lookup during scan enrichment phase (alongside ARP/OUI)
- Uses `net.DefaultResolver.LookupAddr` with 500ms timeout per host
- Populates `Device.Hostname` field which the frontend already displays
- Gracefully falls back to empty string if DNS lookup fails or times out

## Changes
- `internal/recon/scanner.go`: Added `resolveHostname()` method and wired into device creation
- `internal/recon/scanner_test.go`: Added `TestScanOrchestrator_ResolveHostname` test

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] All recon tests pass (5/5)
- [ ] CI passes

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)