### PR TITLE
docs: update roadmap for completed #132 and #162

### DIFF
--- a/docs/requirements/21-phased-roadmap.md
+++ b/docs/requirements/21-phased-roadmap.md
@@ -68,7 +68,7 @@
 
 ### Phase 1: Foundation (Server + Dashboard + Discovery + Topology)
 
-**Status:** v0.2.0 shipped 2026-02-08. All core modules implemented: Recon, Pulse, Insight, LLM, Vault, Gateway. Dashboard polish and Tailscale guides complete.
+**Status:** v0.2.0 shipped 2026-02-08. All core modules implemented: Recon, Pulse, Insight, LLM, Vault, Gateway. Dashboard polish and Tailscale guides complete. Post-release: Docs module (#132), Device CRUD (#162), modular themes (#158).
 
 **Goal:** Functional web-based network scanner with topology visualization. Validate architecture. Time to First Value under 10 minutes.
 
@@ -234,10 +234,19 @@
 
 #### Device Management API (#162)
 
-- [ ] Device CRUD endpoints: GET/PUT/DELETE `/devices/{id}`, POST `/devices`
-- [ ] Manual device creation (`discovery_method = "manual"`)
+- [x] Device CRUD endpoints: GET/PUT/DELETE `/devices/{id}`, POST `/devices`
+- [x] Manual device creation (`discovery_method = "manual"`)
 - [ ] Device status history table and endpoint
 - [ ] Wire frontend device pages to backend (list, detail, edit, delete)
+
+#### Infrastructure Documentation (#132)
+
+- [x] Docs plugin module with application + snapshot CRUD (`internal/docs/`)
+- [x] Docker collector: container discovery and config capture (cross-platform)
+- [x] Snapshot history browsing and LCS-based config diffing
+- [x] Background retention maintenance worker
+- [x] Dashboard Documentation tab with timeline, diff viewer, collector controls
+- [ ] Additional collectors: systemd, Home Assistant, Plex (future)
 
 ### Phase 2: Core Monitoring + Multi-Tenancy
 


### PR DESCRIPTION
## Summary

- Update Phase 1 status line with post-release work (Docs module, Device CRUD, modular themes)
- Mark Device CRUD endpoints and manual device creation as complete in Phase 1b
- Add Infrastructure Documentation (#132) section with 5 completed items

## Test plan

- [x] No code changes, docs only
- [x] Markdown passes lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)