### PR TITLE
test: set up Playwright E2E test infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,9 @@ web/node_modules/
 web/dist/
 web/.env
 web/coverage/
+web/test-results/
+web/playwright-report/
+web/blob-report/
 *.tsbuildinfo
 
 # Embedded dashboard build (copied from web/dist/)

--- a/web/e2e/auth.spec.ts
+++ b/web/e2e/auth.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Authentication', () => {
+  test('login page renders the sign-in form', async ({ page }) => {
+    await page.goto('/login')
+
+    // Verify the heading is visible
+    await expect(page.getByText('Sign in to SubNetree')).toBeVisible()
+
+    // Verify form fields exist
+    await expect(page.getByLabel('Username')).toBeVisible()
+    await expect(page.getByLabel('Password')).toBeVisible()
+
+    // Verify submit button
+    await expect(page.getByRole('button', { name: 'Sign in' })).toBeVisible()
+  })
+
+  test('login page shows the SubNetree logo', async ({ page }) => {
+    await page.goto('/login')
+    await expect(page.getByAlt('SubNetree')).toBeVisible()
+  })
+
+  test('login page shows description text', async ({ page }) => {
+    await page.goto('/login')
+    await expect(
+      page.getByText('Enter your credentials to access the dashboard.')
+    ).toBeVisible()
+  })
+
+  test('submitting empty form shows browser validation', async ({ page }) => {
+    await page.goto('/login')
+
+    // Both fields have the "required" attribute, so the browser prevents
+    // submission before our JS handler runs. Verify the fields are required.
+    const usernameInput = page.getByLabel('Username')
+    const passwordInput = page.getByLabel('Password')
+
+    await expect(usernameInput).toHaveAttribute('required', '')
+    await expect(passwordInput).toHaveAttribute('required', '')
+  })
+
+  test('invalid credentials show error message', async ({ page }) => {
+    await page.goto('/login')
+
+    await page.getByLabel('Username').fill('nonexistent_user')
+    await page.getByLabel('Password').fill('wrong_password')
+    await page.getByRole('button', { name: 'Sign in' }).click()
+
+    // The login API call should fail and display an error alert
+    const errorAlert = page.getByRole('alert')
+    await expect(errorAlert).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('password visibility toggle works', async ({ page }) => {
+    await page.goto('/login')
+
+    const passwordInput = page.getByLabel('Password')
+    await passwordInput.fill('secret123')
+
+    // Initially the password is hidden
+    await expect(passwordInput).toHaveAttribute('type', 'password')
+
+    // Click the show password button
+    await page.getByLabel('Show password').click()
+    await expect(passwordInput).toHaveAttribute('type', 'text')
+
+    // Click again to hide
+    await page.getByLabel('Hide password').click()
+    await expect(passwordInput).toHaveAttribute('type', 'password')
+  })
+})

--- a/web/e2e/health.spec.ts
+++ b/web/e2e/health.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Health - Smoke tests', () => {
+  test('page loads without crashing', async ({ page }) => {
+    const response = await page.goto('/')
+    expect(response?.status()).toBeLessThan(500)
+  })
+
+  test('root redirects to /login when unauthenticated', async ({ page }) => {
+    await page.goto('/')
+    // The ProtectedRoute component redirects unauthenticated users to /login
+    await expect(page).toHaveURL(/\/login/)
+  })
+
+  test('page has a title', async ({ page }) => {
+    await page.goto('/')
+    await expect(page).toHaveTitle(/.+/)
+  })
+})

--- a/web/e2e/navigation.spec.ts
+++ b/web/e2e/navigation.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Navigation - Unauthenticated', () => {
+  test('accessing /dashboard redirects to /login', async ({ page }) => {
+    await page.goto('/dashboard')
+    await expect(page).toHaveURL(/\/login/)
+  })
+
+  test('accessing /devices redirects to /login', async ({ page }) => {
+    await page.goto('/devices')
+    await expect(page).toHaveURL(/\/login/)
+  })
+
+  test('accessing /topology redirects to /login', async ({ page }) => {
+    await page.goto('/topology')
+    await expect(page).toHaveURL(/\/login/)
+  })
+
+  test('accessing /settings redirects to /login', async ({ page }) => {
+    await page.goto('/settings')
+    await expect(page).toHaveURL(/\/login/)
+  })
+
+  test('accessing /about redirects to /login', async ({ page }) => {
+    await page.goto('/about')
+    await expect(page).toHaveURL(/\/login/)
+  })
+
+  test('non-existent route shows not-found page', async ({ page }) => {
+    await page.goto('/this-page-does-not-exist')
+    // The NotFoundPage should render for unmatched routes
+    // Checking that we did NOT get redirected to /login (it's a catch-all route, not protected)
+    await expect(page).not.toHaveURL(/\/login/)
+  })
+})
+
+test.describe('Navigation - Login page', () => {
+  test('login page is accessible without authentication', async ({ page }) => {
+    const response = await page.goto('/login')
+    expect(response?.status()).toBe(200)
+  })
+
+  test('setup page is accessible without authentication', async ({ page }) => {
+    const response = await page.goto('/setup')
+    expect(response?.status()).toBe(200)
+  })
+})

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,9 @@
     "type-check": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "engines": {
     "node": ">=20.0.0"
@@ -38,6 +40,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
+    "@playwright/test": "^1.58.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,58 @@
+import { defineConfig, devices } from '@playwright/test'
+
+/**
+ * Playwright E2E test configuration for SubNetree Dashboard.
+ *
+ * Run tests:   pnpm test:e2e
+ * UI mode:     pnpm test:e2e:ui
+ * Debug:       npx playwright test --debug
+ */
+export default defineConfig({
+  testDir: './e2e',
+  outputDir: './test-results',
+
+  /* Fail the build on CI if you accidentally left test.only in the source code */
+  forbidOnly: !!process.env.CI,
+
+  /* Retry once in CI, never locally */
+  retries: process.env.CI ? 1 : 0,
+
+  /* Single worker in CI for stability, parallel locally */
+  workers: process.env.CI ? 1 : undefined,
+
+  /* Reporter: list for CI, html for local debugging */
+  reporter: process.env.CI ? 'list' : 'html',
+
+  /* Shared settings for all tests */
+  use: {
+    baseURL: 'http://localhost:5173',
+
+    /* Collect trace on first retry for debugging CI failures */
+    trace: 'on-first-retry',
+
+    /* Screenshot on failure */
+    screenshot: 'only-on-failure',
+
+    /* Action timeout: 10 seconds */
+    actionTimeout: 10_000,
+  },
+
+  /* Test timeout: 30 seconds */
+  timeout: 30_000,
+
+  /* Chromium only for speed */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  /* Start Vite dev server before running tests */
+  webServer: {
+    command: 'pnpm dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 30_000,
+  },
+})

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@eslint/js':
         specifier: ^9.39.2
         version: 9.39.2
+      '@playwright/test':
+        specifier: ^1.58.2
+        version: 1.58.2
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -522,6 +525,11 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@playwright/test@1.58.2':
+    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
@@ -1445,6 +1453,11 @@ packages:
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1947,6 +1960,16 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  playwright-core@1.58.2:
+    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.58.2:
+    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -2883,6 +2906,10 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@playwright/test@1.58.2':
+    dependencies:
+      playwright: 1.58.2
 
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.10)(react@19.2.4)':
     dependencies:
@@ -3922,6 +3949,9 @@ snapshots:
 
   fraction.js@5.3.4: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -4434,6 +4464,14 @@ snapshots:
   pify@2.3.0: {}
 
   pirates@4.0.7: {}
+
+  playwright-core@1.58.2: {}
+
+  playwright@1.58.2:
+    dependencies:
+      playwright-core: 1.58.2
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 


### PR DESCRIPTION
## Summary

- Add Playwright with Chromium-only config for fast E2E browser testing
- Create 17 tests across 3 spec files:
  - **health.spec.ts**: Page loads, unauthenticated redirect, page title
  - **auth.spec.ts**: Login form rendering, required attributes, invalid credentials, password toggle
  - **navigation.spec.ts**: Protected route redirects, public route access, 404 handling
- Auto-starts Vite dev server before tests, captures screenshots/traces on failure
- Add `pnpm test:e2e` and `pnpm test:e2e:ui` scripts

Closes #95

## Test plan

- [x] `npx playwright test --list` discovers 17 tests
- [x] `npx tsc --noEmit` passes (e2e/ excluded from app tsconfig)
- [ ] Manual: `pnpm test:e2e` runs with backend server available

🤖 Generated with [Claude Code](https://claude.com/claude-code)