### PR TITLE
chore: inherit editorconfig from DevSpace parent

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,38 +1,5 @@
 # EditorConfig helps maintain consistent coding styles
 # https://editorconfig.org
 
-root = true
+root = false
 
-[*]
-charset = utf-8
-end_of_line = lf
-insert_final_newline = true
-trim_trailing_whitespace = true
-indent_style = space
-indent_size = 2
-
-[*.go]
-indent_style = tab
-indent_size = 4
-
-[*.{md,markdown}]
-trim_trailing_whitespace = false
-
-[Makefile]
-indent_style = tab
-indent_size = 4
-
-[*.{yml,yaml}]
-indent_size = 2
-
-[*.{js,jsx,ts,tsx}]
-indent_size = 2
-
-[*.{css,scss}]
-indent_size = 2
-
-[*.proto]
-indent_size = 2
-
-[*.sql]
-indent_size = 2


### PR DESCRIPTION
## Summary

- Switch SubNetree `.editorconfig` to `root = false` so it inherits shared formatting rules from `D:\DevSpace\.editorconfig`
- Removes 33 lines of redundant rule definitions that are now inherited from the parent config

Part of the DevSpace directory restructuring (projects moved from `D:\` root into `D:\DevSpace\`).

## Test plan

- [ ] Verify editor formatting still works correctly in VS Code (Go tabs, JS 2-space, etc.)
- [ ] Confirm `.editorconfig` inheritance resolves properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)