### PR TITLE
chore: add markdownlint config and fix violations

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,18 @@
+{
+  "default": true,
+  "MD003": { "style": "atx" },
+  "MD004": { "style": "dash" },
+  "MD007": { "indent": 2 },
+  "MD013": false,
+  "MD024": { "siblings_only": true },
+  "MD025": { "front_matter_title": "" },
+  "MD029": { "style": "ordered" },
+  "MD033": { "allowed_elements": ["br", "details", "summary", "img", "a", "sub", "sup"] },
+  "MD035": { "style": "---" },
+  "MD040": true,
+  "MD041": true,
+  "MD046": { "style": "fenced" },
+  "MD048": { "style": "backtick" },
+  "MD049": { "style": "asterisk" },
+  "MD050": { "style": "asterisk" }
+}

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -16,18 +16,18 @@ diverse, inclusive, and healthy community.
 
 Examples of behavior that contributes to a positive environment:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
 
 Examples of unacceptable behavior:
 
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a professional setting
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
 
 ## Enforcement Responsibilities
 
@@ -52,4 +52,4 @@ All complaints will be reviewed and investigated promptly and fairly.
 
 This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/),
 version 2.1, available at
-https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+[Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ make lint
 
 ### Project Structure
 
-```
+```text
 cmd/            Entry points (server, agent)
 internal/       Private packages (plugins, server, services)
 pkg/            Public packages (plugin SDK, models)
@@ -77,7 +77,7 @@ configs/        Example configuration files
 
 We use [Conventional Commits](https://www.conventionalcommits.org/):
 
-```
+```text
 feat: add device type icon mapping
 fix: prevent duplicate scan entries on network change
 refactor: extract plugin lifecycle into separate package

--- a/SUPPORTERS.md
+++ b/SUPPORTERS.md
@@ -3,6 +3,7 @@
 SubNetree is free for personal, home-lab, and non-competing production use forever. These individuals and organizations have chosen to voluntarily support the project's development. Their generosity helps fund continued development, infrastructure, and community growth.
 
 **Want to support SubNetree?**
+
 - [GitHub Sponsors](https://github.com/sponsors/HerbHall)
 - [Ko-fi](https://ko-fi.com/herbhall)
 - [Buy Me a Coffee](https://buymeacoffee.com/herbhall)

--- a/docs/requirements/.markdownlint.json
+++ b/docs/requirements/.markdownlint.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../.markdownlint.json",
+  "MD041": false,
+  "MD025": false
+}


### PR DESCRIPTION
## Summary

- Add `.markdownlint.json` project config enforcing existing conventions (ATX headings, dash lists, backtick fences, asterisk emphasis, MD013 disabled)
- Add per-directory override for `docs/requirements/` section files (disables MD041/MD025 since they start with `##` by design)
- Fix violations across 3 files:
  - `CODE_OF_CONDUCT.md`: `*` list markers to `-` (MD004), bare URL wrapped in link syntax (MD034)
  - `CONTRIBUTING.md`: Added `text` language to 2 fenced code blocks (MD040)
  - `SUPPORTERS.md`: Added blank line before list (MD032)

## Test plan

- [ ] Install VS Code markdownlint extension (`DavidAnson.vscode-markdownlint`)
- [ ] Open any root `.md` file -- should show no warnings
- [ ] Open `docs/requirements/*.md` -- MD041/MD025 should not fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)