### PR TITLE
feat: wire frontend device pages to backend CRUD API

### DIFF
--- a/web/src/api/devices.ts
+++ b/web/src/api/devices.ts
@@ -1,5 +1,5 @@
 import { api } from './client'
-import type { TopologyGraph, Scan, Device } from './types'
+import type { TopologyGraph, Scan, Device, DeviceType } from './types'
 
 /**
  * Fetch the network topology (devices + connections).
@@ -16,13 +16,72 @@ export async function getDevice(id: string): Promise<Device> {
 }
 
 /**
- * Update device notes and tags.
+ * Update device fields (notes, tags, custom_fields, device_type).
  */
 export async function updateDevice(
   id: string,
-  data: { notes?: string; tags?: string[] }
+  data: { notes?: string; tags?: string[]; custom_fields?: Record<string, string>; device_type?: DeviceType }
 ): Promise<Device> {
   return api.put<Device>(`/recon/devices/${id}`, data)
+}
+
+/**
+ * Request body for creating a new device.
+ */
+export interface CreateDeviceRequest {
+  hostname: string
+  ip_addresses: string[]
+  mac_address?: string
+  device_type?: DeviceType
+  notes?: string
+  tags?: string[]
+}
+
+/**
+ * Paginated device list response.
+ */
+export interface DeviceListResponse {
+  devices: Device[]
+  total: number
+  limit: number
+  offset: number
+}
+
+/**
+ * Parameters for listing devices.
+ */
+export interface ListDevicesParams {
+  limit?: number
+  offset?: number
+  status?: string
+  type?: string
+}
+
+/**
+ * List devices with optional filters and pagination.
+ */
+export async function listDevices(params: ListDevicesParams = {}): Promise<DeviceListResponse> {
+  const searchParams = new URLSearchParams()
+  if (params.limit !== undefined) searchParams.set('limit', String(params.limit))
+  if (params.offset !== undefined) searchParams.set('offset', String(params.offset))
+  if (params.status && params.status !== 'all') searchParams.set('status', params.status)
+  if (params.type && params.type !== 'all') searchParams.set('type', params.type)
+  const query = searchParams.toString()
+  return api.get<DeviceListResponse>(`/recon/devices${query ? `?${query}` : ''}`)
+}
+
+/**
+ * Create a new device.
+ */
+export async function createDevice(data: CreateDeviceRequest): Promise<Device> {
+  return api.post<Device>('/recon/devices', data)
+}
+
+/**
+ * Delete a device by ID.
+ */
+export async function deleteDevice(id: string): Promise<void> {
+  return api.delete<void>(`/recon/devices/${id}`)
 }
 
 /**

--- a/web/src/components/create-device-dialog.tsx
+++ b/web/src/components/create-device-dialog.tsx
@@ -1,0 +1,294 @@
+import { useState, useEffect, useRef } from 'react'
+import { createPortal } from 'react-dom'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { X, Plus, Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { createDevice } from '@/api/devices'
+import type { DeviceType } from '@/api/types'
+
+interface CreateDeviceDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+const DEVICE_TYPE_OPTIONS: { value: DeviceType; label: string }[] = [
+  { value: 'server', label: 'Server' },
+  { value: 'desktop', label: 'Desktop' },
+  { value: 'laptop', label: 'Laptop' },
+  { value: 'mobile', label: 'Mobile' },
+  { value: 'router', label: 'Router' },
+  { value: 'switch', label: 'Switch' },
+  { value: 'access_point', label: 'Access Point' },
+  { value: 'firewall', label: 'Firewall' },
+  { value: 'printer', label: 'Printer' },
+  { value: 'nas', label: 'NAS' },
+  { value: 'iot', label: 'IoT' },
+  { value: 'phone', label: 'Phone' },
+  { value: 'tablet', label: 'Tablet' },
+  { value: 'camera', label: 'Camera' },
+  { value: 'unknown', label: 'Unknown' },
+]
+
+export function CreateDeviceDialog({ open, onOpenChange }: CreateDeviceDialogProps) {
+  const queryClient = useQueryClient()
+  const dialogRef = useRef<HTMLDivElement>(null)
+
+  const [hostname, setHostname] = useState('')
+  const [ipAddresses, setIpAddresses] = useState('')
+  const [macAddress, setMacAddress] = useState('')
+  const [deviceType, setDeviceType] = useState<DeviceType>('unknown')
+  const [notes, setNotes] = useState('')
+  const [tags, setTags] = useState('')
+  const [validationError, setValidationError] = useState('')
+
+  const createMutation = useMutation({
+    mutationFn: createDevice,
+    onSuccess: (device) => {
+      queryClient.invalidateQueries({ queryKey: ['devices'] })
+      queryClient.invalidateQueries({ queryKey: ['topology'] })
+      toast.success(`Device "${device.hostname}" created`)
+      resetForm()
+      onOpenChange(false)
+    },
+    onError: (err) => {
+      toast.error(err instanceof Error ? err.message : 'Failed to create device')
+    },
+  })
+
+  function resetForm() {
+    setHostname('')
+    setIpAddresses('')
+    setMacAddress('')
+    setDeviceType('unknown')
+    setNotes('')
+    setTags('')
+    setValidationError('')
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setValidationError('')
+
+    if (!hostname.trim()) {
+      setValidationError('Hostname is required')
+      return
+    }
+
+    const ips = ipAddresses
+      .split(',')
+      .map((ip) => ip.trim())
+      .filter((ip) => ip.length > 0)
+
+    const tagList = tags
+      .split(',')
+      .map((t) => t.trim())
+      .filter((t) => t.length > 0)
+
+    createMutation.mutate({
+      hostname: hostname.trim(),
+      ip_addresses: ips,
+      mac_address: macAddress.trim() || undefined,
+      device_type: deviceType,
+      notes: notes.trim() || undefined,
+      tags: tagList.length > 0 ? tagList : undefined,
+    })
+  }
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onOpenChange(false)
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [open, onOpenChange])
+
+  // Prevent body scroll and focus dialog when open
+  useEffect(() => {
+    if (!open) return
+
+    const prevOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+
+    requestAnimationFrame(() => {
+      dialogRef.current?.focus()
+    })
+
+    return () => {
+      document.body.style.overflow = prevOverflow
+    }
+  }, [open])
+
+  // Reset form when dialog closes
+  useEffect(() => {
+    if (!open) {
+      resetForm()
+    }
+  }, [open])
+
+  if (!open) return null
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Create device"
+    >
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={() => onOpenChange(false)}
+      />
+
+      {/* Dialog content */}
+      <div
+        ref={dialogRef}
+        tabIndex={-1}
+        className="relative z-50 w-full max-w-lg rounded-lg border bg-card p-6 shadow-lg outline-none max-h-[90vh] overflow-y-auto"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between mb-6">
+          <div>
+            <h2 className="text-lg font-semibold">Add Device</h2>
+            <p className="text-sm text-muted-foreground mt-0.5">
+              Manually register a device on your network.
+            </p>
+          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            onClick={() => onOpenChange(false)}
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+
+        {/* Form */}
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {/* Hostname */}
+          <div className="space-y-2">
+            <Label htmlFor="hostname">
+              Hostname <span className="text-red-500">*</span>
+            </Label>
+            <Input
+              id="hostname"
+              placeholder="e.g., nas-01, pi-hole, proxmox-node"
+              value={hostname}
+              onChange={(e) => setHostname(e.target.value)}
+              autoFocus
+            />
+          </div>
+
+          {/* IP Addresses */}
+          <div className="space-y-2">
+            <Label htmlFor="ip-addresses">IP Addresses</Label>
+            <Input
+              id="ip-addresses"
+              placeholder="e.g., 192.168.1.100, 10.0.0.5"
+              value={ipAddresses}
+              onChange={(e) => setIpAddresses(e.target.value)}
+            />
+            <p className="text-xs text-muted-foreground">
+              Separate multiple addresses with commas.
+            </p>
+          </div>
+
+          {/* MAC Address */}
+          <div className="space-y-2">
+            <Label htmlFor="mac-address">MAC Address</Label>
+            <Input
+              id="mac-address"
+              placeholder="e.g., AA:BB:CC:DD:EE:FF"
+              value={macAddress}
+              onChange={(e) => setMacAddress(e.target.value)}
+            />
+          </div>
+
+          {/* Device Type */}
+          <div className="space-y-2">
+            <Label htmlFor="device-type">Device Type</Label>
+            <select
+              id="device-type"
+              value={deviceType}
+              onChange={(e) => setDeviceType(e.target.value as DeviceType)}
+              className="w-full h-9 px-3 rounded-md border bg-background text-sm"
+            >
+              {DEVICE_TYPE_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Notes */}
+          <div className="space-y-2">
+            <Label htmlFor="notes">Notes</Label>
+            <textarea
+              id="notes"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              className="w-full min-h-[80px] p-3 rounded-md border bg-background text-sm resize-y"
+              placeholder="Optional notes about this device..."
+            />
+          </div>
+
+          {/* Tags */}
+          <div className="space-y-2">
+            <Label htmlFor="tags">Tags</Label>
+            <Input
+              id="tags"
+              placeholder="e.g., production, critical, lab"
+              value={tags}
+              onChange={(e) => setTags(e.target.value)}
+            />
+            <p className="text-xs text-muted-foreground">
+              Separate tags with commas.
+            </p>
+          </div>
+
+          {/* Validation error */}
+          {validationError && (
+            <p className="text-sm text-red-500">{validationError}</p>
+          )}
+
+          {/* Actions */}
+          <div className="flex items-center justify-end gap-2 pt-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={createMutation.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={createMutation.isPending}
+              className="gap-2"
+            >
+              {createMutation.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Plus className="h-4 w-4" />
+              )}
+              {createMutation.isPending ? 'Creating...' : 'Create Device'}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/web/src/components/device-card.tsx
+++ b/web/src/components/device-card.tsx
@@ -19,7 +19,7 @@ import {
 } from 'lucide-react'
 import { Card, CardContent } from '@/components/ui/card'
 import { cn } from '@/lib/utils'
-import type { TopologyNode, DeviceType, DeviceStatus } from '@/api/types'
+import type { TopologyNode, Device, DeviceType, DeviceStatus } from '@/api/types'
 
 // Map device types to icons
 const deviceTypeIcons: Record<DeviceType, LucideIcon> = {
@@ -83,9 +83,19 @@ const statusColors: Record<DeviceStatus, { bg: string; text: string; dot: string
   },
 }
 
+/** Common device shape accepted by card components. Works with both TopologyNode and Device. */
+type DeviceCardDevice = TopologyNode | Device
+
 interface DeviceCardProps {
-  device: TopologyNode
+  device: DeviceCardDevice
   className?: string
+}
+
+/** Get display name from either TopologyNode.label or Device.hostname. */
+function getDeviceName(device: DeviceCardDevice): string {
+  if ('label' in device && device.label) return device.label
+  if ('hostname' in device && device.hostname) return device.hostname
+  return 'Unnamed Device'
 }
 
 export function DeviceCard({ device, className }: DeviceCardProps) {
@@ -126,8 +136,8 @@ export function DeviceCard({ device, className }: DeviceCardProps) {
           </div>
 
           {/* Device name */}
-          <h3 className="font-semibold text-sm truncate mb-1" title={device.label}>
-            {device.label || 'Unnamed Device'}
+          <h3 className="font-semibold text-sm truncate mb-1" title={getDeviceName(device)}>
+            {getDeviceName(device)}
           </h3>
 
           {/* IP Address */}
@@ -173,7 +183,7 @@ export function DeviceCardCompact({ device, className }: DeviceCardProps) {
 
           {/* Name + IP */}
           <div className="min-w-0 flex-1">
-            <p className="text-sm font-medium truncate">{device.label || 'Unnamed'}</p>
+            <p className="text-sm font-medium truncate">{getDeviceName(device)}</p>
             <p className="text-xs text-muted-foreground font-mono truncate">{primaryIp}</p>
           </div>
 


### PR DESCRIPTION
## Summary

- Add `createDevice()`, `deleteDevice()`, `listDevices()` to frontend API client
- Switch device list page from topology endpoint to dedicated `/recon/devices` endpoint with server-side pagination and filtering
- Add "Add Device" button with full create dialog (hostname, IPs, MAC, device type, notes, tags)
- Add delete action per device in list view + delete button on detail page, both with confirmation dialogs
- Add device type editing (dropdown) on detail page
- Toast notifications for all CRUD operations
- Update `DeviceCard` to handle both `TopologyNode` and `Device` types

Completes the remaining frontend items from #162.

## Test plan

- [ ] TypeScript compiles (`npx tsc --noEmit`)
- [ ] ESLint passes (`pnpm run lint`)
- [ ] Frontend builds (`pnpm run build`)
- [ ] Verify device list loads from `/recon/devices` endpoint
- [ ] Verify "Add Device" creates a manual device
- [ ] Verify delete removes device with confirmation
- [ ] Verify device type edit saves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)