### PR TITLE
feat: add infrastructure documentation module foundation

### DIFF
--- a/cmd/subnetree/main.go
+++ b/cmd/subnetree/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/HerbHall/subnetree/internal/config"
 	"github.com/HerbHall/subnetree/internal/dashboard"
 	"github.com/HerbHall/subnetree/internal/dispatch"
+	"github.com/HerbHall/subnetree/internal/docs"
 	"github.com/HerbHall/subnetree/internal/event"
 	"github.com/HerbHall/subnetree/internal/gateway"
 	"github.com/HerbHall/subnetree/internal/insight"
@@ -132,6 +133,7 @@ func main() {
 		webhook.New(),
 		llm.New(),
 		insight.New(),
+		docs.New(),
 	}
 	for _, m := range modules {
 		if err := reg.Register(m); err != nil {

--- a/internal/docs/collector.go
+++ b/internal/docs/collector.go
@@ -1,0 +1,17 @@
+package docs
+
+import "context"
+
+// Collector defines the interface for infrastructure configuration collectors.
+type Collector interface {
+	Name() string
+	Available() bool
+	Discover(ctx context.Context) ([]Application, error)
+	Collect(ctx context.Context, appID string) (*CollectedConfig, error)
+}
+
+// CollectedConfig holds the raw configuration content retrieved by a collector.
+type CollectedConfig struct {
+	Content string `json:"content"`
+	Format  string `json:"format"` // "json", "yaml", "toml", "text"
+}

--- a/internal/docs/config.go
+++ b/internal/docs/config.go
@@ -1,0 +1,21 @@
+package docs
+
+import "time"
+
+type Config struct {
+	RetentionPeriod     time.Duration `mapstructure:"retention_period"`
+	MaintenanceInterval time.Duration `mapstructure:"maintenance_interval"`
+	MaxSnapshotsPerApp  int           `mapstructure:"max_snapshots_per_app"`
+	DockerSocket        string        `mapstructure:"docker_socket"`
+	CollectInterval     time.Duration `mapstructure:"collect_interval"`
+}
+
+func DefaultConfig() Config {
+	return Config{
+		RetentionPeriod:     90 * 24 * time.Hour,
+		MaintenanceInterval: 1 * time.Hour,
+		MaxSnapshotsPerApp:  100,
+		DockerSocket:        "",
+		CollectInterval:     6 * time.Hour,
+	}
+}

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -1,0 +1,164 @@
+package docs
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/HerbHall/subnetree/pkg/plugin"
+	"go.uber.org/zap"
+)
+
+// Compile-time interface guards.
+var (
+	_ plugin.Plugin        = (*Module)(nil)
+	_ plugin.HTTPProvider  = (*Module)(nil)
+	_ plugin.HealthChecker = (*Module)(nil)
+)
+
+// Module implements the Docs infrastructure documentation plugin.
+type Module struct {
+	logger     *zap.Logger
+	cfg        Config
+	store      *DocsStore
+	bus        plugin.EventBus
+	plugins    plugin.PluginResolver
+	collectors []Collector
+	ctx        context.Context
+	cancel     context.CancelFunc
+	wg         sync.WaitGroup
+}
+
+// New creates a new Docs plugin instance.
+func New() *Module {
+	return &Module{}
+}
+
+func (m *Module) Info() plugin.PluginInfo {
+	return plugin.PluginInfo{
+		Name:        "docs",
+		Version:     "0.1.0",
+		Description: "Infrastructure documentation and configuration tracking",
+		Required:    false,
+		APIVersion:  plugin.APIVersionCurrent,
+	}
+}
+
+func (m *Module) Init(_ context.Context, deps plugin.Dependencies) error {
+	m.logger = deps.Logger
+
+	m.cfg = DefaultConfig()
+	if deps.Config != nil {
+		if err := deps.Config.Unmarshal(&m.cfg); err != nil {
+			return fmt.Errorf("unmarshal docs config: %w", err)
+		}
+	}
+
+	if deps.Store != nil {
+		if err := deps.Store.Migrate(context.Background(), "docs", migrations()); err != nil {
+			return fmt.Errorf("docs migrations: %w", err)
+		}
+		m.store = NewStore(deps.Store.DB())
+	}
+
+	m.bus = deps.Bus
+	m.plugins = deps.Plugins
+
+	m.logger.Info("docs module initialized",
+		zap.Duration("retention_period", m.cfg.RetentionPeriod),
+		zap.Duration("collect_interval", m.cfg.CollectInterval),
+		zap.Int("max_snapshots_per_app", m.cfg.MaxSnapshotsPerApp),
+	)
+	return nil
+}
+
+func (m *Module) Start(_ context.Context) error {
+	m.ctx, m.cancel = context.WithCancel(context.Background())
+	m.startMaintenance()
+	m.logger.Info("docs module started")
+	return nil
+}
+
+func (m *Module) Stop(_ context.Context) error {
+	if m.cancel != nil {
+		m.cancel()
+	}
+	m.wg.Wait()
+	m.logger.Info("docs module stopped")
+	return nil
+}
+
+// Health implements plugin.HealthChecker.
+func (m *Module) Health(_ context.Context) plugin.HealthStatus {
+	details := map[string]string{}
+
+	if m.store != nil {
+		details["store"] = "connected"
+	} else {
+		details["store"] = "unavailable"
+	}
+
+	details["collectors"] = fmt.Sprintf("%d", len(m.collectors))
+
+	status := "healthy"
+	if m.store == nil {
+		status = "degraded"
+	}
+
+	return plugin.HealthStatus{
+		Status:  status,
+		Details: details,
+	}
+}
+
+// publishEvent publishes an event to the event bus.
+func (m *Module) publishEvent(ctx context.Context, topic string, payload any) {
+	if m.bus == nil {
+		return
+	}
+	m.bus.PublishAsync(ctx, plugin.Event{
+		Topic:     topic,
+		Source:    "docs",
+		Timestamp: time.Now(),
+		Payload:   payload,
+	})
+}
+
+// startMaintenance launches a background goroutine that periodically
+// deletes old snapshots past the retention window.
+func (m *Module) startMaintenance() {
+	m.wg.Add(1)
+	go func() {
+		defer m.wg.Done()
+		ticker := time.NewTicker(m.cfg.MaintenanceInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-m.ctx.Done():
+				return
+			case <-ticker.C:
+				m.runMaintenance()
+			}
+		}
+	}()
+}
+
+// runMaintenance executes a single maintenance cycle.
+func (m *Module) runMaintenance() {
+	if m.store == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(m.ctx, 30*time.Second)
+	defer cancel()
+
+	cutoff := time.Now().Add(-m.cfg.RetentionPeriod)
+
+	deleted, err := m.store.DeleteOldSnapshots(ctx, cutoff)
+	if err != nil {
+		m.logger.Warn("failed to delete old snapshots", zap.Error(err))
+	} else if deleted > 0 {
+		m.logger.Info("purged old snapshots", zap.Int64("count", deleted))
+	}
+}

--- a/internal/docs/docs_test.go
+++ b/internal/docs/docs_test.go
@@ -1,0 +1,191 @@
+package docs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/HerbHall/subnetree/internal/store"
+	"github.com/HerbHall/subnetree/pkg/plugin"
+	"github.com/HerbHall/subnetree/pkg/plugin/plugintest"
+	"go.uber.org/zap"
+)
+
+func TestPluginContract(t *testing.T) {
+	plugintest.TestPluginContract(t, func() plugin.Plugin { return New() })
+}
+
+func TestNew(t *testing.T) {
+	m := New()
+	if m == nil {
+		t.Fatal("New() returned nil")
+	}
+}
+
+func TestInfo(t *testing.T) {
+	m := New()
+	info := m.Info()
+
+	if info.Name != "docs" {
+		t.Errorf("Info().Name = %q, want %q", info.Name, "docs")
+	}
+	if info.Version != "0.1.0" {
+		t.Errorf("Info().Version = %q, want %q", info.Version, "0.1.0")
+	}
+	if info.Description == "" {
+		t.Error("Info().Description is empty, want non-empty")
+	}
+	if info.Required {
+		t.Error("Info().Required = true, want false")
+	}
+	if info.APIVersion < plugin.APIVersionMin {
+		t.Errorf("Info().APIVersion = %d, below minimum %d", info.APIVersion, plugin.APIVersionMin)
+	}
+}
+
+func TestInit_NilStore(t *testing.T) {
+	m := New()
+	err := m.Init(context.Background(), plugin.Dependencies{
+		Logger: zap.NewNop(),
+	})
+	if err != nil {
+		t.Fatalf("Init() with nil store error = %v", err)
+	}
+
+	if m.store != nil {
+		t.Error("store should be nil when deps.Store is nil")
+	}
+
+	defaults := DefaultConfig()
+	if m.cfg.RetentionPeriod != defaults.RetentionPeriod {
+		t.Errorf("cfg.RetentionPeriod = %v, want default %v", m.cfg.RetentionPeriod, defaults.RetentionPeriod)
+	}
+	if m.cfg.MaxSnapshotsPerApp != defaults.MaxSnapshotsPerApp {
+		t.Errorf("cfg.MaxSnapshotsPerApp = %d, want default %d", m.cfg.MaxSnapshotsPerApp, defaults.MaxSnapshotsPerApp)
+	}
+	if m.cfg.CollectInterval != defaults.CollectInterval {
+		t.Errorf("cfg.CollectInterval = %v, want default %v", m.cfg.CollectInterval, defaults.CollectInterval)
+	}
+}
+
+func TestInit_WithStore(t *testing.T) {
+	db, err := store.New(":memory:")
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	m := New()
+	err = m.Init(context.Background(), plugin.Dependencies{
+		Logger: zap.NewNop(),
+		Store:  db,
+	})
+	if err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	if m.store == nil {
+		t.Error("store should be non-nil when deps.Store is provided")
+	}
+}
+
+func TestHealth_NoStore(t *testing.T) {
+	m := New()
+	err := m.Init(context.Background(), plugin.Dependencies{
+		Logger: zap.NewNop(),
+	})
+	if err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	status := m.Health(context.Background())
+
+	if status.Status != "degraded" {
+		t.Errorf("Health().Status = %q, want %q (store is nil)", status.Status, "degraded")
+	}
+	if v, ok := status.Details["store"]; !ok || v != "unavailable" {
+		t.Errorf("Health().Details[\"store\"] = %q, want %q", v, "unavailable")
+	}
+}
+
+func TestHealth_WithStore(t *testing.T) {
+	db, err := store.New(":memory:")
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	m := New()
+	err = m.Init(context.Background(), plugin.Dependencies{
+		Logger: zap.NewNop(),
+		Store:  db,
+	})
+	if err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	status := m.Health(context.Background())
+
+	if status.Status != "healthy" {
+		t.Errorf("Health().Status = %q, want %q", status.Status, "healthy")
+	}
+	if v, ok := status.Details["store"]; !ok || v != "connected" {
+		t.Errorf("Health().Details[\"store\"] = %q, want %q", v, "connected")
+	}
+}
+
+func TestRoutes(t *testing.T) {
+	m := New()
+	routes := m.Routes()
+
+	if len(routes) != 5 {
+		t.Fatalf("Routes() returned %d routes, want 5", len(routes))
+	}
+
+	expected := []struct {
+		Method string
+		Path   string
+	}{
+		{"GET", "/applications"},
+		{"GET", "/applications/{id}"},
+		{"GET", "/snapshots"},
+		{"GET", "/snapshots/{id}"},
+		{"POST", "/snapshots"},
+	}
+
+	for i, want := range expected {
+		if routes[i].Method != want.Method {
+			t.Errorf("routes[%d].Method = %q, want %q", i, routes[i].Method, want.Method)
+		}
+		if routes[i].Path != want.Path {
+			t.Errorf("routes[%d].Path = %q, want %q", i, routes[i].Path, want.Path)
+		}
+		if routes[i].Handler == nil {
+			t.Errorf("routes[%d].Handler is nil, want non-nil", i)
+		}
+	}
+}
+
+func TestStartStop(t *testing.T) {
+	db, err := store.New(":memory:")
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	m := New()
+	err = m.Init(context.Background(), plugin.Dependencies{
+		Logger: zap.NewNop(),
+		Store:  db,
+	})
+	if err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	if err := m.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	if err := m.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+}

--- a/internal/docs/events.go
+++ b/internal/docs/events.go
@@ -1,0 +1,9 @@
+package docs
+
+// Event topics published by the Docs module.
+const (
+	TopicApplicationDiscovered = "docs.application.discovered"
+	TopicApplicationRemoved    = "docs.application.removed"
+	TopicSnapshotCreated       = "docs.snapshot.created"
+	TopicConfigChanged         = "docs.config.changed"
+)

--- a/internal/docs/handlers.go
+++ b/internal/docs/handlers.go
@@ -1,0 +1,278 @@
+package docs
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/HerbHall/subnetree/pkg/plugin"
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+)
+
+// Routes implements plugin.HTTPProvider.
+func (m *Module) Routes() []plugin.Route {
+	return []plugin.Route{
+		{Method: "GET", Path: "/applications", Handler: m.handleListApplications},
+		{Method: "GET", Path: "/applications/{id}", Handler: m.handleGetApplication},
+		{Method: "GET", Path: "/snapshots", Handler: m.handleListSnapshots},
+		{Method: "GET", Path: "/snapshots/{id}", Handler: m.handleGetSnapshot},
+		{Method: "POST", Path: "/snapshots", Handler: m.handleCreateSnapshot},
+	}
+}
+
+// handleListApplications returns a paginated, filtered list of applications.
+//
+//	@Summary		List applications
+//	@Description	Returns a paginated list of discovered infrastructure applications.
+//	@Tags			docs
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			limit	query		int		false	"Max results"	default(50)
+//	@Param			offset	query		int		false	"Offset"		default(0)
+//	@Param			type	query		string	false	"Filter by app_type"
+//	@Param			status	query		string	false	"Filter by status"
+//	@Success		200		{object}	map[string]any
+//	@Failure		500		{object}	map[string]any
+//	@Router			/docs/applications [get]
+func (m *Module) handleListApplications(w http.ResponseWriter, r *http.Request) {
+	if m.store == nil {
+		docsWriteError(w, http.StatusServiceUnavailable, "docs store not available")
+		return
+	}
+
+	params := ListApplicationsParams{
+		Limit:   docsQueryInt(r, "limit", 50),
+		Offset:  docsQueryInt(r, "offset", 0),
+		AppType: r.URL.Query().Get("type"),
+		Status:  r.URL.Query().Get("status"),
+	}
+
+	apps, total, err := m.store.ListApplications(r.Context(), params)
+	if err != nil {
+		m.logger.Warn("failed to list applications", zap.Error(err))
+		docsWriteError(w, http.StatusInternalServerError, "failed to list applications")
+		return
+	}
+	if apps == nil {
+		apps = []Application{}
+	}
+	docsWriteJSON(w, http.StatusOK, map[string]any{
+		"items": apps,
+		"total": total,
+	})
+}
+
+// handleGetApplication returns a single application by ID.
+//
+//	@Summary		Get application
+//	@Description	Returns a single infrastructure application by its ID.
+//	@Tags			docs
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			id	path		string	true	"Application ID"
+//	@Success		200	{object}	Application
+//	@Failure		400	{object}	map[string]any
+//	@Failure		404	{object}	map[string]any
+//	@Failure		500	{object}	map[string]any
+//	@Router			/docs/applications/{id} [get]
+func (m *Module) handleGetApplication(w http.ResponseWriter, r *http.Request) {
+	if m.store == nil {
+		docsWriteError(w, http.StatusServiceUnavailable, "docs store not available")
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" {
+		docsWriteError(w, http.StatusBadRequest, "application ID is required")
+		return
+	}
+
+	app, err := m.store.GetApplication(r.Context(), id)
+	if err != nil {
+		m.logger.Warn("failed to get application", zap.String("id", id), zap.Error(err))
+		docsWriteError(w, http.StatusInternalServerError, "failed to get application")
+		return
+	}
+	if app == nil {
+		docsWriteError(w, http.StatusNotFound, "application not found")
+		return
+	}
+	docsWriteJSON(w, http.StatusOK, app)
+}
+
+// handleListSnapshots returns a filtered, paginated list of snapshots.
+//
+//	@Summary		List snapshots
+//	@Description	Returns a paginated list of configuration snapshots, optionally filtered by application.
+//	@Tags			docs
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			application_id	query		string	false	"Filter by application ID"
+//	@Param			limit			query		int		false	"Max results"	default(50)
+//	@Param			offset			query		int		false	"Offset"		default(0)
+//	@Success		200				{array}		Snapshot
+//	@Failure		500				{object}	map[string]any
+//	@Router			/docs/snapshots [get]
+func (m *Module) handleListSnapshots(w http.ResponseWriter, r *http.Request) {
+	if m.store == nil {
+		docsWriteError(w, http.StatusServiceUnavailable, "docs store not available")
+		return
+	}
+
+	params := ListSnapshotsParams{
+		ApplicationID: r.URL.Query().Get("application_id"),
+		Limit:         docsQueryInt(r, "limit", 50),
+		Offset:        docsQueryInt(r, "offset", 0),
+	}
+
+	snapshots, err := m.store.ListSnapshots(r.Context(), params)
+	if err != nil {
+		m.logger.Warn("failed to list snapshots", zap.Error(err))
+		docsWriteError(w, http.StatusInternalServerError, "failed to list snapshots")
+		return
+	}
+	if snapshots == nil {
+		snapshots = []Snapshot{}
+	}
+	docsWriteJSON(w, http.StatusOK, snapshots)
+}
+
+// handleGetSnapshot returns a single snapshot by ID.
+//
+//	@Summary		Get snapshot
+//	@Description	Returns a single configuration snapshot including its content.
+//	@Tags			docs
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			id	path		string	true	"Snapshot ID"
+//	@Success		200	{object}	Snapshot
+//	@Failure		400	{object}	map[string]any
+//	@Failure		404	{object}	map[string]any
+//	@Failure		500	{object}	map[string]any
+//	@Router			/docs/snapshots/{id} [get]
+func (m *Module) handleGetSnapshot(w http.ResponseWriter, r *http.Request) {
+	if m.store == nil {
+		docsWriteError(w, http.StatusServiceUnavailable, "docs store not available")
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" {
+		docsWriteError(w, http.StatusBadRequest, "snapshot ID is required")
+		return
+	}
+
+	snap, err := m.store.GetSnapshot(r.Context(), id)
+	if err != nil {
+		m.logger.Warn("failed to get snapshot", zap.String("id", id), zap.Error(err))
+		docsWriteError(w, http.StatusInternalServerError, "failed to get snapshot")
+		return
+	}
+	if snap == nil {
+		docsWriteError(w, http.StatusNotFound, "snapshot not found")
+		return
+	}
+	docsWriteJSON(w, http.StatusOK, snap)
+}
+
+// CreateSnapshotRequest is the request body for POST /snapshots.
+type CreateSnapshotRequest struct {
+	ApplicationID string `json:"application_id"`
+	Content       string `json:"content"`
+	Format        string `json:"format"`
+}
+
+// handleCreateSnapshot creates a new configuration snapshot.
+//
+//	@Summary		Create snapshot
+//	@Description	Creates a new configuration snapshot for an application.
+//	@Tags			docs
+//	@Accept			json
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			request	body		CreateSnapshotRequest	true	"Snapshot to create"
+//	@Success		201		{object}	Snapshot
+//	@Failure		400		{object}	map[string]any
+//	@Failure		500		{object}	map[string]any
+//	@Router			/docs/snapshots [post]
+func (m *Module) handleCreateSnapshot(w http.ResponseWriter, r *http.Request) {
+	if m.store == nil {
+		docsWriteError(w, http.StatusServiceUnavailable, "docs store not available")
+		return
+	}
+
+	var req CreateSnapshotRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		docsWriteError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if req.ApplicationID == "" {
+		docsWriteError(w, http.StatusBadRequest, "application_id is required")
+		return
+	}
+	if req.Content == "" {
+		docsWriteError(w, http.StatusBadRequest, "content is required")
+		return
+	}
+	if req.Format == "" {
+		req.Format = "json"
+	}
+
+	hash := sha256.Sum256([]byte(req.Content))
+
+	snap := &Snapshot{
+		ID:            uuid.New().String(),
+		ApplicationID: req.ApplicationID,
+		ContentHash:   hex.EncodeToString(hash[:]),
+		Content:       req.Content,
+		Format:        req.Format,
+		SizeBytes:     len(req.Content),
+		Source:        "manual",
+		CapturedAt:    time.Now().UTC(),
+	}
+
+	if err := m.store.InsertSnapshot(r.Context(), snap); err != nil {
+		m.logger.Error("failed to create snapshot", zap.Error(err))
+		docsWriteError(w, http.StatusInternalServerError, "failed to create snapshot")
+		return
+	}
+
+	m.publishEvent(r.Context(), TopicSnapshotCreated, snap)
+
+	docsWriteJSON(w, http.StatusCreated, snap)
+}
+
+// -- helpers --
+
+func docsWriteJSON(w http.ResponseWriter, status int, data any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(data)
+}
+
+func docsWriteError(w http.ResponseWriter, status int, detail string) {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"type":   "https://subnetree.com/problems/" + http.StatusText(status),
+		"title":  http.StatusText(status),
+		"status": status,
+		"detail": detail,
+	})
+}
+
+func docsQueryInt(r *http.Request, key string, defaultVal int) int {
+	s := r.URL.Query().Get(key)
+	if s == "" {
+		return defaultVal
+	}
+	v, err := strconv.Atoi(s)
+	if err != nil || v < 0 {
+		return defaultVal
+	}
+	return v
+}

--- a/internal/docs/handlers_test.go
+++ b/internal/docs/handlers_test.go
@@ -1,0 +1,622 @@
+package docs
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/HerbHall/subnetree/internal/store"
+	"go.uber.org/zap"
+)
+
+// newTestModule creates a Module wired to an in-memory store for handler tests.
+func newTestModule(t *testing.T) *Module {
+	t.Helper()
+	db, err := store.New(":memory:")
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	ctx := context.Background()
+	if err := db.Migrate(ctx, "docs", migrations()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	return &Module{
+		logger: zap.NewNop(),
+		store:  NewStore(db.DB()),
+		cfg:    DefaultConfig(),
+	}
+}
+
+// -- handleListApplications tests --
+
+func TestHandleListApplications_Empty(t *testing.T) {
+	m := newTestModule(t)
+	req := httptest.NewRequest(http.MethodGet, "/applications", http.NoBody)
+	w := httptest.NewRecorder()
+
+	m.handleListApplications(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var resp map[string]json.RawMessage
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	var items []Application
+	if err := json.Unmarshal(resp["items"], &items); err != nil {
+		t.Fatalf("decode items: %v", err)
+	}
+	if len(items) != 0 {
+		t.Errorf("len(items) = %d, want 0", len(items))
+	}
+
+	var total int
+	if err := json.Unmarshal(resp["total"], &total); err != nil {
+		t.Fatalf("decode total: %v", err)
+	}
+	if total != 0 {
+		t.Errorf("total = %d, want 0", total)
+	}
+}
+
+func TestHandleListApplications_WithData(t *testing.T) {
+	m := newTestModule(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	app := &Application{
+		ID: "app-001", Name: "Proxmox", AppType: "hypervisor",
+		Collector: "docker", Status: "active", Metadata: "{}",
+		DiscoveredAt: now, UpdatedAt: now,
+	}
+	if err := m.store.InsertApplication(context.Background(), app); err != nil {
+		t.Fatalf("insert application: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/applications", http.NoBody)
+	w := httptest.NewRecorder()
+
+	m.handleListApplications(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var resp map[string]json.RawMessage
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	var items []Application
+	if err := json.Unmarshal(resp["items"], &items); err != nil {
+		t.Fatalf("decode items: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("len(items) = %d, want 1", len(items))
+	}
+	if items[0].ID != "app-001" {
+		t.Errorf("items[0].ID = %q, want %q", items[0].ID, "app-001")
+	}
+	if items[0].Name != "Proxmox" {
+		t.Errorf("items[0].Name = %q, want %q", items[0].Name, "Proxmox")
+	}
+}
+
+func TestHandleListApplications_NilStore(t *testing.T) {
+	m := &Module{logger: zap.NewNop()}
+	req := httptest.NewRequest(http.MethodGet, "/applications", http.NoBody)
+	w := httptest.NewRecorder()
+
+	m.handleListApplications(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusServiceUnavailable)
+	}
+}
+
+func TestHandleListApplications_WithFilters(t *testing.T) {
+	m := newTestModule(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	apps := []*Application{
+		{
+			ID: "app-001", Name: "Proxmox", AppType: "hypervisor",
+			Collector: "docker", Status: "active", Metadata: "{}",
+			DiscoveredAt: now, UpdatedAt: now,
+		},
+		{
+			ID: "app-002", Name: "Nginx", AppType: "web_server",
+			Collector: "docker", Status: "active", Metadata: "{}",
+			DiscoveredAt: now, UpdatedAt: now.Add(time.Second),
+		},
+	}
+	for _, a := range apps {
+		if err := m.store.InsertApplication(context.Background(), a); err != nil {
+			t.Fatalf("insert application: %v", err)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/applications?type=hypervisor", http.NoBody)
+	w := httptest.NewRecorder()
+
+	m.handleListApplications(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var resp map[string]json.RawMessage
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	var items []Application
+	if err := json.Unmarshal(resp["items"], &items); err != nil {
+		t.Fatalf("decode items: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("len(items) = %d, want 1", len(items))
+	}
+	if items[0].AppType != "hypervisor" {
+		t.Errorf("items[0].AppType = %q, want %q", items[0].AppType, "hypervisor")
+	}
+}
+
+// -- handleGetApplication tests --
+
+func TestHandleGetApplication_NotFound(t *testing.T) {
+	m := newTestModule(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/applications/nonexistent", http.NoBody)
+	req.SetPathValue("id", "nonexistent")
+	w := httptest.NewRecorder()
+
+	m.handleGetApplication(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestHandleGetApplication_Found(t *testing.T) {
+	m := newTestModule(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	app := &Application{
+		ID: "app-001", Name: "Proxmox", AppType: "hypervisor",
+		DeviceID: "dev-001", Collector: "docker", Status: "active",
+		Metadata: `{"version":"8.0"}`, DiscoveredAt: now, UpdatedAt: now,
+	}
+	if err := m.store.InsertApplication(context.Background(), app); err != nil {
+		t.Fatalf("insert application: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/applications/app-001", http.NoBody)
+	req.SetPathValue("id", "app-001")
+	w := httptest.NewRecorder()
+
+	m.handleGetApplication(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var got Application
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got.ID != "app-001" {
+		t.Errorf("ID = %q, want %q", got.ID, "app-001")
+	}
+	if got.Name != "Proxmox" {
+		t.Errorf("Name = %q, want %q", got.Name, "Proxmox")
+	}
+	if got.AppType != "hypervisor" {
+		t.Errorf("AppType = %q, want %q", got.AppType, "hypervisor")
+	}
+}
+
+func TestHandleGetApplication_EmptyID(t *testing.T) {
+	m := newTestModule(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/applications/", http.NoBody)
+	w := httptest.NewRecorder()
+
+	m.handleGetApplication(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestHandleGetApplication_NilStore(t *testing.T) {
+	m := &Module{logger: zap.NewNop()}
+	req := httptest.NewRequest(http.MethodGet, "/applications/app-001", http.NoBody)
+	req.SetPathValue("id", "app-001")
+	w := httptest.NewRecorder()
+
+	m.handleGetApplication(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusServiceUnavailable)
+	}
+}
+
+// -- handleListSnapshots tests --
+
+func TestHandleListSnapshots_Empty(t *testing.T) {
+	m := newTestModule(t)
+	req := httptest.NewRequest(http.MethodGet, "/snapshots", http.NoBody)
+	w := httptest.NewRecorder()
+
+	m.handleListSnapshots(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var snapshots []Snapshot
+	if err := json.NewDecoder(w.Body).Decode(&snapshots); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(snapshots) != 0 {
+		t.Errorf("len(snapshots) = %d, want 0", len(snapshots))
+	}
+}
+
+func TestHandleListSnapshots_WithData(t *testing.T) {
+	m := newTestModule(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	app := &Application{
+		ID: "app-001", Name: "Test", AppType: "test",
+		Collector: "manual", Status: "active", Metadata: "{}",
+		DiscoveredAt: now, UpdatedAt: now,
+	}
+	if err := m.store.InsertApplication(context.Background(), app); err != nil {
+		t.Fatalf("insert application: %v", err)
+	}
+
+	snap := &Snapshot{
+		ID: "snap-001", ApplicationID: "app-001", ContentHash: "h1",
+		Content: "config data", Format: "json", SizeBytes: 11,
+		Source: "manual", CapturedAt: now,
+	}
+	if err := m.store.InsertSnapshot(context.Background(), snap); err != nil {
+		t.Fatalf("insert snapshot: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/snapshots?application_id=app-001", http.NoBody)
+	w := httptest.NewRecorder()
+
+	m.handleListSnapshots(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var snapshots []Snapshot
+	if err := json.NewDecoder(w.Body).Decode(&snapshots); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(snapshots) != 1 {
+		t.Fatalf("len(snapshots) = %d, want 1", len(snapshots))
+	}
+	if snapshots[0].ID != "snap-001" {
+		t.Errorf("snapshots[0].ID = %q, want %q", snapshots[0].ID, "snap-001")
+	}
+}
+
+func TestHandleListSnapshots_NilStore(t *testing.T) {
+	m := &Module{logger: zap.NewNop()}
+	req := httptest.NewRequest(http.MethodGet, "/snapshots", http.NoBody)
+	w := httptest.NewRecorder()
+
+	m.handleListSnapshots(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusServiceUnavailable)
+	}
+}
+
+// -- handleGetSnapshot tests --
+
+func TestHandleGetSnapshot_NotFound(t *testing.T) {
+	m := newTestModule(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/snapshots/nonexistent", http.NoBody)
+	req.SetPathValue("id", "nonexistent")
+	w := httptest.NewRecorder()
+
+	m.handleGetSnapshot(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestHandleGetSnapshot_Found(t *testing.T) {
+	m := newTestModule(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	app := &Application{
+		ID: "app-001", Name: "Test", AppType: "test",
+		Collector: "manual", Status: "active", Metadata: "{}",
+		DiscoveredAt: now, UpdatedAt: now,
+	}
+	if err := m.store.InsertApplication(context.Background(), app); err != nil {
+		t.Fatalf("insert application: %v", err)
+	}
+
+	snap := &Snapshot{
+		ID: "snap-001", ApplicationID: "app-001", ContentHash: "abc123",
+		Content: `{"key":"value"}`, Format: "json", SizeBytes: 15,
+		Source: "manual", CapturedAt: now,
+	}
+	if err := m.store.InsertSnapshot(context.Background(), snap); err != nil {
+		t.Fatalf("insert snapshot: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/snapshots/snap-001", http.NoBody)
+	req.SetPathValue("id", "snap-001")
+	w := httptest.NewRecorder()
+
+	m.handleGetSnapshot(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var got Snapshot
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got.ID != "snap-001" {
+		t.Errorf("ID = %q, want %q", got.ID, "snap-001")
+	}
+	if got.Content != `{"key":"value"}` {
+		t.Errorf("Content = %q, want %q", got.Content, `{"key":"value"}`)
+	}
+}
+
+func TestHandleGetSnapshot_EmptyID(t *testing.T) {
+	m := newTestModule(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/snapshots/", http.NoBody)
+	w := httptest.NewRecorder()
+
+	m.handleGetSnapshot(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestHandleGetSnapshot_NilStore(t *testing.T) {
+	m := &Module{logger: zap.NewNop()}
+	req := httptest.NewRequest(http.MethodGet, "/snapshots/snap-001", http.NoBody)
+	req.SetPathValue("id", "snap-001")
+	w := httptest.NewRecorder()
+
+	m.handleGetSnapshot(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusServiceUnavailable)
+	}
+}
+
+// -- handleCreateSnapshot tests --
+
+func TestHandleCreateSnapshot_Success(t *testing.T) {
+	m := newTestModule(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	app := &Application{
+		ID: "app-001", Name: "Test", AppType: "test",
+		Collector: "manual", Status: "active", Metadata: "{}",
+		DiscoveredAt: now, UpdatedAt: now,
+	}
+	if err := m.store.InsertApplication(context.Background(), app); err != nil {
+		t.Fatalf("insert application: %v", err)
+	}
+
+	body := `{"application_id":"app-001","content":"{\"key\":\"value\"}","format":"json"}`
+	req := httptest.NewRequest(http.MethodPost, "/snapshots", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	m.handleCreateSnapshot(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusCreated)
+	}
+
+	var got Snapshot
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got.ID == "" {
+		t.Error("ID is empty, want generated UUID")
+	}
+	if got.ApplicationID != "app-001" {
+		t.Errorf("ApplicationID = %q, want %q", got.ApplicationID, "app-001")
+	}
+	if got.ContentHash == "" {
+		t.Error("ContentHash is empty, want SHA-256 hash")
+	}
+	if got.Content != `{"key":"value"}` {
+		t.Errorf("Content = %q, want %q", got.Content, `{"key":"value"}`)
+	}
+	if got.Format != "json" {
+		t.Errorf("Format = %q, want %q", got.Format, "json")
+	}
+	if got.SizeBytes != len(`{"key":"value"}`) {
+		t.Errorf("SizeBytes = %d, want %d", got.SizeBytes, len(`{"key":"value"}`))
+	}
+	if got.Source != "manual" {
+		t.Errorf("Source = %q, want %q", got.Source, "manual")
+	}
+}
+
+func TestHandleCreateSnapshot_DefaultFormat(t *testing.T) {
+	m := newTestModule(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	app := &Application{
+		ID: "app-001", Name: "Test", AppType: "test",
+		Collector: "manual", Status: "active", Metadata: "{}",
+		DiscoveredAt: now, UpdatedAt: now,
+	}
+	if err := m.store.InsertApplication(context.Background(), app); err != nil {
+		t.Fatalf("insert application: %v", err)
+	}
+
+	// Omit the format field -- should default to "json".
+	body := `{"application_id":"app-001","content":"some data"}`
+	req := httptest.NewRequest(http.MethodPost, "/snapshots", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	m.handleCreateSnapshot(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusCreated)
+	}
+
+	var got Snapshot
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got.Format != "json" {
+		t.Errorf("Format = %q, want default %q", got.Format, "json")
+	}
+}
+
+func TestHandleCreateSnapshot_InvalidJSON(t *testing.T) {
+	m := newTestModule(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/snapshots", strings.NewReader("not json"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	m.handleCreateSnapshot(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestHandleCreateSnapshot_MissingApplicationID(t *testing.T) {
+	m := newTestModule(t)
+
+	body := `{"content":"some data","format":"json"}`
+	req := httptest.NewRequest(http.MethodPost, "/snapshots", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	m.handleCreateSnapshot(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestHandleCreateSnapshot_MissingContent(t *testing.T) {
+	m := newTestModule(t)
+
+	body := `{"application_id":"app-001","format":"json"}`
+	req := httptest.NewRequest(http.MethodPost, "/snapshots", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	m.handleCreateSnapshot(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestHandleCreateSnapshot_NilStore(t *testing.T) {
+	m := &Module{logger: zap.NewNop()}
+	body := `{"application_id":"app-001","content":"data"}`
+	req := httptest.NewRequest(http.MethodPost, "/snapshots", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	m.handleCreateSnapshot(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusServiceUnavailable)
+	}
+}
+
+// -- docsQueryInt tests --
+
+func TestDocsQueryInt(t *testing.T) {
+	tests := []struct {
+		name       string
+		query      string
+		key        string
+		defaultVal int
+		want       int
+	}{
+		{
+			name:       "no param returns default",
+			query:      "",
+			key:        "limit",
+			defaultVal: 50,
+			want:       50,
+		},
+		{
+			name:       "valid param",
+			query:      "limit=25",
+			key:        "limit",
+			defaultVal: 50,
+			want:       25,
+		},
+		{
+			name:       "negative returns default",
+			query:      "limit=-5",
+			key:        "limit",
+			defaultVal: 50,
+			want:       50,
+		},
+		{
+			name:       "non-numeric returns default",
+			query:      "limit=abc",
+			key:        "limit",
+			defaultVal: 50,
+			want:       50,
+		},
+		{
+			name:       "zero returns zero",
+			query:      "offset=0",
+			key:        "offset",
+			defaultVal: 10,
+			want:       0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url := "/test"
+			if tt.query != "" {
+				url += "?" + tt.query
+			}
+			req := httptest.NewRequest(http.MethodGet, url, http.NoBody)
+			got := docsQueryInt(req, tt.key, tt.defaultVal)
+			if got != tt.want {
+				t.Errorf("docsQueryInt() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/docs/migrations.go
+++ b/internal/docs/migrations.go
@@ -1,0 +1,54 @@
+package docs
+
+import (
+	"database/sql"
+
+	"github.com/HerbHall/subnetree/pkg/plugin"
+)
+
+func migrations() []plugin.Migration {
+	return []plugin.Migration{
+		{
+			Version:     1,
+			Description: "create docs tables (applications, snapshots)",
+			Up: func(tx *sql.Tx) error {
+				stmts := []string{
+					`CREATE TABLE IF NOT EXISTS docs_applications (
+						id            TEXT PRIMARY KEY,
+						name          TEXT NOT NULL,
+						app_type      TEXT NOT NULL DEFAULT 'unknown',
+						device_id     TEXT NOT NULL DEFAULT '',
+						collector     TEXT NOT NULL DEFAULT '',
+						status        TEXT NOT NULL DEFAULT 'active',
+						metadata      TEXT NOT NULL DEFAULT '{}',
+						discovered_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+						updated_at    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+					)`,
+					`CREATE INDEX IF NOT EXISTS idx_docs_applications_type ON docs_applications(app_type)`,
+					`CREATE INDEX IF NOT EXISTS idx_docs_applications_device ON docs_applications(device_id)`,
+					`CREATE INDEX IF NOT EXISTS idx_docs_applications_status ON docs_applications(status)`,
+
+					`CREATE TABLE IF NOT EXISTS docs_snapshots (
+						id             TEXT PRIMARY KEY,
+						application_id TEXT NOT NULL REFERENCES docs_applications(id) ON DELETE CASCADE,
+						content_hash   TEXT NOT NULL,
+						content        TEXT NOT NULL,
+						format         TEXT NOT NULL DEFAULT 'json',
+						size_bytes     INTEGER NOT NULL DEFAULT 0,
+						source         TEXT NOT NULL DEFAULT 'auto',
+						captured_at    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+					)`,
+					`CREATE INDEX IF NOT EXISTS idx_docs_snapshots_app ON docs_snapshots(application_id, captured_at)`,
+					`CREATE INDEX IF NOT EXISTS idx_docs_snapshots_hash ON docs_snapshots(content_hash)`,
+					`CREATE INDEX IF NOT EXISTS idx_docs_snapshots_captured ON docs_snapshots(captured_at)`,
+				}
+				for _, stmt := range stmts {
+					if _, err := tx.Exec(stmt); err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+		},
+	}
+}

--- a/internal/docs/store.go
+++ b/internal/docs/store.go
@@ -1,0 +1,295 @@
+package docs
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// Application represents a discovered infrastructure application.
+type Application struct {
+	ID           string    `json:"id"`
+	Name         string    `json:"name"`
+	AppType      string    `json:"app_type"`
+	DeviceID     string    `json:"device_id,omitempty"`
+	Collector    string    `json:"collector"`
+	Status       string    `json:"status"`
+	Metadata     string    `json:"metadata"`
+	DiscoveredAt time.Time `json:"discovered_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+}
+
+// Snapshot represents a point-in-time capture of an application's configuration.
+type Snapshot struct {
+	ID            string    `json:"id"`
+	ApplicationID string    `json:"application_id"`
+	ContentHash   string    `json:"content_hash"`
+	Content       string    `json:"content"`
+	Format        string    `json:"format"`
+	SizeBytes     int       `json:"size_bytes"`
+	Source        string    `json:"source"`
+	CapturedAt    time.Time `json:"captured_at"`
+}
+
+// ListApplicationsParams controls filtering and pagination for application queries.
+type ListApplicationsParams struct {
+	Limit   int
+	Offset  int
+	AppType string
+	Status  string
+}
+
+// ListSnapshotsParams controls filtering and pagination for snapshot queries.
+type ListSnapshotsParams struct {
+	ApplicationID string
+	Limit         int
+	Offset        int
+}
+
+// DocsStore provides database access for the Docs module.
+type DocsStore struct {
+	db *sql.DB
+}
+
+// NewStore creates a new DocsStore backed by the given database.
+func NewStore(db *sql.DB) *DocsStore {
+	return &DocsStore{db: db}
+}
+
+// -- Applications --
+
+// InsertApplication inserts a new application record.
+func (s *DocsStore) InsertApplication(ctx context.Context, a *Application) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO docs_applications (
+			id, name, app_type, device_id, collector, status, metadata, discovered_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		a.ID, a.Name, a.AppType, a.DeviceID, a.Collector, a.Status, a.Metadata,
+		a.DiscoveredAt, a.UpdatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("insert application: %w", err)
+	}
+	return nil
+}
+
+// GetApplication returns an application by ID. Returns nil, nil if not found.
+func (s *DocsStore) GetApplication(ctx context.Context, id string) (*Application, error) {
+	var a Application
+	err := s.db.QueryRowContext(ctx, `
+		SELECT id, name, app_type, device_id, collector, status, metadata, discovered_at, updated_at
+		FROM docs_applications WHERE id = ?`,
+		id,
+	).Scan(
+		&a.ID, &a.Name, &a.AppType, &a.DeviceID, &a.Collector, &a.Status,
+		&a.Metadata, &a.DiscoveredAt, &a.UpdatedAt,
+	)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get application: %w", err)
+	}
+	return &a, nil
+}
+
+// ListApplications returns a filtered, paginated list of applications with total count.
+func (s *DocsStore) ListApplications(ctx context.Context, params ListApplicationsParams) ([]Application, int, error) {
+	if params.Limit <= 0 {
+		params.Limit = 50
+	}
+
+	where := "1=1"
+	args := []any{}
+	if params.AppType != "" {
+		where += " AND app_type = ?"
+		args = append(args, params.AppType)
+	}
+	if params.Status != "" {
+		where += " AND status = ?"
+		args = append(args, params.Status)
+	}
+
+	var total int
+	err := s.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM docs_applications WHERE "+where, args..., //nolint:gosec // where uses parameterized placeholders only
+	).Scan(&total)
+	if err != nil {
+		return nil, 0, fmt.Errorf("count applications: %w", err)
+	}
+
+	queryArgs := make([]any, 0, len(args)+2)
+	queryArgs = append(queryArgs, args...)
+	queryArgs = append(queryArgs, params.Limit, params.Offset)
+	//nolint:gosec // where uses parameterized placeholders only
+	rows, err := s.db.QueryContext(ctx,
+		"SELECT id, name, app_type, device_id, collector, status, metadata, discovered_at, updated_at "+
+			"FROM docs_applications WHERE "+where+" ORDER BY updated_at DESC LIMIT ? OFFSET ?",
+		queryArgs...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list applications: %w", err)
+	}
+	defer rows.Close()
+
+	var apps []Application
+	for rows.Next() {
+		var a Application
+		if err := rows.Scan(
+			&a.ID, &a.Name, &a.AppType, &a.DeviceID, &a.Collector, &a.Status,
+			&a.Metadata, &a.DiscoveredAt, &a.UpdatedAt,
+		); err != nil {
+			return nil, 0, fmt.Errorf("scan application row: %w", err)
+		}
+		apps = append(apps, a)
+	}
+	return apps, total, rows.Err()
+}
+
+// UpdateApplication updates an existing application record.
+func (s *DocsStore) UpdateApplication(ctx context.Context, a *Application) error {
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE docs_applications SET
+			name = ?, app_type = ?, device_id = ?, collector = ?, status = ?,
+			metadata = ?, updated_at = ?
+		WHERE id = ?`,
+		a.Name, a.AppType, a.DeviceID, a.Collector, a.Status,
+		a.Metadata, a.UpdatedAt, a.ID,
+	)
+	if err != nil {
+		return fmt.Errorf("update application: %w", err)
+	}
+	return nil
+}
+
+// -- Snapshots --
+
+// InsertSnapshot inserts a new snapshot record.
+func (s *DocsStore) InsertSnapshot(ctx context.Context, snap *Snapshot) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO docs_snapshots (
+			id, application_id, content_hash, content, format, size_bytes, source, captured_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		snap.ID, snap.ApplicationID, snap.ContentHash, snap.Content, snap.Format,
+		snap.SizeBytes, snap.Source, snap.CapturedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("insert snapshot: %w", err)
+	}
+	return nil
+}
+
+// GetSnapshot returns a snapshot by ID. Returns nil, nil if not found.
+func (s *DocsStore) GetSnapshot(ctx context.Context, id string) (*Snapshot, error) {
+	var snap Snapshot
+	err := s.db.QueryRowContext(ctx, `
+		SELECT id, application_id, content_hash, content, format, size_bytes, source, captured_at
+		FROM docs_snapshots WHERE id = ?`,
+		id,
+	).Scan(
+		&snap.ID, &snap.ApplicationID, &snap.ContentHash, &snap.Content,
+		&snap.Format, &snap.SizeBytes, &snap.Source, &snap.CapturedAt,
+	)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get snapshot: %w", err)
+	}
+	return &snap, nil
+}
+
+// ListSnapshots returns a filtered, paginated list of snapshots.
+func (s *DocsStore) ListSnapshots(ctx context.Context, params ListSnapshotsParams) ([]Snapshot, error) {
+	if params.Limit <= 0 {
+		params.Limit = 50
+	}
+
+	where := "1=1"
+	args := []any{}
+	if params.ApplicationID != "" {
+		where += " AND application_id = ?"
+		args = append(args, params.ApplicationID)
+	}
+
+	queryArgs := make([]any, 0, len(args)+2)
+	queryArgs = append(queryArgs, args...)
+	queryArgs = append(queryArgs, params.Limit, params.Offset)
+	//nolint:gosec // where uses parameterized placeholders only
+	rows, err := s.db.QueryContext(ctx,
+		"SELECT id, application_id, content_hash, content, format, size_bytes, source, captured_at "+
+			"FROM docs_snapshots WHERE "+where+" ORDER BY captured_at DESC LIMIT ? OFFSET ?",
+		queryArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("list snapshots: %w", err)
+	}
+	defer rows.Close()
+
+	var snapshots []Snapshot
+	for rows.Next() {
+		var snap Snapshot
+		if err := rows.Scan(
+			&snap.ID, &snap.ApplicationID, &snap.ContentHash, &snap.Content,
+			&snap.Format, &snap.SizeBytes, &snap.Source, &snap.CapturedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan snapshot row: %w", err)
+		}
+		snapshots = append(snapshots, snap)
+	}
+	return snapshots, rows.Err()
+}
+
+// GetLatestSnapshot returns the most recent snapshot for an application. Returns nil, nil if none.
+func (s *DocsStore) GetLatestSnapshot(ctx context.Context, applicationID string) (*Snapshot, error) {
+	var snap Snapshot
+	err := s.db.QueryRowContext(ctx, `
+		SELECT id, application_id, content_hash, content, format, size_bytes, source, captured_at
+		FROM docs_snapshots WHERE application_id = ? ORDER BY captured_at DESC LIMIT 1`,
+		applicationID,
+	).Scan(
+		&snap.ID, &snap.ApplicationID, &snap.ContentHash, &snap.Content,
+		&snap.Format, &snap.SizeBytes, &snap.Source, &snap.CapturedAt,
+	)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get latest snapshot: %w", err)
+	}
+	return &snap, nil
+}
+
+// DeleteSnapshot deletes a snapshot by ID.
+func (s *DocsStore) DeleteSnapshot(ctx context.Context, id string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM docs_snapshots WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("delete snapshot: %w", err)
+	}
+	return nil
+}
+
+// CountSnapshots returns the number of snapshots for an application.
+func (s *DocsStore) CountSnapshots(ctx context.Context, applicationID string) (int, error) {
+	var count int
+	err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM docs_snapshots WHERE application_id = ?`,
+		applicationID,
+	).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("count snapshots: %w", err)
+	}
+	return count, nil
+}
+
+// DeleteOldSnapshots deletes snapshots captured before the given time.
+// Returns the number of rows deleted.
+func (s *DocsStore) DeleteOldSnapshots(ctx context.Context, before time.Time) (int64, error) {
+	result, err := s.db.ExecContext(ctx,
+		`DELETE FROM docs_snapshots WHERE captured_at < ?`,
+		before,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("delete old snapshots: %w", err)
+	}
+	return result.RowsAffected()
+}

--- a/internal/docs/store_test.go
+++ b/internal/docs/store_test.go
@@ -1,0 +1,743 @@
+package docs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/HerbHall/subnetree/internal/store"
+)
+
+// testStore creates an in-memory SQLite database, runs docs migrations,
+// and returns a DocsStore ready for testing.
+func testStore(t *testing.T) *DocsStore {
+	t.Helper()
+	db, err := store.New(":memory:")
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	ctx := context.Background()
+	if err := db.Migrate(ctx, "docs", migrations()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return NewStore(db.DB())
+}
+
+// insertTestApp is a helper that inserts an application and fails the test on error.
+func insertTestApp(t *testing.T, s *DocsStore, a *Application) {
+	t.Helper()
+	if err := s.InsertApplication(context.Background(), a); err != nil {
+		t.Fatalf("InsertApplication: %v", err)
+	}
+}
+
+// insertTestSnap is a helper that inserts a snapshot and fails the test on error.
+func insertTestSnap(t *testing.T, s *DocsStore, snap *Snapshot) {
+	t.Helper()
+	if err := s.InsertSnapshot(context.Background(), snap); err != nil {
+		t.Fatalf("InsertSnapshot: %v", err)
+	}
+}
+
+// -- Applications --
+
+func TestInsertAndGetApplication(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	app := &Application{
+		ID:           "app-001",
+		Name:         "Proxmox VE",
+		AppType:      "hypervisor",
+		DeviceID:     "dev-001",
+		Collector:    "docker",
+		Status:       "active",
+		Metadata:     `{"version":"8.0"}`,
+		DiscoveredAt: now,
+		UpdatedAt:    now,
+	}
+	insertTestApp(t, s, app)
+
+	got, err := s.GetApplication(ctx, "app-001")
+	if err != nil {
+		t.Fatalf("GetApplication: %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetApplication returned nil, want non-nil")
+	}
+	if got.ID != "app-001" {
+		t.Errorf("ID = %q, want %q", got.ID, "app-001")
+	}
+	if got.Name != "Proxmox VE" {
+		t.Errorf("Name = %q, want %q", got.Name, "Proxmox VE")
+	}
+	if got.AppType != "hypervisor" {
+		t.Errorf("AppType = %q, want %q", got.AppType, "hypervisor")
+	}
+	if got.DeviceID != "dev-001" {
+		t.Errorf("DeviceID = %q, want %q", got.DeviceID, "dev-001")
+	}
+	if got.Collector != "docker" {
+		t.Errorf("Collector = %q, want %q", got.Collector, "docker")
+	}
+	if got.Status != "active" {
+		t.Errorf("Status = %q, want %q", got.Status, "active")
+	}
+	if got.Metadata != `{"version":"8.0"}` {
+		t.Errorf("Metadata = %q, want %q", got.Metadata, `{"version":"8.0"}`)
+	}
+}
+
+func TestGetApplication_NotFound(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	got, err := s.GetApplication(ctx, "nonexistent")
+	if err != nil {
+		t.Fatalf("GetApplication: %v", err)
+	}
+	if got != nil {
+		t.Errorf("GetApplication = %+v, want nil", got)
+	}
+}
+
+func TestListApplications(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC().Truncate(time.Second)
+
+	apps := []*Application{
+		{
+			ID: "app-001", Name: "Proxmox", AppType: "hypervisor",
+			Collector: "docker", Status: "active", Metadata: "{}",
+			DiscoveredAt: now, UpdatedAt: now,
+		},
+		{
+			ID: "app-002", Name: "Nginx", AppType: "web_server",
+			Collector: "docker", Status: "active", Metadata: "{}",
+			DiscoveredAt: now, UpdatedAt: now.Add(time.Second),
+		},
+		{
+			ID: "app-003", Name: "Old App", AppType: "hypervisor",
+			Collector: "manual", Status: "removed", Metadata: "{}",
+			DiscoveredAt: now, UpdatedAt: now.Add(2 * time.Second),
+		},
+	}
+	for _, a := range apps {
+		insertTestApp(t, s, a)
+	}
+
+	tests := []struct {
+		name      string
+		params    ListApplicationsParams
+		wantCount int
+		wantTotal int
+	}{
+		{
+			name:      "all applications",
+			params:    ListApplicationsParams{Limit: 50},
+			wantCount: 3,
+			wantTotal: 3,
+		},
+		{
+			name:      "filter by type hypervisor",
+			params:    ListApplicationsParams{Limit: 50, AppType: "hypervisor"},
+			wantCount: 2,
+			wantTotal: 2,
+		},
+		{
+			name:      "filter by type web_server",
+			params:    ListApplicationsParams{Limit: 50, AppType: "web_server"},
+			wantCount: 1,
+			wantTotal: 1,
+		},
+		{
+			name:      "filter by status active",
+			params:    ListApplicationsParams{Limit: 50, Status: "active"},
+			wantCount: 2,
+			wantTotal: 2,
+		},
+		{
+			name:      "filter by status removed",
+			params:    ListApplicationsParams{Limit: 50, Status: "removed"},
+			wantCount: 1,
+			wantTotal: 1,
+		},
+		{
+			name:      "filter by type and status",
+			params:    ListApplicationsParams{Limit: 50, AppType: "hypervisor", Status: "active"},
+			wantCount: 1,
+			wantTotal: 1,
+		},
+		{
+			name:      "pagination limit",
+			params:    ListApplicationsParams{Limit: 2},
+			wantCount: 2,
+			wantTotal: 3,
+		},
+		{
+			name:      "pagination offset",
+			params:    ListApplicationsParams{Limit: 50, Offset: 2},
+			wantCount: 1,
+			wantTotal: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, total, err := s.ListApplications(ctx, tt.params)
+			if err != nil {
+				t.Fatalf("ListApplications: %v", err)
+			}
+			if len(got) != tt.wantCount {
+				t.Errorf("len(apps) = %d, want %d", len(got), tt.wantCount)
+			}
+			if total != tt.wantTotal {
+				t.Errorf("total = %d, want %d", total, tt.wantTotal)
+			}
+		})
+	}
+}
+
+func TestListApplications_Empty(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	got, total, err := s.ListApplications(ctx, ListApplicationsParams{Limit: 50})
+	if err != nil {
+		t.Fatalf("ListApplications: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil slice for empty result, got %v", got)
+	}
+	if total != 0 {
+		t.Errorf("total = %d, want 0", total)
+	}
+}
+
+func TestListApplications_DefaultLimit(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	app := &Application{
+		ID: "app-001", Name: "Test", AppType: "test",
+		Collector: "manual", Status: "active", Metadata: "{}",
+		DiscoveredAt: now, UpdatedAt: now,
+	}
+	insertTestApp(t, s, app)
+
+	// Pass 0 for limit -- should default to 50 and still return the result.
+	got, total, err := s.ListApplications(ctx, ListApplicationsParams{Limit: 0})
+	if err != nil {
+		t.Fatalf("ListApplications with limit 0: %v", err)
+	}
+	if len(got) != 1 {
+		t.Errorf("len(apps) = %d, want 1", len(got))
+	}
+	if total != 1 {
+		t.Errorf("total = %d, want 1", total)
+	}
+}
+
+func TestUpdateApplication(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	app := &Application{
+		ID: "app-001", Name: "Proxmox", AppType: "hypervisor",
+		DeviceID: "dev-001", Collector: "docker", Status: "active",
+		Metadata: "{}", DiscoveredAt: now, UpdatedAt: now,
+	}
+	insertTestApp(t, s, app)
+
+	// Update some fields.
+	app.Name = "Proxmox VE Updated"
+	app.Status = "removed"
+	app.Metadata = `{"version":"8.1"}`
+	app.UpdatedAt = now.Add(time.Minute)
+
+	if err := s.UpdateApplication(ctx, app); err != nil {
+		t.Fatalf("UpdateApplication: %v", err)
+	}
+
+	got, err := s.GetApplication(ctx, "app-001")
+	if err != nil {
+		t.Fatalf("GetApplication: %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetApplication returned nil after update")
+	}
+	if got.Name != "Proxmox VE Updated" {
+		t.Errorf("Name = %q, want %q", got.Name, "Proxmox VE Updated")
+	}
+	if got.Status != "removed" {
+		t.Errorf("Status = %q, want %q", got.Status, "removed")
+	}
+	if got.Metadata != `{"version":"8.1"}` {
+		t.Errorf("Metadata = %q, want %q", got.Metadata, `{"version":"8.1"}`)
+	}
+}
+
+// -- Snapshots --
+
+func TestInsertAndGetSnapshot(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC().Truncate(time.Second)
+
+	// Insert application first (foreign key constraint).
+	app := &Application{
+		ID: "app-001", Name: "Test App", AppType: "test",
+		Collector: "manual", Status: "active", Metadata: "{}",
+		DiscoveredAt: now, UpdatedAt: now,
+	}
+	insertTestApp(t, s, app)
+
+	snap := &Snapshot{
+		ID:            "snap-001",
+		ApplicationID: "app-001",
+		ContentHash:   "abc123hash",
+		Content:       `{"config":"value"}`,
+		Format:        "json",
+		SizeBytes:     18,
+		Source:        "manual",
+		CapturedAt:    now,
+	}
+	insertTestSnap(t, s, snap)
+
+	got, err := s.GetSnapshot(ctx, "snap-001")
+	if err != nil {
+		t.Fatalf("GetSnapshot: %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetSnapshot returned nil, want non-nil")
+	}
+	if got.ID != "snap-001" {
+		t.Errorf("ID = %q, want %q", got.ID, "snap-001")
+	}
+	if got.ApplicationID != "app-001" {
+		t.Errorf("ApplicationID = %q, want %q", got.ApplicationID, "app-001")
+	}
+	if got.ContentHash != "abc123hash" {
+		t.Errorf("ContentHash = %q, want %q", got.ContentHash, "abc123hash")
+	}
+	if got.Content != `{"config":"value"}` {
+		t.Errorf("Content = %q, want %q", got.Content, `{"config":"value"}`)
+	}
+	if got.Format != "json" {
+		t.Errorf("Format = %q, want %q", got.Format, "json")
+	}
+	if got.SizeBytes != 18 {
+		t.Errorf("SizeBytes = %d, want %d", got.SizeBytes, 18)
+	}
+	if got.Source != "manual" {
+		t.Errorf("Source = %q, want %q", got.Source, "manual")
+	}
+}
+
+func TestGetSnapshot_NotFound(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	got, err := s.GetSnapshot(ctx, "nonexistent")
+	if err != nil {
+		t.Fatalf("GetSnapshot: %v", err)
+	}
+	if got != nil {
+		t.Errorf("GetSnapshot = %+v, want nil", got)
+	}
+}
+
+func TestListSnapshots(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC().Truncate(time.Second)
+
+	// Insert two applications.
+	app1 := &Application{
+		ID: "app-001", Name: "App 1", AppType: "test",
+		Collector: "manual", Status: "active", Metadata: "{}",
+		DiscoveredAt: now, UpdatedAt: now,
+	}
+	app2 := &Application{
+		ID: "app-002", Name: "App 2", AppType: "test",
+		Collector: "manual", Status: "active", Metadata: "{}",
+		DiscoveredAt: now, UpdatedAt: now,
+	}
+	insertTestApp(t, s, app1)
+	insertTestApp(t, s, app2)
+
+	// Insert snapshots: 2 for app-001, 1 for app-002.
+	snaps := []*Snapshot{
+		{
+			ID: "snap-001", ApplicationID: "app-001", ContentHash: "h1",
+			Content: "c1", Format: "json", SizeBytes: 2, Source: "auto",
+			CapturedAt: now,
+		},
+		{
+			ID: "snap-002", ApplicationID: "app-001", ContentHash: "h2",
+			Content: "c2", Format: "json", SizeBytes: 2, Source: "auto",
+			CapturedAt: now.Add(time.Second),
+		},
+		{
+			ID: "snap-003", ApplicationID: "app-002", ContentHash: "h3",
+			Content: "c3", Format: "yaml", SizeBytes: 2, Source: "manual",
+			CapturedAt: now.Add(2 * time.Second),
+		},
+	}
+	for _, sn := range snaps {
+		insertTestSnap(t, s, sn)
+	}
+
+	tests := []struct {
+		name      string
+		params    ListSnapshotsParams
+		wantCount int
+	}{
+		{
+			name:      "all snapshots",
+			params:    ListSnapshotsParams{Limit: 50},
+			wantCount: 3,
+		},
+		{
+			name:      "filter by app-001",
+			params:    ListSnapshotsParams{ApplicationID: "app-001", Limit: 50},
+			wantCount: 2,
+		},
+		{
+			name:      "filter by app-002",
+			params:    ListSnapshotsParams{ApplicationID: "app-002", Limit: 50},
+			wantCount: 1,
+		},
+		{
+			name:      "pagination limit",
+			params:    ListSnapshotsParams{Limit: 2},
+			wantCount: 2,
+		},
+		{
+			name:      "pagination offset",
+			params:    ListSnapshotsParams{Limit: 50, Offset: 2},
+			wantCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := s.ListSnapshots(ctx, tt.params)
+			if err != nil {
+				t.Fatalf("ListSnapshots: %v", err)
+			}
+			if len(got) != tt.wantCount {
+				t.Errorf("len(snapshots) = %d, want %d", len(got), tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestListSnapshots_Empty(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	got, err := s.ListSnapshots(ctx, ListSnapshotsParams{Limit: 50})
+	if err != nil {
+		t.Fatalf("ListSnapshots: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil slice for empty result, got %v", got)
+	}
+}
+
+func TestGetLatestSnapshot(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC().Truncate(time.Second)
+
+	app := &Application{
+		ID: "app-001", Name: "Test App", AppType: "test",
+		Collector: "manual", Status: "active", Metadata: "{}",
+		DiscoveredAt: now, UpdatedAt: now,
+	}
+	insertTestApp(t, s, app)
+
+	// Insert multiple snapshots with different timestamps.
+	snaps := []*Snapshot{
+		{
+			ID: "snap-old", ApplicationID: "app-001", ContentHash: "h1",
+			Content: "old config", Format: "json", SizeBytes: 10,
+			Source: "auto", CapturedAt: now.Add(-2 * time.Hour),
+		},
+		{
+			ID: "snap-mid", ApplicationID: "app-001", ContentHash: "h2",
+			Content: "mid config", Format: "json", SizeBytes: 10,
+			Source: "auto", CapturedAt: now.Add(-1 * time.Hour),
+		},
+		{
+			ID: "snap-new", ApplicationID: "app-001", ContentHash: "h3",
+			Content: "new config", Format: "json", SizeBytes: 10,
+			Source: "auto", CapturedAt: now,
+		},
+	}
+	for _, sn := range snaps {
+		insertTestSnap(t, s, sn)
+	}
+
+	got, err := s.GetLatestSnapshot(ctx, "app-001")
+	if err != nil {
+		t.Fatalf("GetLatestSnapshot: %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetLatestSnapshot returned nil, want non-nil")
+	}
+	if got.ID != "snap-new" {
+		t.Errorf("ID = %q, want %q", got.ID, "snap-new")
+	}
+	if got.Content != "new config" {
+		t.Errorf("Content = %q, want %q", got.Content, "new config")
+	}
+}
+
+func TestGetLatestSnapshot_NotFound(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	got, err := s.GetLatestSnapshot(ctx, "nonexistent-app")
+	if err != nil {
+		t.Fatalf("GetLatestSnapshot: %v", err)
+	}
+	if got != nil {
+		t.Errorf("GetLatestSnapshot = %+v, want nil", got)
+	}
+}
+
+func TestDeleteSnapshot(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC().Truncate(time.Second)
+
+	app := &Application{
+		ID: "app-001", Name: "Test App", AppType: "test",
+		Collector: "manual", Status: "active", Metadata: "{}",
+		DiscoveredAt: now, UpdatedAt: now,
+	}
+	insertTestApp(t, s, app)
+
+	snap := &Snapshot{
+		ID: "snap-001", ApplicationID: "app-001", ContentHash: "h1",
+		Content: "config", Format: "json", SizeBytes: 6,
+		Source: "manual", CapturedAt: now,
+	}
+	insertTestSnap(t, s, snap)
+
+	// Verify it exists.
+	got, err := s.GetSnapshot(ctx, "snap-001")
+	if err != nil {
+		t.Fatalf("GetSnapshot before delete: %v", err)
+	}
+	if got == nil {
+		t.Fatal("snapshot should exist before deletion")
+	}
+
+	// Delete it.
+	if err := s.DeleteSnapshot(ctx, "snap-001"); err != nil {
+		t.Fatalf("DeleteSnapshot: %v", err)
+	}
+
+	// Verify it is gone.
+	got, err = s.GetSnapshot(ctx, "snap-001")
+	if err != nil {
+		t.Fatalf("GetSnapshot after delete: %v", err)
+	}
+	if got != nil {
+		t.Errorf("GetSnapshot after delete = %+v, want nil", got)
+	}
+}
+
+func TestCountSnapshots(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC().Truncate(time.Second)
+
+	app := &Application{
+		ID: "app-001", Name: "Test App", AppType: "test",
+		Collector: "manual", Status: "active", Metadata: "{}",
+		DiscoveredAt: now, UpdatedAt: now,
+	}
+	insertTestApp(t, s, app)
+
+	// Count when empty.
+	count, err := s.CountSnapshots(ctx, "app-001")
+	if err != nil {
+		t.Fatalf("CountSnapshots: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("count = %d, want 0", count)
+	}
+
+	// Insert 3 snapshots.
+	for i := 0; i < 3; i++ {
+		snap := &Snapshot{
+			ID: "snap-" + string(rune('a'+i)), ApplicationID: "app-001",
+			ContentHash: "h", Content: "c", Format: "json", SizeBytes: 1,
+			Source: "auto", CapturedAt: now.Add(time.Duration(i) * time.Second),
+		}
+		insertTestSnap(t, s, snap)
+	}
+
+	count, err = s.CountSnapshots(ctx, "app-001")
+	if err != nil {
+		t.Fatalf("CountSnapshots: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("count = %d, want 3", count)
+	}
+}
+
+func TestDeleteOldSnapshots(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC().Truncate(time.Second)
+
+	app := &Application{
+		ID: "app-001", Name: "Test App", AppType: "test",
+		Collector: "manual", Status: "active", Metadata: "{}",
+		DiscoveredAt: now, UpdatedAt: now,
+	}
+	insertTestApp(t, s, app)
+
+	// Insert an old snapshot (48 hours ago).
+	old := &Snapshot{
+		ID: "snap-old", ApplicationID: "app-001", ContentHash: "h1",
+		Content: "old", Format: "json", SizeBytes: 3,
+		Source: "auto", CapturedAt: now.Add(-48 * time.Hour),
+	}
+	insertTestSnap(t, s, old)
+
+	// Insert a recent snapshot (1 hour ago).
+	recent := &Snapshot{
+		ID: "snap-recent", ApplicationID: "app-001", ContentHash: "h2",
+		Content: "recent", Format: "json", SizeBytes: 6,
+		Source: "auto", CapturedAt: now.Add(-1 * time.Hour),
+	}
+	insertTestSnap(t, s, recent)
+
+	// Delete snapshots older than 24 hours.
+	cutoff := now.Add(-24 * time.Hour)
+	deleted, err := s.DeleteOldSnapshots(ctx, cutoff)
+	if err != nil {
+		t.Fatalf("DeleteOldSnapshots: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("deleted = %d, want 1", deleted)
+	}
+
+	// Verify only the recent snapshot remains.
+	remaining, err := s.ListSnapshots(ctx, ListSnapshotsParams{ApplicationID: "app-001", Limit: 50})
+	if err != nil {
+		t.Fatalf("ListSnapshots: %v", err)
+	}
+	if len(remaining) != 1 {
+		t.Fatalf("expected 1 remaining snapshot, got %d", len(remaining))
+	}
+	if remaining[0].ID != "snap-recent" {
+		t.Errorf("remaining snapshot ID = %q, want %q", remaining[0].ID, "snap-recent")
+	}
+}
+
+func TestDeleteOldSnapshots_NoneToDelete(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC().Truncate(time.Second)
+
+	app := &Application{
+		ID: "app-001", Name: "Test App", AppType: "test",
+		Collector: "manual", Status: "active", Metadata: "{}",
+		DiscoveredAt: now, UpdatedAt: now,
+	}
+	insertTestApp(t, s, app)
+
+	// Insert a recent snapshot.
+	snap := &Snapshot{
+		ID: "snap-001", ApplicationID: "app-001", ContentHash: "h1",
+		Content: "config", Format: "json", SizeBytes: 6,
+		Source: "auto", CapturedAt: now,
+	}
+	insertTestSnap(t, s, snap)
+
+	// Delete snapshots older than 24 hours -- none should match.
+	cutoff := now.Add(-24 * time.Hour)
+	deleted, err := s.DeleteOldSnapshots(ctx, cutoff)
+	if err != nil {
+		t.Fatalf("DeleteOldSnapshots: %v", err)
+	}
+	if deleted != 0 {
+		t.Errorf("deleted = %d, want 0", deleted)
+	}
+}
+
+func TestListSnapshots_OrderByCapturedAtDesc(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC().Truncate(time.Second)
+
+	app := &Application{
+		ID: "app-001", Name: "Test App", AppType: "test",
+		Collector: "manual", Status: "active", Metadata: "{}",
+		DiscoveredAt: now, UpdatedAt: now,
+	}
+	insertTestApp(t, s, app)
+
+	// Insert snapshots out of chronological order.
+	snaps := []*Snapshot{
+		{
+			ID: "snap-mid", ApplicationID: "app-001", ContentHash: "h2",
+			Content: "mid", Format: "json", SizeBytes: 3,
+			Source: "auto", CapturedAt: now.Add(-1 * time.Hour),
+		},
+		{
+			ID: "snap-old", ApplicationID: "app-001", ContentHash: "h1",
+			Content: "old", Format: "json", SizeBytes: 3,
+			Source: "auto", CapturedAt: now.Add(-2 * time.Hour),
+		},
+		{
+			ID: "snap-new", ApplicationID: "app-001", ContentHash: "h3",
+			Content: "new", Format: "json", SizeBytes: 3,
+			Source: "auto", CapturedAt: now,
+		},
+	}
+	for _, sn := range snaps {
+		insertTestSnap(t, s, sn)
+	}
+
+	got, err := s.ListSnapshots(ctx, ListSnapshotsParams{ApplicationID: "app-001", Limit: 50})
+	if err != nil {
+		t.Fatalf("ListSnapshots: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("len(snapshots) = %d, want 3", len(got))
+	}
+
+	// Verify DESC order: new, mid, old.
+	if got[0].ID != "snap-new" {
+		t.Errorf("got[0].ID = %q, want %q", got[0].ID, "snap-new")
+	}
+	if got[1].ID != "snap-mid" {
+		t.Errorf("got[1].ID = %q, want %q", got[1].ID, "snap-mid")
+	}
+	if got[2].ID != "snap-old" {
+		t.Errorf("got[2].ID = %q, want %q", got[2].ID, "snap-old")
+	}
+}

--- a/web/src/api/docs.ts
+++ b/web/src/api/docs.ts
@@ -1,0 +1,101 @@
+import { api } from './client'
+
+/**
+ * A tracked application (Docker container, service, etc.)
+ */
+export interface DocsApplication {
+  id: string
+  name: string
+  app_type: string
+  device_id: string
+  collector: string
+  status: string
+  metadata: string
+  discovered_at: string
+  updated_at: string
+}
+
+/**
+ * A point-in-time snapshot of an application's configuration.
+ */
+export interface DocsSnapshot {
+  id: string
+  application_id: string
+  content_hash: string
+  content: string
+  format: string
+  size_bytes: number
+  source: string
+  captured_at: string
+}
+
+/**
+ * Paginated response for listing applications.
+ */
+export interface ListApplicationsResponse {
+  items: DocsApplication[]
+  total: number
+}
+
+/**
+ * List tracked applications with optional filtering.
+ */
+export async function listApplications(params?: {
+  limit?: number
+  offset?: number
+  type?: string
+  status?: string
+}): Promise<ListApplicationsResponse> {
+  const searchParams = new URLSearchParams()
+  if (params?.limit !== undefined) searchParams.set('limit', String(params.limit))
+  if (params?.offset !== undefined) searchParams.set('offset', String(params.offset))
+  if (params?.type) searchParams.set('type', params.type)
+  if (params?.status) searchParams.set('status', params.status)
+
+  const query = searchParams.toString()
+  const path = `/docs/applications${query ? `?${query}` : ''}`
+  return api.get<ListApplicationsResponse>(path)
+}
+
+/**
+ * Get a single application by ID.
+ */
+export async function getApplication(id: string): Promise<DocsApplication> {
+  return api.get<DocsApplication>(`/docs/applications/${id}`)
+}
+
+/**
+ * List snapshots with optional filtering by application.
+ */
+export async function listSnapshots(params?: {
+  application_id?: string
+  limit?: number
+  offset?: number
+}): Promise<DocsSnapshot[]> {
+  const searchParams = new URLSearchParams()
+  if (params?.application_id) searchParams.set('application_id', params.application_id)
+  if (params?.limit !== undefined) searchParams.set('limit', String(params.limit))
+  if (params?.offset !== undefined) searchParams.set('offset', String(params.offset))
+
+  const query = searchParams.toString()
+  const path = `/docs/snapshots${query ? `?${query}` : ''}`
+  return api.get<DocsSnapshot[]>(path)
+}
+
+/**
+ * Get a single snapshot by ID.
+ */
+export async function getSnapshot(id: string): Promise<DocsSnapshot> {
+  return api.get<DocsSnapshot>(`/docs/snapshots/${id}`)
+}
+
+/**
+ * Create a new snapshot for an application.
+ */
+export async function createSnapshot(data: {
+  application_id: string
+  content: string
+  format: string
+}): Promise<DocsSnapshot> {
+  return api.post<DocsSnapshot>('/docs/snapshots', data)
+}

--- a/web/src/layouts/app-layout.tsx
+++ b/web/src/layouts/app-layout.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useMemo } from 'react'
 import { Outlet, NavLink, useNavigate } from 'react-router-dom'
 import { useAuthStore } from '@/stores/auth'
 import { Button } from '@/components/ui/button'
-import { LayoutDashboard, Monitor, Network, Settings, Info, LogOut } from 'lucide-react'
+import { LayoutDashboard, Monitor, Network, FileText, Settings, Info, LogOut } from 'lucide-react'
 import { useKeyboardShortcuts } from '@/hooks/use-keyboard-shortcuts'
 import { KeyboardShortcutsDialog } from '@/components/keyboard-shortcuts-dialog'
 
@@ -10,6 +10,7 @@ const navItems = [
   { to: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
   { to: '/devices', label: 'Devices', icon: Monitor },
   { to: '/topology', label: 'Topology', icon: Network },
+  { to: '/documentation', label: 'Docs', icon: FileText },
   { to: '/settings', label: 'Settings', icon: Settings },
   { to: '/about', label: 'About', icon: Info },
 ]
@@ -24,6 +25,7 @@ export function AppLayout() {
   const goToDashboard = useCallback(() => navigate('/dashboard'), [navigate])
   const goToDevices = useCallback(() => navigate('/devices'), [navigate])
   const goToTopology = useCallback(() => navigate('/topology'), [navigate])
+  const goToDocs = useCallback(() => navigate('/documentation'), [navigate])
   const goToSettings = useCallback(() => navigate('/settings'), [navigate])
 
   const shortcuts = useMemo(
@@ -32,9 +34,10 @@ export function AppLayout() {
       { key: '1', handler: goToDashboard, description: 'Go to Dashboard' },
       { key: '2', handler: goToDevices, description: 'Go to Devices' },
       { key: '3', handler: goToTopology, description: 'Go to Topology' },
-      { key: '4', handler: goToSettings, description: 'Go to Settings' },
+      { key: '4', handler: goToDocs, description: 'Go to Docs' },
+      { key: '5', handler: goToSettings, description: 'Go to Settings' },
     ],
-    [openShortcuts, goToDashboard, goToDevices, goToTopology, goToSettings]
+    [openShortcuts, goToDashboard, goToDevices, goToTopology, goToDocs, goToSettings]
   )
 
   useKeyboardShortcuts(shortcuts)

--- a/web/src/pages/documentation.tsx
+++ b/web/src/pages/documentation.tsx
@@ -1,0 +1,220 @@
+import { useQuery } from '@tanstack/react-query'
+import { FileText, Loader2, RefreshCw, Clock } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { listApplications } from '@/api/docs'
+import type { DocsApplication } from '@/api/docs'
+import { cn } from '@/lib/utils'
+
+const APP_TYPE_LABELS: Record<string, string> = {
+  docker: 'Docker',
+  systemd: 'Systemd',
+  kubernetes: 'Kubernetes',
+  compose: 'Compose',
+  manual: 'Manual',
+}
+
+const STATUS_CONFIG: Record<string, { bg: string; text: string; dot: string }> = {
+  active: { bg: 'bg-green-500/10', text: 'text-green-500', dot: 'bg-green-500' },
+  inactive: { bg: 'bg-gray-500/10', text: 'text-gray-500', dot: 'bg-gray-500' },
+  error: { bg: 'bg-red-500/10', text: 'text-red-500', dot: 'bg-red-500' },
+}
+
+export function DocumentationPage() {
+  const {
+    data,
+    isLoading,
+    error,
+    refetch,
+  } = useQuery({
+    queryKey: ['docs-applications'],
+    queryFn: () => listApplications(),
+  })
+
+  const applications = data?.items ?? []
+  const total = data?.total ?? 0
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Documentation</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Track and version infrastructure configurations
+          </p>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={() => refetch()}
+            disabled={isLoading}
+          >
+            <RefreshCw className={cn('h-4 w-4', isLoading && 'animate-spin')} />
+          </Button>
+        </div>
+      </div>
+
+      {/* Stats */}
+      {!isLoading && !error && applications.length > 0 && (
+        <div className="grid gap-4 sm:grid-cols-3">
+          <Card>
+            <CardContent className="p-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-xs text-muted-foreground">Total Applications</p>
+                  <p className="text-2xl font-bold mt-1">{total}</p>
+                </div>
+                <div className="p-2.5 rounded-lg bg-muted/50">
+                  <FileText className="h-5 w-5 text-muted-foreground" />
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="p-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-xs text-muted-foreground">Active</p>
+                  <p className="text-2xl font-bold mt-1">
+                    {applications.filter((a) => a.status === 'active').length}
+                  </p>
+                </div>
+                <div className="p-2.5 rounded-lg bg-green-500/10">
+                  <FileText className="h-5 w-5 text-green-600 dark:text-green-400" />
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="p-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-xs text-muted-foreground">Inactive</p>
+                  <p className="text-2xl font-bold mt-1">
+                    {applications.filter((a) => a.status === 'inactive').length}
+                  </p>
+                </div>
+                <div className="p-2.5 rounded-lg bg-gray-500/10">
+                  <FileText className="h-5 w-5 text-gray-600 dark:text-gray-400" />
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      {/* Error state */}
+      {error && (
+        <div className="rounded-lg border border-red-500/50 bg-red-500/10 p-4">
+          <p className="text-sm text-red-400">
+            {error instanceof Error ? error.message : 'Failed to load applications'}
+          </p>
+          <Button variant="outline" size="sm" onClick={() => refetch()} className="mt-2">
+            Try Again
+          </Button>
+        </div>
+      )}
+
+      {/* Loading state */}
+      {isLoading && !error && (
+        <div className="flex items-center justify-center py-16">
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!isLoading && !error && applications.length === 0 && (
+        <Card>
+          <CardContent className="py-16">
+            <div className="text-center">
+              <FileText className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+              <h3 className="text-lg font-medium">No applications tracked yet</h3>
+              <p className="text-sm text-muted-foreground mt-2 max-w-md mx-auto">
+                Applications will appear here when collectors discover Docker containers
+                and other services on your network.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Application cards */}
+      {!isLoading && !error && applications.length > 0 && (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {applications.map((app) => (
+            <ApplicationCard key={app.id} application={app} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ApplicationCard({ application }: { application: DocsApplication }) {
+  const statusStyle = STATUS_CONFIG[application.status] ?? STATUS_CONFIG.inactive
+  const typeLabel = APP_TYPE_LABELS[application.app_type] ?? application.app_type
+
+  return (
+    <Card className="hover:border-green-500/50 transition-colors">
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between">
+          <CardTitle className="text-sm font-medium truncate">
+            {application.name}
+          </CardTitle>
+          <span
+            className={cn(
+              'inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-xs shrink-0',
+              statusStyle.bg,
+              statusStyle.text,
+            )}
+          >
+            <span className={cn('h-1.5 w-1.5 rounded-full', statusStyle.dot)} />
+            <span className="capitalize">{application.status}</span>
+          </span>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-2 text-sm">
+          <div className="flex items-center justify-between">
+            <span className="text-muted-foreground">Type</span>
+            <span className="px-2 py-0.5 rounded bg-muted text-xs font-medium">
+              {typeLabel}
+            </span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-muted-foreground">Collector</span>
+            <span className="text-xs font-mono">{application.collector}</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-muted-foreground">Updated</span>
+            <span className="flex items-center gap-1 text-xs text-muted-foreground">
+              <Clock className="h-3 w-3" />
+              {formatRelativeTime(application.updated_at)}
+            </span>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function formatRelativeTime(dateStr: string): string {
+  try {
+    const date = new Date(dateStr)
+    const now = new Date()
+    const diffMs = now.getTime() - date.getTime()
+    const diffMins = Math.floor(diffMs / 60000)
+    const diffHours = Math.floor(diffMins / 60)
+    const diffDays = Math.floor(diffHours / 24)
+
+    if (diffMins < 1) return 'Just now'
+    if (diffMins < 60) return `${diffMins}m ago`
+    if (diffHours < 24) return `${diffHours}h ago`
+    return `${diffDays}d ago`
+  } catch {
+    return dateStr
+  }
+}

--- a/web/src/router/index.tsx
+++ b/web/src/router/index.tsx
@@ -10,6 +10,7 @@ import { DeviceDetailPage } from '@/pages/devices/[id]'
 import { SettingsPage } from '@/pages/settings'
 import { AboutPage } from '@/pages/about'
 import { TopologyPage } from '@/pages/topology'
+import { DocumentationPage } from '@/pages/documentation'
 import { NotFoundPage } from '@/pages/not-found'
 
 export const router = createBrowserRouter([
@@ -31,6 +32,7 @@ export const router = createBrowserRouter([
           { path: '/devices', element: <DevicesPage /> },
           { path: '/devices/:id', element: <DeviceDetailPage /> },
           { path: '/topology', element: <TopologyPage /> },
+          { path: '/documentation', element: <DocumentationPage /> },
           { path: '/settings', element: <SettingsPage /> },
           { path: '/about', element: <AboutPage /> },
         ],


### PR DESCRIPTION
## Summary

- Add `internal/docs/` plugin module with CRUD operations for applications and snapshots (PR1 of Epic #132)
- Create SQLite schema (`docs_applications`, `docs_snapshots`) with filtering, pagination, and retention
- Add Dashboard Documentation tab with application inventory cards, status badges, and TanStack Query integration
- 48 Go tests covering plugin contract, store operations, and HTTP handlers

## Details

**Backend** (10 Go files):
- Plugin lifecycle: Info, Init, Start, Stop, Health, Routes
- 5 REST endpoints: list/get applications, list/get/create snapshots
- Collector interface defined for future Docker/systemd implementations
- Background maintenance worker for snapshot retention cleanup
- Event bus publishes `docs.snapshot.created` on new snapshots

**Frontend** (3 files created, 2 modified):
- `documentation.tsx`: Card grid with stats, status/type badges, relative timestamps
- `docs.ts`: API client with typed functions
- Nav item with `FileText` icon, keyboard shortcut `4`

**Database schema**:
- `docs_applications`: id, name, app_type, device_id, collector, status, metadata, timestamps
- `docs_snapshots`: id, application_id, content_hash, content, format, size_bytes, source, captured_at

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go vet ./...` passes
- [x] `go test ./internal/docs/...` -- 48 tests pass
- [x] `pnpm run lint` -- zero errors, zero warnings
- [x] `pnpm run build` -- frontend builds successfully
- [ ] CI passes (Go build, lint, test, frontend build)

Closes #132 partially (PR1 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)