### PR TITLE
feat: agent dashboard API types and list page

### DIFF
--- a/web/src/api/agents.ts
+++ b/web/src/api/agents.ts
@@ -1,0 +1,61 @@
+import { api } from './client'
+import type {
+  AgentInfo,
+  CreateEnrollmentTokenRequest,
+  EnrollmentTokenResponse,
+  HardwareProfile,
+  SoftwareInventory,
+  ServiceInfo,
+} from './types'
+
+/**
+ * List all registered Scout agents.
+ */
+export async function listAgents(): Promise<AgentInfo[]> {
+  return api.get<AgentInfo[]>('/dispatch/agents')
+}
+
+/**
+ * Get a single agent by ID.
+ */
+export async function getAgent(id: string): Promise<AgentInfo> {
+  return api.get<AgentInfo>(`/dispatch/agents/${id}`)
+}
+
+/**
+ * Delete an agent by ID.
+ */
+export async function deleteAgent(id: string): Promise<void> {
+  return api.delete<void>(`/dispatch/agents/${id}`)
+}
+
+/**
+ * Create a new enrollment token for agent registration.
+ * The raw token is only returned once in the response.
+ */
+export async function createEnrollmentToken(
+  req: CreateEnrollmentTokenRequest
+): Promise<EnrollmentTokenResponse> {
+  return api.post<EnrollmentTokenResponse>('/dispatch/enroll', req)
+}
+
+/**
+ * Get hardware profile for an agent.
+ */
+export async function getAgentHardware(id: string): Promise<HardwareProfile> {
+  return api.get<HardwareProfile>(`/dispatch/agents/${id}/hardware`)
+}
+
+/**
+ * Get software inventory for an agent.
+ */
+export async function getAgentSoftware(id: string): Promise<SoftwareInventory> {
+  return api.get<SoftwareInventory>(`/dispatch/agents/${id}/software`)
+}
+
+/**
+ * Get running services for an agent.
+ */
+export async function getAgentServices(id: string): Promise<ServiceInfo[]> {
+  return api.get<ServiceInfo[]>(`/dispatch/agents/${id}/services`)
+}

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -183,3 +183,111 @@ export interface ScanCompletedData {
 export interface ScanErrorData {
   error: string
 }
+
+// ============================================================================
+// Agent Types
+// ============================================================================
+
+/** Agent connection status. */
+export type AgentStatus = 'pending' | 'connected' | 'disconnected'
+
+/** Registered Scout agent as returned by the Dispatch module. */
+export interface AgentInfo {
+  id: string
+  hostname: string
+  platform: string
+  agent_version: string
+  proto_version: number
+  device_id: string
+  status: AgentStatus
+  last_check_in?: string
+  enrolled_at: string
+  cert_serial: string
+  cert_expires_at?: string
+  config_json: string
+}
+
+/** Request body for creating an enrollment token. */
+export interface CreateEnrollmentTokenRequest {
+  description: string
+  max_uses?: number
+  expires_in?: string
+}
+
+/** Response from creating an enrollment token (raw token only returned once). */
+export interface EnrollmentTokenResponse {
+  id: string
+  token: string
+  expires_at?: string
+  max_uses: number
+}
+
+/** Hardware profile reported by Scout agent. */
+export interface HardwareProfile {
+  cpu_model: string
+  cpu_cores: number
+  cpu_threads: number
+  ram_bytes: number
+  disks: DiskInfo[]
+  gpus: GPUInfo[]
+  nics: NICInfo[]
+  bios_version: string
+  system_manufacturer: string
+  system_model: string
+  serial_number: string
+}
+
+export interface DiskInfo {
+  name: string
+  size_bytes: number
+  disk_type: string
+  model: string
+  serial: string
+}
+
+export interface GPUInfo {
+  model: string
+  vram_bytes: number
+  driver_version: string
+}
+
+export interface NICInfo {
+  name: string
+  speed_mbps: number
+  mac_address: string
+  nic_type: string
+}
+
+/** Software inventory reported by Scout agent. */
+export interface SoftwareInventory {
+  os_name: string
+  os_version: string
+  os_build: string
+  packages: InstalledPackage[]
+  docker_containers: DockerContainer[]
+}
+
+export interface InstalledPackage {
+  name: string
+  version: string
+  publisher: string
+  install_date: string
+}
+
+export interface DockerContainer {
+  container_id: string
+  name: string
+  image: string
+  status: string
+}
+
+/** Service information reported by Scout agent. */
+export interface ServiceInfo {
+  name: string
+  display_name: string
+  status: string
+  start_type: string
+  cpu_percent: number
+  memory_bytes: number
+  ports: number[]
+}

--- a/web/src/components/keyboard-shortcuts-dialog.tsx
+++ b/web/src/components/keyboard-shortcuts-dialog.tsx
@@ -20,7 +20,9 @@ const sections: { title: string; shortcuts: ShortcutEntry[] }[] = [
       { keys: ['1'], action: 'Dashboard' },
       { keys: ['2'], action: 'Devices' },
       { keys: ['3'], action: 'Topology' },
-      { keys: ['4'], action: 'Settings' },
+      { keys: ['4'], action: 'Agents' },
+      { keys: ['5'], action: 'Docs' },
+      { keys: ['6'], action: 'Settings' },
     ],
   },
   {

--- a/web/src/layouts/app-layout.tsx
+++ b/web/src/layouts/app-layout.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useMemo } from 'react'
 import { Outlet, NavLink, useNavigate } from 'react-router-dom'
 import { useAuthStore } from '@/stores/auth'
 import { Button } from '@/components/ui/button'
-import { LayoutDashboard, Monitor, Network, FileText, Settings, Info, LogOut } from 'lucide-react'
+import { LayoutDashboard, Monitor, Network, Bot, FileText, Settings, Info, LogOut } from 'lucide-react'
 import { useKeyboardShortcuts } from '@/hooks/use-keyboard-shortcuts'
 import { KeyboardShortcutsDialog } from '@/components/keyboard-shortcuts-dialog'
 
@@ -10,6 +10,7 @@ const navItems = [
   { to: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
   { to: '/devices', label: 'Devices', icon: Monitor },
   { to: '/topology', label: 'Topology', icon: Network },
+  { to: '/agents', label: 'Agents', icon: Bot },
   { to: '/documentation', label: 'Docs', icon: FileText },
   { to: '/settings', label: 'Settings', icon: Settings },
   { to: '/about', label: 'About', icon: Info },
@@ -25,6 +26,7 @@ export function AppLayout() {
   const goToDashboard = useCallback(() => navigate('/dashboard'), [navigate])
   const goToDevices = useCallback(() => navigate('/devices'), [navigate])
   const goToTopology = useCallback(() => navigate('/topology'), [navigate])
+  const goToAgents = useCallback(() => navigate('/agents'), [navigate])
   const goToDocs = useCallback(() => navigate('/documentation'), [navigate])
   const goToSettings = useCallback(() => navigate('/settings'), [navigate])
 
@@ -34,10 +36,11 @@ export function AppLayout() {
       { key: '1', handler: goToDashboard, description: 'Go to Dashboard' },
       { key: '2', handler: goToDevices, description: 'Go to Devices' },
       { key: '3', handler: goToTopology, description: 'Go to Topology' },
-      { key: '4', handler: goToDocs, description: 'Go to Docs' },
-      { key: '5', handler: goToSettings, description: 'Go to Settings' },
+      { key: '4', handler: goToAgents, description: 'Go to Agents' },
+      { key: '5', handler: goToDocs, description: 'Go to Docs' },
+      { key: '6', handler: goToSettings, description: 'Go to Settings' },
     ],
-    [openShortcuts, goToDashboard, goToDevices, goToTopology, goToDocs, goToSettings]
+    [openShortcuts, goToDashboard, goToDevices, goToTopology, goToAgents, goToDocs, goToSettings]
   )
 
   useKeyboardShortcuts(shortcuts)

--- a/web/src/pages/agents/[id].tsx
+++ b/web/src/pages/agents/[id].tsx
@@ -1,0 +1,31 @@
+import { useParams, Link } from 'react-router-dom'
+import { ChevronLeft } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+export function AgentDetailPage() {
+  const { id } = useParams<{ id: string }>()
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <Button variant="ghost" size="icon" asChild>
+          <Link to="/agents">
+            <ChevronLeft className="h-4 w-4" />
+          </Link>
+        </Button>
+        <div>
+          <h1 className="text-2xl font-semibold">Agent Detail</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Agent ID: <span className="font-mono">{id}</span>
+          </p>
+        </div>
+      </div>
+
+      <div className="rounded-lg border bg-card p-8 text-center">
+        <p className="text-muted-foreground">
+          Agent detail view coming in Phase 02-02.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/web/src/pages/agents/index.tsx
+++ b/web/src/pages/agents/index.tsx
@@ -1,0 +1,337 @@
+import { useState, useCallback, useMemo, useRef } from 'react'
+import { Link } from 'react-router-dom'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { RefreshCw, AlertCircle, Bot, Trash2, Search } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Skeleton } from '@/components/ui/skeleton'
+import { listAgents, deleteAgent } from '@/api/agents'
+import { useKeyboardShortcuts } from '@/hooks/use-keyboard-shortcuts'
+import { cn } from '@/lib/utils'
+import type { AgentStatus } from '@/api/types'
+
+function formatRelativeTime(isoString: string): string {
+  const now = Date.now()
+  const then = new Date(isoString).getTime()
+  const diffSeconds = Math.floor((now - then) / 1000)
+
+  if (diffSeconds < 60) return 'just now'
+  const diffMinutes = Math.floor(diffSeconds / 60)
+  if (diffMinutes < 60) return `${diffMinutes}m ago`
+  const diffHours = Math.floor(diffMinutes / 60)
+  if (diffHours < 24) return `${diffHours}h ago`
+  const diffDays = Math.floor(diffHours / 24)
+  if (diffDays < 30) return `${diffDays}d ago`
+  const diffMonths = Math.floor(diffDays / 30)
+  return `${diffMonths}mo ago`
+}
+
+export function AgentsPage() {
+  const queryClient = useQueryClient()
+  const [deletingId, setDeletingId] = useState<string | null>(null)
+  const [searchQuery, setSearchQuery] = useState('')
+  const searchInputRef = useRef<HTMLInputElement>(null)
+
+  const {
+    data: agents,
+    isLoading,
+    error,
+    refetch,
+  } = useQuery({
+    queryKey: ['agents'],
+    queryFn: listAgents,
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteAgent(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['agents'] })
+      toast.success('Agent deleted')
+      setDeletingId(null)
+    },
+    onError: (err) => {
+      toast.error(err instanceof Error ? err.message : 'Failed to delete agent')
+      setDeletingId(null)
+    },
+  })
+
+  const focusSearch = useCallback(() => searchInputRef.current?.focus(), [])
+  const refreshData = useCallback(() => { refetch() }, [refetch])
+
+  useKeyboardShortcuts(
+    useMemo(
+      () => [
+        { key: '/', handler: focusSearch, description: 'Focus search' },
+        { key: 'r', handler: refreshData, description: 'Refresh data' },
+      ],
+      [focusSearch, refreshData]
+    )
+  )
+
+  function handleDeleteClick(e: React.MouseEvent, agentId: string) {
+    e.preventDefault()
+    e.stopPropagation()
+    setDeletingId(agentId)
+  }
+
+  function confirmDelete() {
+    if (deletingId) {
+      deleteMutation.mutate(deletingId)
+    }
+  }
+
+  function cancelDelete() {
+    setDeletingId(null)
+  }
+
+  const filteredAgents = useMemo(() => {
+    if (!agents) return []
+    if (!searchQuery) return agents
+
+    const query = searchQuery.toLowerCase()
+    return agents.filter(
+      (a) =>
+        a.hostname?.toLowerCase().includes(query) ||
+        a.platform?.toLowerCase().includes(query) ||
+        a.agent_version?.toLowerCase().includes(query) ||
+        a.device_id?.toLowerCase().includes(query)
+    )
+  }, [agents, searchQuery])
+
+  const totalAgents = agents?.length ?? 0
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Agents</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            {searchQuery ? `${filteredAgents.length} matching of ` : ''}
+            {totalAgents} agent{totalAgents !== 1 ? 's' : ''}
+          </p>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="icon" onClick={() => refetch()} disabled={isLoading}>
+            <RefreshCw className={cn('h-4 w-4', isLoading && 'animate-spin')} />
+          </Button>
+        </div>
+      </div>
+
+      {/* Search */}
+      <div className="relative max-w-sm">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+        <Input
+          ref={searchInputRef}
+          placeholder="Search hostname, platform, version..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          className="pl-9"
+        />
+      </div>
+
+      {/* Error state */}
+      {error && (
+        <div className="flex flex-col items-center justify-center py-16 text-center">
+          <AlertCircle className="h-12 w-12 text-red-400 mb-4" />
+          <h3 className="text-lg font-medium">Failed to load agents</h3>
+          <p className="text-sm text-muted-foreground mt-1 max-w-sm">
+            {error instanceof Error ? error.message : 'An unexpected error occurred while fetching agent data.'}
+          </p>
+          <Button variant="outline" className="mt-4 gap-2" onClick={() => refetch()}>
+            <RefreshCw className="h-4 w-4" />
+            Try Again
+          </Button>
+        </div>
+      )}
+
+      {/* Loading state */}
+      {isLoading && !error && (
+        <div className="rounded-lg border overflow-hidden">
+          <div className="bg-muted/50 px-4 py-3">
+            <div className="flex items-center gap-4">
+              <Skeleton className="h-4 w-28" />
+              <Skeleton className="h-4 w-20" />
+              <Skeleton className="h-4 w-16" />
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-4 w-20" />
+              <Skeleton className="h-4 w-20" />
+              <Skeleton className="h-4 w-12" />
+            </div>
+          </div>
+          <div className="divide-y">
+            {[...Array(5)].map((_, i) => (
+              <div key={i} className="px-4 py-3">
+                <div className="flex items-center gap-4">
+                  <Skeleton className="h-4 w-32" />
+                  <Skeleton className="h-4 w-20" />
+                  <Skeleton className="h-5 w-20 rounded-full" />
+                  <Skeleton className="h-4 w-16" />
+                  <Skeleton className="h-4 w-20" />
+                  <Skeleton className="h-4 w-20" />
+                  <Skeleton className="h-4 w-8" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!isLoading && !error && filteredAgents.length === 0 && (
+        <div className="text-center py-12">
+          <Bot className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+          {totalAgents === 0 ? (
+            <>
+              <h3 className="text-lg font-medium">No agents enrolled</h3>
+              <p className="text-sm text-muted-foreground mt-1 max-w-md mx-auto">
+                Install the Scout agent on devices you want to monitor. Create an enrollment
+                token and use it to register agents with the server.
+              </p>
+            </>
+          ) : (
+            <>
+              <h3 className="text-lg font-medium">No matching agents</h3>
+              <p className="text-sm text-muted-foreground mt-1">
+                Try adjusting your search query.
+              </p>
+            </>
+          )}
+        </div>
+      )}
+
+      {/* Agent table */}
+      {!isLoading && !error && filteredAgents.length > 0 && (
+        <div className="rounded-lg border overflow-hidden">
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="bg-muted/50">
+                <tr>
+                  <th className="px-4 py-3 text-left font-medium">Hostname</th>
+                  <th className="px-4 py-3 text-left font-medium">Platform</th>
+                  <th className="px-4 py-3 text-left font-medium">Status</th>
+                  <th className="px-4 py-3 text-left font-medium">Version</th>
+                  <th className="px-4 py-3 text-left font-medium">Last Check-in</th>
+                  <th className="px-4 py-3 text-left font-medium">Enrolled</th>
+                  <th className="px-4 py-3 text-left font-medium w-12">
+                    <span className="sr-only">Actions</span>
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {filteredAgents.map((agent) => (
+                  <tr
+                    key={agent.id}
+                    className="hover:bg-muted/30 transition-colors"
+                  >
+                    <td className="px-4 py-3">
+                      <Link
+                        to={`/agents/${agent.id}`}
+                        className="font-medium hover:text-primary"
+                      >
+                        {agent.hostname || 'Unknown'}
+                      </Link>
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground">
+                      {agent.platform || '-'}
+                    </td>
+                    <td className="px-4 py-3">
+                      <AgentStatusBadge status={agent.status} />
+                    </td>
+                    <td className="px-4 py-3 font-mono text-xs">
+                      {agent.agent_version || '-'}
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground">
+                      {agent.last_check_in
+                        ? formatRelativeTime(agent.last_check_in)
+                        : 'Never'}
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground">
+                      {formatRelativeTime(agent.enrolled_at)}
+                    </td>
+                    <td className="px-4 py-3">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8 text-muted-foreground hover:text-red-500"
+                        onClick={(e) => handleDeleteClick(e, agent.id)}
+                        title="Delete agent"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {/* Delete Confirmation Dialog */}
+      <DeleteConfirmDialog
+        open={!!deletingId}
+        isPending={deleteMutation.isPending}
+        onConfirm={confirmDelete}
+        onCancel={cancelDelete}
+      />
+    </div>
+  )
+}
+
+function AgentStatusBadge({ status }: { status: AgentStatus }) {
+  const config = {
+    connected: { bg: 'bg-green-500/10', text: 'text-green-500', dot: 'bg-green-500' },
+    pending: { bg: 'bg-amber-500/10', text: 'text-amber-500', dot: 'bg-amber-500' },
+    disconnected: { bg: 'bg-red-500/10', text: 'text-red-500', dot: 'bg-red-500' },
+  }
+  const c = config[status] ?? config.disconnected
+
+  return (
+    <span className={cn('inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-xs', c.bg, c.text)}>
+      <span className={cn('h-1.5 w-1.5 rounded-full', c.dot)} />
+      <span className="capitalize">{status}</span>
+    </span>
+  )
+}
+
+function DeleteConfirmDialog({
+  open,
+  isPending,
+  onConfirm,
+  onCancel,
+}: {
+  open: boolean
+  isPending: boolean
+  onConfirm: () => void
+  onCancel: () => void
+}) {
+  if (!open) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="fixed inset-0 bg-black/60 backdrop-blur-sm" onClick={onCancel} />
+      <div className="relative z-50 w-full max-w-sm rounded-lg border bg-card p-6 shadow-lg">
+        <h3 className="text-lg font-semibold mb-2">Delete Agent</h3>
+        <p className="text-sm text-muted-foreground mb-4">
+          Are you sure you want to delete this agent? The agent will need to
+          re-enroll to reconnect.
+        </p>
+        <div className="flex items-center justify-end gap-2">
+          <Button variant="outline" onClick={onCancel} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={onConfirm}
+            disabled={isPending}
+          >
+            {isPending ? 'Deleting...' : 'Delete'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/router/index.tsx
+++ b/web/src/router/index.tsx
@@ -24,6 +24,12 @@ const DeviceDetailPage = lazy(() =>
 const TopologyPage = lazy(() =>
   import('@/pages/topology').then((m) => ({ default: m.TopologyPage }))
 )
+const AgentsPage = lazy(() =>
+  import('@/pages/agents').then((m) => ({ default: m.AgentsPage }))
+)
+const AgentDetailPage = lazy(() =>
+  import('@/pages/agents/[id]').then((m) => ({ default: m.AgentDetailPage }))
+)
 const DocumentationPage = lazy(() =>
   import('@/pages/documentation').then((m) => ({ default: m.DocumentationPage }))
 )
@@ -68,6 +74,8 @@ export const router = createBrowserRouter([
           { path: '/devices', element: <SuspensePage><DevicesPage /></SuspensePage> },
           { path: '/devices/:id', element: <SuspensePage><DeviceDetailPage /></SuspensePage> },
           { path: '/topology', element: <SuspensePage><TopologyPage /></SuspensePage> },
+          { path: '/agents', element: <SuspensePage><AgentsPage /></SuspensePage> },
+          { path: '/agents/:id', element: <SuspensePage><AgentDetailPage /></SuspensePage> },
           { path: '/documentation', element: <SuspensePage><DocumentationPage /></SuspensePage> },
           { path: '/settings', element: <SuspensePage><SettingsPage /></SuspensePage> },
           { path: '/about', element: <SuspensePage><AboutPage /></SuspensePage> },


### PR DESCRIPTION
## Summary

- Add TypeScript types for Scout agents (`AgentInfo`, `AgentStatus`, `HardwareProfile`, `SoftwareInventory`, `ServiceInfo`, `EnrollmentToken`) matching Go struct JSON tags
- Create API client (`agents.ts`) with 7 functions for all Dispatch REST endpoints
- Build `/agents` list page with status table, color-coded badges (green/yellow/red), relative timestamps, delete with confirmation, search, and loading/empty/error states
- Add `/agents/:id` placeholder detail page for Phase 02-02
- Wire sidebar navigation with Bot icon after Topology
- Renumber keyboard shortcuts: 4=Agents, 5=Docs, 6=Settings

## Test plan

- [ ] `pnpm run type-check` passes
- [ ] `pnpm run lint` passes (0 errors)
- [ ] `pnpm run build` succeeds
- [ ] `pnpm test` -- all 117 existing tests pass
- [ ] `/agents` route renders agent table with correct columns
- [ ] Status badges show green (connected), yellow (pending), red (disconnected)
- [ ] Delete agent shows confirmation dialog and removes from list
- [ ] Sidebar shows Agents with Bot icon between Topology and Docs
- [ ] Keyboard shortcut 4 navigates to /agents
- [ ] Keyboard shortcuts dialog shows updated numbering

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)