### PR TITLE
docs: add Tailscale deployment and Funnel/Serve guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,12 @@ subnetree backup --data-dir /data --output my-backup.tar.gz
 subnetree restore --input my-backup.tar.gz --data-dir /data --force
 ```
 
+## Guides
+
+- [Development Setup](docs/guides/development-setup.md) -- local dev environment
+- [Tailscale Deployment](docs/guides/tailscale-deployment.md) -- running SubNetree + Scout over Tailscale
+- [Tailscale Serve & Funnel](docs/guides/tailscale-funnel.md) -- exposing the dashboard without port forwarding
+
 ## Community
 
 - [GitHub Discussions](https://github.com/HerbHall/subnetree/discussions) -- questions, ideas, and general chat

--- a/docs/guides/tailscale-deployment.md
+++ b/docs/guides/tailscale-deployment.md
@@ -1,0 +1,207 @@
+# Running SubNetree over Tailscale
+
+This guide explains how to run SubNetree and Scout agents across a distributed
+homelab using [Tailscale](https://tailscale.com) as the overlay network.
+
+## Why Tailscale?
+
+Tailscale creates a WireGuard-based mesh VPN (called a "tailnet") between your
+devices. Each device gets a stable `100.x.y.z` address that works regardless of
+NAT, firewalls, or physical location. This makes it ideal for homelabs spread
+across multiple sites -- a NAS at home, a Pi at a parent's house, a VPS in the
+cloud -- all reachable as if they were on the same LAN.
+
+SubNetree benefits from Tailscale in two ways:
+
+1. **The server** becomes reachable from any tailnet device without port
+   forwarding
+2. **Scout agents** on remote nodes can connect back to the server over stable
+   Tailscale IPs
+
+## Prerequisites
+
+- Tailscale installed on every device that needs to communicate
+  ([install guide](https://tailscale.com/download))
+- A Tailscale account (free for personal use, up to 100 devices)
+- SubNetree server binary or Docker image
+- Scout agent binary (optional, for remote host monitoring)
+
+## Network Topology
+
+```mermaid
+graph TD
+    subgraph Tailnet["Tailscale Mesh (100.x.y.z)"]
+        Server["SubNetree Server<br/>100.64.0.1:8080"]
+        Scout1["Scout Agent<br/>100.64.0.2"]
+        Scout2["Scout Agent<br/>100.64.0.3"]
+        Device1["Other Devices<br/>100.64.0.x"]
+    end
+
+    Browser["Browser"] -- "HTTPS via Tailscale" --> Server
+    Scout1 -- "gRPC :9090" --> Server
+    Scout2 -- "gRPC :9090" --> Server
+    Server -- "ICMP / ARP" --> Device1
+```
+
+## Step 1: Install Tailscale on the Server Host
+
+Follow the [Tailscale install guide](https://tailscale.com/download) for your
+OS. After installation:
+
+```bash
+# Authenticate and join your tailnet
+tailscale up
+
+# Verify your Tailscale IP
+tailscale ip -4
+# Example output: 100.64.0.1
+```
+
+Note your server's Tailscale IP -- Scout agents will use this to connect.
+
+## Step 2: Run SubNetree Server
+
+### Option A: Docker (Recommended)
+
+```bash
+docker run -d --name subnetree \
+  --network host \
+  -v subnetree-data:/data \
+  ghcr.io/herbhall/subnetree:latest
+```
+
+Host networking gives SubNetree access to both the Tailscale interface and your
+local LAN for scanning.
+
+### Option B: Binary
+
+```bash
+./subnetree --config subnetree.yaml
+```
+
+With a config that binds to all interfaces:
+
+```yaml
+server:
+  host: "0.0.0.0"
+  port: 8080
+```
+
+Binding to `0.0.0.0` (the default) means SubNetree listens on both the LAN
+interface and the Tailscale interface. To restrict access to Tailscale only,
+bind to your Tailscale IP:
+
+```yaml
+server:
+  host: "100.64.0.1"  # Replace with your Tailscale IP
+  port: 8080
+```
+
+## Step 3: Verify Server Access
+
+From any device on your tailnet:
+
+```bash
+# Replace with your server's Tailscale IP
+curl http://100.64.0.1:8080/api/v1/health
+```
+
+You should see a JSON health response. You can also open
+`http://100.64.0.1:8080` in a browser to access the dashboard.
+
+## Step 4: Install Scout Agents (Optional)
+
+On each remote device you want to monitor:
+
+```bash
+# Install Tailscale (if not already done)
+tailscale up
+
+# Run Scout, pointing at the server's Tailscale IP
+./scout --server 100.64.0.1:9090 --interval 30
+```
+
+Scout uses gRPC with mTLS for secure communication. Over Tailscale, traffic is
+already encrypted by WireGuard, providing defense in depth.
+
+### Docker Scout
+
+```bash
+docker run -d --name scout \
+  --network host \
+  ghcr.io/herbhall/scout:latest \
+  --server 100.64.0.1:9090
+```
+
+## Step 5: Configure Tailscale ACLs (Optional)
+
+By default, Tailscale allows all traffic between devices on your tailnet. For
+tighter security, configure
+[ACLs](https://tailscale.com/kb/1018/acls) to restrict which devices can reach
+SubNetree:
+
+```jsonc
+// Example: Only tagged devices can reach the server
+{
+  "acls": [
+    {
+      "action": "accept",
+      "src": ["tag:homelab"],
+      "dst": ["tag:subnetree-server:8080", "tag:subnetree-server:9090"]
+    }
+  ],
+  "tagOwners": {
+    "tag:homelab": ["autogroup:admin"],
+    "tag:subnetree-server": ["autogroup:admin"]
+  }
+}
+```
+
+Then tag your devices:
+
+```bash
+# On the server
+tailscale up --advertise-tags=tag:subnetree-server
+
+# On monitored devices
+tailscale up --advertise-tags=tag:homelab
+```
+
+## Step 6: Scanning Remote Subnets
+
+SubNetree's Recon module scans the local subnet by default. Devices on remote
+sites behind other Tailscale nodes are not directly scannable unless you set up
+a [subnet router](https://tailscale.com/kb/1019/subnets):
+
+```bash
+# On a device at the remote site, advertise the local subnet
+tailscale up --advertise-routes=192.168.1.0/24
+```
+
+Then approve the route in the Tailscale admin console. SubNetree can then scan
+`192.168.1.0/24` as if it were local.
+
+## Ports Reference
+
+| Port | Protocol | Purpose |
+| --- | --- | --- |
+| 8080 | HTTP | Dashboard and REST API |
+| 9090 | gRPC | Scout agent communication |
+
+## Troubleshooting
+
+**Cannot reach server from remote device** -- Verify both devices are on the
+same tailnet with `tailscale status`. Check that the server's firewall allows
+traffic on ports 8080 and 9090.
+
+**Docker container cannot see Tailscale interface** -- Use `--network host` so
+the container shares the host's network stack (including the Tailscale
+interface).
+
+**Scanning finds only local devices** -- SubNetree scans the local subnet. For
+remote subnets, configure Tailscale subnet routes (see Step 6).
+
+**MagicDNS names not resolving** -- Enable
+[MagicDNS](https://tailscale.com/kb/1081/magicdns) in the Tailscale admin
+console. You can then access SubNetree at
+`http://your-server-hostname:8080` instead of the IP.

--- a/docs/guides/tailscale-funnel.md
+++ b/docs/guides/tailscale-funnel.md
@@ -1,0 +1,212 @@
+# Exposing SubNetree with Tailscale Serve and Funnel
+
+This guide explains how to expose the SubNetree dashboard using Tailscale's
+built-in reverse proxy features, without port forwarding or dynamic DNS.
+
+## Serve vs Funnel vs Port Forwarding
+
+| Feature | Tailscale Serve | Tailscale Funnel | Port Forwarding |
+| --- | --- | --- | --- |
+| **Audience** | Your tailnet only | Public internet | Public internet |
+| **HTTPS** | Automatic (LE cert) | Automatic (LE cert) | Manual |
+| **Auth required** | Tailscale login | None (app handles it) | None |
+| **DNS** | MagicDNS or `*.ts.net` | `*.ts.net` | Manual (DDNS) |
+| **Port forwarding** | Not needed | Not needed | Required |
+| **Setup** | One command | One command | Router config |
+
+**Recommendation:** Use **Serve** for personal access across your tailnet.
+Use **Funnel** only when you need to share the dashboard with someone outside
+your tailnet.
+
+## Prerequisites
+
+- Tailscale v1.52+ installed on the SubNetree server host
+- SubNetree running on `localhost:8080`
+- MagicDNS enabled in your
+  [Tailscale admin console](https://login.tailscale.com/admin/dns) (optional
+  but recommended)
+- For Funnel: HTTPS and Funnel enabled in
+  [access controls](https://login.tailscale.com/admin/acls)
+
+## Tailscale Serve (Private -- Tailnet Only)
+
+Serve exposes a local port to other devices on your tailnet over HTTPS with an
+automatic TLS certificate.
+
+```bash
+# Expose SubNetree's HTTP port on your tailnet
+tailscale serve 8080
+```
+
+This makes SubNetree available at `https://your-hostname.tailnet-name.ts.net`
+for any device on your tailnet.
+
+### Serve with a Custom Port
+
+```bash
+# Expose on a different HTTPS port
+tailscale serve --https 443 8080
+```
+
+### Check Status
+
+```bash
+tailscale serve status
+```
+
+### Stop Serving
+
+```bash
+tailscale serve off
+```
+
+## Tailscale Funnel (Public -- Internet)
+
+Funnel exposes a local service to the public internet through Tailscale's relay
+infrastructure. Traffic flows through Tailscale's servers, so no ports need to
+be opened on your router.
+
+### Enable Funnel in ACLs
+
+Add this to your Tailscale ACL policy (in the admin console):
+
+```jsonc
+{
+  "nodeAttrs": [
+    {
+      "target": ["autogroup:member"],
+      "attr": ["funnel"]
+    }
+  ]
+}
+```
+
+### Start Funnel
+
+```bash
+# Expose SubNetree to the public internet
+tailscale funnel 8080
+```
+
+SubNetree is now reachable at `https://your-hostname.tailnet-name.ts.net` from
+anywhere on the internet.
+
+### Check Status
+
+```bash
+tailscale funnel status
+```
+
+### Stop Funnel
+
+```bash
+tailscale funnel off
+```
+
+## Docker Setup
+
+When running SubNetree in Docker, the Tailscale client must be on the **host**,
+not inside the container:
+
+```bash
+# 1. SubNetree container with host networking
+docker run -d --name subnetree \
+  --network host \
+  -v subnetree-data:/data \
+  ghcr.io/herbhall/subnetree:latest
+
+# 2. Tailscale Serve on the host (not in the container)
+tailscale serve 8080
+```
+
+If you run Tailscale inside a container (sidecar pattern), make sure both
+containers share the same network namespace.
+
+### Docker Compose with Tailscale Sidecar
+
+For an all-in-one deployment:
+
+```yaml
+# docker-compose.yml
+services:
+  tailscale:
+    image: tailscale/tailscale:latest
+    hostname: subnetree
+    environment:
+      - TS_AUTHKEY=tskey-auth-xxxxx  # Generate at admin console
+      - TS_STATE_DIR=/var/lib/tailscale
+      - TS_SERVE_CONFIG=/config/serve.json
+    volumes:
+      - tailscale-state:/var/lib/tailscale
+      - ./tailscale-config:/config
+    cap_add:
+      - NET_ADMIN
+      - SYS_MODULE
+    restart: unless-stopped
+
+  subnetree:
+    image: ghcr.io/herbhall/subnetree:latest
+    network_mode: "service:tailscale"
+    volumes:
+      - subnetree-data:/data
+    depends_on:
+      - tailscale
+    restart: unless-stopped
+
+volumes:
+  tailscale-state:
+  subnetree-data:
+```
+
+Create `tailscale-config/serve.json`:
+
+```json
+{
+  "TCP": {
+    "443": {
+      "HTTPS": true
+    }
+  },
+  "Web": {
+    "your-hostname.tailnet-name.ts.net:443": {
+      "Handlers": {
+        "/": {
+          "Proxy": "http://127.0.0.1:8080"
+        }
+      }
+    }
+  }
+}
+```
+
+Replace `your-hostname.tailnet-name.ts.net` with your actual Tailscale hostname.
+
+## Security Considerations
+
+- **Serve** traffic is restricted to your tailnet -- only authenticated
+  Tailscale users can access it
+- **Funnel** traffic is public -- SubNetree's built-in JWT authentication
+  protects the dashboard, but the login page is exposed
+- SubNetree's first-run setup wizard creates an admin account; complete this
+  **before** enabling Funnel
+- Consider enabling
+  [Tailscale SSH](https://tailscale.com/kb/1193/tailscale-ssh) alongside Serve
+  for secure management access
+- Review your Tailscale ACLs to limit which devices can use Serve and Funnel
+
+## Troubleshooting
+
+**"Funnel not available"** -- Ensure Funnel is enabled in your Tailscale ACL
+policy and that your Tailscale client is v1.52 or later.
+
+**"HTTPS certificate error"** -- Tailscale provisions Let's Encrypt certificates
+automatically for `*.ts.net` domains. Ensure MagicDNS is enabled in your admin
+console.
+
+**Docker: "connection refused"** -- With the sidecar pattern, SubNetree must use
+`network_mode: "service:tailscale"` so both containers share the same network
+namespace. Verify SubNetree is listening on `0.0.0.0:8080` (not `127.0.0.1`).
+
+**Dashboard loads but API calls fail** -- If using Funnel with SubNetree behind
+a proxy, ensure the `Host` header is forwarded correctly. Tailscale Serve/Funnel
+handles this automatically.

--- a/docs/requirements/21-phased-roadmap.md
+++ b/docs/requirements/21-phased-roadmap.md
@@ -124,8 +124,8 @@
 - [x] About page with version info, license, and Community Supporters section
 
 #### Documentation
-- [ ] Tailscale deployment guide: running SubNetree + Scout over Tailscale
-- [ ] Tailscale Funnel/Serve guide: exposing dashboard without port forwarding
+- [x] Tailscale deployment guide: running SubNetree + Scout over Tailscale
+- [x] Tailscale Funnel/Serve guide: exposing dashboard without port forwarding
 
 #### Operations
 - [x] Backup/restore CLI commands (`subnetree backup`, `subnetree restore`)


### PR DESCRIPTION
## Summary

- Added `docs/guides/tailscale-deployment.md` -- running SubNetree + Scout over Tailscale (topology diagram, bind config, ACLs, subnet routing)
- Added `docs/guides/tailscale-funnel.md` -- exposing dashboard via Tailscale Serve (private) and Funnel (public), including Docker sidecar compose
- Added Guides section to README linking all three guides
- Checked off both Tailscale documentation items in the roadmap

Closes #80

## Test plan

- [ ] Verify markdownlint passes on both new files
- [ ] Verify Mermaid diagram renders on GitHub
- [ ] Verify README guide links resolve correctly
- [ ] CI passes (no code changes, docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)