### PR TITLE
chore: add VS Code workspace configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ coverage.html
 
 # IDE
 .idea/
-.vscode/
+.vscode/mcp.json
 *.swp
 *.swo
 *~

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,18 @@
+{
+  "recommendations": [
+    "golang.go",
+    "esbenp.prettier-vscode",
+    "dbaeumer.vscode-eslint",
+    "bradlc.vscode-tailwindcss",
+    "editorconfig.editorconfig",
+    "bierner.markdown-mermaid",
+    "DavidAnson.vscode-markdownlint",
+    "zxh404.vscode-proto3",
+    "ms-vscode.makefile-tools",
+    "ms-azuretools.vscode-docker",
+    "redhat.vscode-yaml",
+    "qwtel.sqlite-viewer",
+    "42Crunch.vscode-openapi",
+    "ryanluker.vscode-coverage-gutters"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,53 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Server",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}/cmd/subnetree",
+      "cwd": "${workspaceFolder}",
+      "env": {},
+      "args": []
+    },
+    {
+      "name": "Debug Scout",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}/cmd/scout",
+      "cwd": "${workspaceFolder}",
+      "env": {},
+      "args": []
+    },
+    {
+      "name": "Debug Current Test",
+      "type": "go",
+      "request": "launch",
+      "mode": "test",
+      "program": "${fileDirname}",
+      "args": ["-test.run", "${selectedText}", "-test.v", "-count=1"],
+      "showLog": true
+    },
+    {
+      "name": "Debug Package Tests",
+      "type": "go",
+      "request": "launch",
+      "mode": "test",
+      "program": "${fileDirname}",
+      "args": ["-test.v", "-count=1"],
+      "showLog": true
+    },
+    {
+      "name": "Attach to Chrome (React)",
+      "type": "chrome",
+      "request": "launch",
+      "url": "http://localhost:5173",
+      "webRoot": "${workspaceFolder}/web/src",
+      "sourceMapPathOverrides": {
+        "webpack:///./src/*": "${webRoot}/*"
+      }
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,83 @@
+{
+  // ── Go ────────────────────────────────────────────────────────────
+  "go.useLanguageServer": true,
+  "go.lintTool": "golangci-lint",
+  "go.lintFlags": ["--fast"],
+  "go.testFlags": ["-race", "-count=1"],
+  "go.testTimeout": "120s",
+  "go.formatTool": "gofmt",
+  "go.toolsManagement.autoUpdate": true,
+  "gopls": {
+    "ui.semanticTokens": true,
+    "ui.completion.usePlaceholders": true
+  },
+
+  // ── TypeScript / React ────────────────────────────────────────────
+  "typescript.tsdk": "web/node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "eslint.workingDirectories": ["web"],
+
+  // ── Formatting ────────────────────────────────────────────────────
+  "editor.formatOnSave": true,
+  "[go]": {
+    "editor.defaultFormatter": "golang.go",
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": "explicit"
+    }
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[css]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[yaml]": {
+    "editor.defaultFormatter": "redhat.vscode-yaml"
+  },
+  "[markdown]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+
+  // ── File associations & exclusions ────────────────────────────────
+  "files.associations": {
+    "*.proto": "proto3"
+  },
+  "files.exclude": {
+    "**/node_modules": true,
+    "**/bin": true,
+    "**/dist": true,
+    "**/*.tsbuildinfo": true
+  },
+  "files.watcherExclude": {
+    "**/node_modules/**": true,
+    "**/bin/**": true,
+    "**/dist/**": true,
+    "**/.git/objects/**": true
+  },
+
+  // ── Tailwind CSS ──────────────────────────────────────────────────
+  "tailwindCSS.experimental.classRegex": [
+    ["cva\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"],
+    ["cx\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]
+  ],
+
+  // ── Search exclusions ─────────────────────────────────────────────
+  "search.exclude": {
+    "**/node_modules": true,
+    "**/dist": true,
+    "**/bin": true,
+    "**/coverage.out": true,
+    "**/api/swagger": true,
+    "**/*.tsbuildinfo": true,
+    "**/pnpm-lock.yaml": true
+  }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,114 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Build All",
+      "type": "shell",
+      "command": "make build",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": ["$go"],
+      "presentation": { "reveal": "always", "panel": "shared" }
+    },
+    {
+      "label": "Build Server",
+      "type": "shell",
+      "command": "make build-server",
+      "group": "build",
+      "problemMatcher": ["$go"]
+    },
+    {
+      "label": "Build Scout",
+      "type": "shell",
+      "command": "make build-scout",
+      "group": "build",
+      "problemMatcher": ["$go"]
+    },
+    {
+      "label": "Build Dashboard",
+      "type": "shell",
+      "command": "make build-dashboard",
+      "group": "build",
+      "problemMatcher": ["$tsc"]
+    },
+    {
+      "label": "Dev Dashboard",
+      "type": "shell",
+      "command": "make dev-dashboard",
+      "isBackground": true,
+      "problemMatcher": {
+        "pattern": { "regexp": "." },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "VITE",
+          "endsPattern": "ready in"
+        }
+      },
+      "presentation": { "reveal": "always", "panel": "dedicated" }
+    },
+    {
+      "label": "Test (Go)",
+      "type": "shell",
+      "command": "make test",
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      },
+      "problemMatcher": ["$go"],
+      "presentation": { "reveal": "always" }
+    },
+    {
+      "label": "Test with Race Detection",
+      "type": "shell",
+      "command": "make test-race",
+      "group": "test",
+      "problemMatcher": ["$go"]
+    },
+    {
+      "label": "Test Coverage",
+      "type": "shell",
+      "command": "make test-coverage",
+      "group": "test",
+      "problemMatcher": ["$go"]
+    },
+    {
+      "label": "Lint (Go)",
+      "type": "shell",
+      "command": "make lint",
+      "problemMatcher": ["$go"],
+      "presentation": { "reveal": "always" }
+    },
+    {
+      "label": "Lint Dashboard",
+      "type": "shell",
+      "command": "make lint-dashboard",
+      "problemMatcher": ["$eslint-stylish"]
+    },
+    {
+      "label": "Generate Swagger",
+      "type": "shell",
+      "command": "make swagger",
+      "problemMatcher": []
+    },
+    {
+      "label": "Generate Protobuf",
+      "type": "shell",
+      "command": "make proto",
+      "problemMatcher": []
+    },
+    {
+      "label": "License Check",
+      "type": "shell",
+      "command": "make license-check",
+      "problemMatcher": []
+    },
+    {
+      "label": "Clean",
+      "type": "shell",
+      "command": "make clean",
+      "problemMatcher": []
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add shared `.vscode/` configs (settings, launch, tasks, extensions) for consistent dev experience
- Track `.vscode/` in git except `mcp.json` (personal MCP server config)
- 5 debug configurations: server, scout, current test, package tests, Chrome React
- 14 task definitions integrating all Makefile commands
- 5 new extension recommendations: Docker, YAML, SQLite Viewer, OpenAPI, Coverage Gutters

## Test plan
- [ ] Open a Go file, verify format-on-save works
- [ ] Open a `.tsx` file, verify Prettier format-on-save works
- [ ] Press F5 with `cmd/subnetree/main.go` open, verify "Debug Server" launches
- [ ] Press Ctrl+Shift+B, verify "Build All" task runs
- [ ] Verify `mcp.json` is NOT tracked (stays gitignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)