### PR TITLE
docs: align documentation with v0.2.1 project state

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![codecov](https://codecov.io/gh/HerbHall/subnetree/branch/main/graph/badge.svg)](https://codecov.io/gh/HerbHall/subnetree)
 [![License](https://img.shields.io/badge/license-BSL%201.1-blue)](LICENSE)
 
-> **v0.2.0**: All core modules are functional. Discovery, monitoring, analytics, credential vault, and remote access all work. Contributions and feedback welcome!
+> **v0.2.1**: All core modules are functional. Discovery, monitoring, analytics, credential vault, and remote access all work. Contributions and feedback welcome!
 
 **Your homelab command center.** SubNetree discovers devices on your network, monitors their status, and gives you one-click access to everything -- without typing passwords a thousand times a day.
 
@@ -16,12 +16,12 @@ Homelabbers juggle dozens of tools: UnRAID for storage, Proxmox for VMs, Home As
 
 - **Discovers everything** on your LAN automatically (ARP, ICMP -- with mDNS, SNMP, UPnP planned)
 - **Shows status at a glance** from multiple platforms in one place
-- **Launches anything** with one click -- web UIs, SSH, RDP -- credentials handled
+- **Launches anything** with one click -- web UIs, SSH -- credentials handled
 - **Extends via plugins** to monitor whatever you need
 
 ## Current Status
 
-> **v0.2.0** -- All core modules functional. 431+ tests across 5 new modules.
+> **v0.2.1** -- All core modules functional. 398 tests across 5 new modules.
 
 ### What Works Today
 
@@ -102,14 +102,14 @@ docker-compose up -d
 ### Monitoring
 
 - Device health and status tracking
-- Optional Scout agents for detailed host metrics
+- Scout agents for detailed host metrics (coming in v0.3.0)
 - Plugin-extensible -- monitor anything
 
 ### Quick Access
 
-- One-click launch to web UIs, SSH, RDP, VNC
+- One-click launch to web UIs and SSH sessions
 - Credential vault so you don't re-type passwords
-- Secure browser-based remote access (coming soon)
+- HTTP reverse proxy and SSH-in-browser via WebSocket
 
 ## How SubNetree Compares
 
@@ -166,7 +166,7 @@ graph TD
 | **Pulse** | Health monitoring, metrics, alerting |
 | **Dispatch** | Scout agent enrollment and management |
 | **Vault** | Encrypted credential storage |
-| **Gateway** | Browser-based remote access (SSH, RDP, HTTP proxy) |
+| **Gateway** | Browser-based remote access (SSH, HTTP proxy) |
 | **Webhook** | Event-driven webhook notifications |
 | **LLM** | AI provider integration (Ollama, optional) |
 | **Insight** | Statistical analytics, anomaly detection, NL queries |
@@ -240,7 +240,7 @@ api/
 
 ## Roadmap
 
-- **v0.2.0** (shipped): All core modules -- monitoring, analytics, vault, gateway, LLM
+- **v0.2.1** (shipped): All core modules -- monitoring, analytics, vault, gateway, LLM
 - **v0.3.0**: Windows Scout agent + gRPC mTLS + Dispatch
 - **v0.4.0**: Enhanced discovery (SNMP, mDNS, UPnP, LLDP/CDP) + alerting
 - **v0.5.0**: Multi-tenant support for MSPs

--- a/docs/releases/v0.2.0.md
+++ b/docs/releases/v0.2.0.md
@@ -8,7 +8,7 @@
 v0.2.0 is the first feature release after the alpha. Every core module is now
 fully implemented -- Pulse monitoring, Insight analytics, LLM integration,
 credential Vault, and Gateway remote access all ship with real functionality
-and comprehensive test coverage (431+ new tests).
+and comprehensive test coverage (398 new tests).
 
 ## New Modules
 
@@ -21,7 +21,7 @@ and comprehensive test coverage (431+ new tests).
 - Publishes `pulse.metrics.collected` events consumed by Insight
 - REST API: 6 endpoints for checks, results, alerts, and device status
 
-### Insight -- AI-Powered Analytics (115 tests)
+### Insight -- AI-Powered Analytics (90 tests)
 
 - Statistical algorithms: EWMA baselines, Z-score anomaly detection,
   CUSUM change-point detection, linear regression forecasting,
@@ -37,7 +37,7 @@ and comprehensive test coverage (431+ new tests).
 - Plugin wrapper with health checks and graceful degradation
 - Product works fully without any LLM configured (`Required: false`)
 
-### Vault -- Credential Encryption (128 tests)
+### Vault -- Credential Encryption (120 tests)
 
 - Argon2id key encryption key (KEK) derivation
 - AES-256-GCM envelope encryption with per-credential data encryption keys
@@ -102,10 +102,13 @@ This release establishes the following version roadmap:
 
 ## Statistics
 
-- **431+ new tests** across 5 modules
+- **398 tests** across 5 modules
 - **0 new Go dependencies** for Vault, Gateway, and Insight
-- **84 tests** in Gateway alone (sessions, proxy, SSH, handlers, store)
-- **128 tests** in Vault (encryption, store, API, key management)
+- **120 tests** in Vault (encryption, store, API, key management)
+- **90 tests** in Insight (baselines, anomaly detection, forecasting, NL query)
+- **84 tests** in Gateway (sessions, proxy, SSH, handlers, store)
+- **80 tests** in Pulse (checks, alerts, retention, API handlers)
+- **24 tests** in LLM (Ollama provider, plugin wrapper, contract suite)
 
 ## Getting Started
 

--- a/docs/releases/v0.2.1.md
+++ b/docs/releases/v0.2.1.md
@@ -1,0 +1,69 @@
+# v0.2.1 Release Notes
+
+**Release Date:** 2026-02-08
+**Tag:** `v0.2.1`
+
+## Overview
+
+v0.2.1 is a patch release fixing a critical startup bug in v0.2.0 and adding
+release verification tooling.
+
+## Critical Fix
+
+### Vault Route Pattern Conflict (PR #139)
+
+v0.2.0 panicked on startup due to a Go 1.22+ ServeMux route conflict in the
+Vault plugin. Two route patterns were structurally ambiguous:
+
+- `GET /api/v1/vault/credentials/{id}/data`
+- `GET /api/v1/vault/credentials/device/{device_id}`
+
+Both matched `/api/v1/vault/credentials/device/data`, and neither was more
+specific. Go's enhanced ServeMux (1.22+) detects this at registration time
+and panics rather than silently picking one.
+
+**Fix:** Renamed the device-scoped route to
+`GET /api/v1/vault/device-credentials/{device_id}`.
+
+## New: Release Verification Scripts
+
+Added automated verification scripts for testing release binaries across
+platforms:
+
+- `tools/verify-release.ps1` -- Windows PowerShell (11 test sections)
+- `tools/verify-release.sh` -- Linux/macOS bash (12 test sections)
+- `.github/ISSUE_TEMPLATE/release_verification.md` -- tracking template
+
+Both scripts download the release binary, verify checksums, start a server,
+run through setup, authentication, scanning, vault, pulse, insight, and
+cleanup -- fully automated.
+
+## Verification Results
+
+- **Windows amd64**: 27 passed, 0 failed (Windows 11)
+- Network scan discovered 33 devices
+- Vault unseal/create/decrypt/seal all passed
+- Pulse auto-created ICMP checks for all discovered devices
+
+## All Changes
+
+- `fix(vault)`: resolve route pattern conflict causing server panic (#139)
+- `fix`: set vault passphrase env var in release verification scripts
+- `fix`: use valid log format in release verification scripts
+- `fix`: correct verification script API paths and auth handling
+- `fix`: resolve 3 false warnings in release verification scripts
+- `chore`: add release verification scripts and issue template (#138, #135)
+
+## Upgrade from v0.2.0
+
+v0.2.0 will panic on startup. Upgrade to v0.2.1 immediately.
+
+```bash
+docker pull ghcr.io/herbhall/subnetree:v0.2.1
+docker stop subnetree && docker rm subnetree
+docker run -d --name subnetree \
+  -p 8080:8080 \
+  -v subnetree-data:/data \
+  --cap-add NET_RAW --cap-add NET_ADMIN \
+  ghcr.io/herbhall/subnetree:v0.2.1
+```

--- a/docs/requirements/21-phased-roadmap.md
+++ b/docs/requirements/21-phased-roadmap.md
@@ -107,7 +107,7 @@
 - [x] ICMP ping sweep
 - [x] ARP scanning
 - [x] OUI manufacturer lookup (embedded database)
-- [ ] LLDP/CDP neighbor discovery for topology (defer to Phase 2)
+- [ ] LLDP/CDP neighbor discovery for topology (deferred to Phase 2)
 - [x] Device persistence in SQLite
 - [x] Publishes `recon.device.discovered` events
 
@@ -199,14 +199,14 @@
 - [ ] Research certificate management libraries for mTLS (Go stdlib crypto/x509 patterns)
 - [ ] Evaluate Windows service management (golang.org/x/sys/windows/svc)
 
-- [ ] Scout agent binary for Windows
+- [ ] Scout agent binary for Windows (skeleton exists, not functional)
 - [ ] Internal CA for mTLS certificate management
 - [ ] Token-based enrollment with certificate signing
 - [ ] gRPC communication with mTLS
 - [ ] System metrics: CPU, memory, disk, network
 - [ ] Exponential backoff reconnection
 - [ ] Certificate auto-renewal (90-day certs, renew at day 60)
-- [ ] Dispatch module: agent list, status, check-in tracking
+- [x] Dispatch module: agent list, status, check-in tracking (stub with lifecycle tests)
 - [ ] Dashboard: agent status view, enrollment flow
 - [ ] Proto management via buf (replace protoc)
 


### PR DESCRIPTION
## Summary

Post-release audit found documentation drift between the roadmap, README, release notes, and actual project state. This PR aligns everything.

- Update README version references from v0.2.0 to v0.2.1
- Remove false RDP/VNC claims (only SSH + HTTP proxy are implemented)
- Fix Scout agent aspirational language (stub exists, not functional)
- Resolve remote access description contradiction
- Correct inflated test counts in v0.2.0 release notes (398 actual, not 431+)
- Create missing v0.2.1 patch release notes
- Fix roadmap checklist: check Dispatch (exists), annotate Scout skeleton

## Test plan

- [ ] README claims match actual codebase capabilities
- [ ] Release notes test counts match `go test -v` output
- [ ] Roadmap checklist accurately reflects implementation state
- [ ] No broken markdown links

🤖 Generated with [Claude Code](https://claude.com/claude-code)