### PR TITLE
fix(vault): resolve route pattern conflict causing server panic

### DIFF
--- a/internal/vault/handlers.go
+++ b/internal/vault/handlers.go
@@ -23,7 +23,7 @@ func (m *Module) Routes() []plugin.Route {
 		// Decrypted data retrieval
 		{Method: "GET", Path: "/credentials/{id}/data", Handler: m.handleGetCredentialData},
 		// Device-scoped listing
-		{Method: "GET", Path: "/credentials/device/{device_id}", Handler: m.handleListDeviceCredentials},
+		{Method: "GET", Path: "/device-credentials/{device_id}", Handler: m.handleListDeviceCredentials},
 		// Key management
 		{Method: "POST", Path: "/rotate-keys", Handler: m.handleRotateKeys},
 		{Method: "POST", Path: "/seal", Handler: m.handleSeal},

--- a/internal/vault/handlers_test.go
+++ b/internal/vault/handlers_test.go
@@ -569,7 +569,7 @@ func TestHandleListDeviceCredentials_Success(t *testing.T) {
 		EncryptedData: []byte("enc"), CreatedAt: now, UpdatedAt: now,
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/credentials/device/dev-1", http.NoBody)
+	req := httptest.NewRequest(http.MethodGet, "/device-credentials/dev-1", http.NoBody)
 	req.SetPathValue("device_id", "dev-1")
 	rr := httptest.NewRecorder()
 	m.handleListDeviceCredentials(rr, req)

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -133,7 +133,7 @@ func TestRoutes(t *testing.T) {
 		"PUT /credentials/{id}":               "",
 		"DELETE /credentials/{id}":            "",
 		"GET /credentials/{id}/data":          "",
-		"GET /credentials/device/{device_id}": "",
+		"GET /device-credentials/{device_id}": "",
 		"POST /rotate-keys":                   "",
 		"POST /seal":                          "",
 		"POST /unseal":                        "",


### PR DESCRIPTION
## Summary

- Rename vault device-scoped route from `GET /credentials/device/{device_id}` to `GET /device-credentials/{device_id}`
- Go 1.22+ ServeMux detects that `GET /credentials/{id}/data` and `GET /credentials/device/{device_id}` are structurally ambiguous (both match `/credentials/device/data`)
- This caused a panic on server startup when the vault plugin is enabled -- **release-blocking bug in v0.2.0**

## Root Cause

The Go standard library's enhanced `ServeMux` (Go 1.22+) rejects route patterns where two patterns can match the same path but neither is more specific. The wildcard `{id}` in `/credentials/{id}/data` captures the literal `device`, creating overlap with `/credentials/device/{device_id}`.

## Test plan

- [x] All 28 Go packages pass (`go test ./... -count=1`)
- [x] Vault tests specifically pass (128 tests)
- [x] Build succeeds (`go build ./...`)
- [ ] CI passes
- [ ] Re-run `verify-release.ps1` after merging and re-tagging

🤖 Generated with [Claude Code](https://claude.com/claude-code)