### PR TITLE
fix(docs): single-line docker commands for PowerShell compatibility

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -155,11 +155,8 @@ release:
     ### Installation
 
     **Docker (recommended):**
-    ```bash
-    docker run -d -p 8080:8080 \
-      -v subnetree-data:/data \
-      --cap-add NET_RAW --cap-add NET_ADMIN \
-      ghcr.io/herbhall/subnetree:{{ .Tag }}
+    ```
+    docker run -d -p 8080:8080 -v subnetree-data:/data --cap-add NET_RAW --cap-add NET_ADMIN ghcr.io/herbhall/subnetree:{{ .Tag }}
     ```
 
     **Binary:** Download the appropriate archive for your platform below.

--- a/README.md
+++ b/README.md
@@ -47,23 +47,16 @@ See the [phased roadmap](docs/requirements/21-phased-roadmap.md) for the full pl
 
 ## Quick Start (Docker)
 
-```bash
-docker run -d --name subnetree \
-  -p 8080:8080 \
-  -v subnetree-data:/data \
-  --cap-add NET_RAW --cap-add NET_ADMIN \
-  ghcr.io/herbhall/subnetree:latest
+```console
+docker run -d --name subnetree -p 8080:8080 -v subnetree-data:/data --cap-add NET_RAW --cap-add NET_ADMIN ghcr.io/herbhall/subnetree:latest
 ```
 
 Open <http://localhost:8080> -- first-time setup will prompt you to create an admin account.
 
 For full network scanning capability on home networks:
 
-```bash
-docker run -d --name subnetree \
-  --network host \
-  -v subnetree-data:/data \
-  ghcr.io/herbhall/subnetree:latest
+```console
+docker run -d --name subnetree --network host -v subnetree-data:/data ghcr.io/herbhall/subnetree:latest
 ```
 
 ### Docker Compose

--- a/docs/releases/v0.2.0.md
+++ b/docs/releases/v0.2.0.md
@@ -114,24 +114,16 @@ This release establishes the following version roadmap:
 
 ### Docker (Recommended)
 
-```bash
-docker run -d --name subnetree \
-  -p 8080:8080 \
-  -v subnetree-data:/data \
-  --cap-add NET_RAW --cap-add NET_ADMIN \
-  ghcr.io/herbhall/subnetree:v0.2.0
+```console
+docker run -d --name subnetree -p 8080:8080 -v subnetree-data:/data --cap-add NET_RAW --cap-add NET_ADMIN ghcr.io/herbhall/subnetree:v0.2.0
 ```
 
 ### Upgrade from v0.1.0-alpha
 
 Pull the new image and restart. Database migrations run automatically.
 
-```bash
+```console
 docker pull ghcr.io/herbhall/subnetree:v0.2.0
 docker stop subnetree && docker rm subnetree
-docker run -d --name subnetree \
-  -p 8080:8080 \
-  -v subnetree-data:/data \
-  --cap-add NET_RAW --cap-add NET_ADMIN \
-  ghcr.io/herbhall/subnetree:v0.2.0
+docker run -d --name subnetree -p 8080:8080 -v subnetree-data:/data --cap-add NET_RAW --cap-add NET_ADMIN ghcr.io/herbhall/subnetree:v0.2.0
 ```

--- a/docs/releases/v0.2.1.md
+++ b/docs/releases/v0.2.1.md
@@ -58,12 +58,8 @@ cleanup -- fully automated.
 
 v0.2.0 will panic on startup. Upgrade to v0.2.1 immediately.
 
-```bash
+```console
 docker pull ghcr.io/herbhall/subnetree:v0.2.1
 docker stop subnetree && docker rm subnetree
-docker run -d --name subnetree \
-  -p 8080:8080 \
-  -v subnetree-data:/data \
-  --cap-add NET_RAW --cap-add NET_ADMIN \
-  ghcr.io/herbhall/subnetree:v0.2.1
+docker run -d --name subnetree -p 8080:8080 -v subnetree-data:/data --cap-add NET_RAW --cap-add NET_ADMIN ghcr.io/herbhall/subnetree:v0.2.1
 ```


### PR DESCRIPTION
## Summary

- Docker `run` commands using bash `\` line continuation break in PowerShell (which uses backtick for continuation)
- Converted all multi-line `docker run` commands to single-line format that works in any shell
- Changed code fence language from `bash` to `console` (shell-agnostic)
- Updated: README.md, .goreleaser.yaml release header, v0.2.0 and v0.2.1 release notes

## Test plan

- [ ] Verify `docker run` command copies cleanly from GitHub release page into PowerShell
- [ ] Verify command copies cleanly into bash/zsh
- [ ] Verify markdownlint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)