### PR TITLE
feat: service mapping data layer

### DIFF
--- a/internal/svcmap/correlator.go
+++ b/internal/svcmap/correlator.go
@@ -1,0 +1,219 @@
+package svcmap
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/HerbHall/subnetree/pkg/models"
+	"go.uber.org/zap"
+)
+
+// staleCutoff defines how long since last_seen before a service is marked unknown.
+const staleCutoff = 5 * time.Minute
+
+// ServiceSource provides Scout agent service data.
+type ServiceSource interface {
+	GetServices(ctx context.Context, agentID string) ([]ScoutService, error)
+}
+
+// AppSource provides application data (e.g., Docker containers from Docs module).
+type AppSource interface {
+	ListApplicationsByDevice(ctx context.Context, deviceID string) ([]AppInfo, error)
+}
+
+// ScoutService is a lightweight DTO for a service reported by a Scout agent.
+type ScoutService struct {
+	Name        string
+	DisplayName string
+	Status      string // "running", "stopped", etc.
+	StartType   string // "auto", "manual", "disabled"
+	CPUPercent  float64
+	MemoryBytes int64
+	Ports       []string
+}
+
+// AppInfo is a lightweight DTO for an application/container.
+type AppInfo struct {
+	ID            string
+	Name          string
+	ContainerName string
+	Status        string // "running", "exited", "created"
+}
+
+// Correlator merges services from Scout agents and application sources
+// into a unified service inventory.
+type Correlator struct {
+	store  *Store
+	logger *zap.Logger
+}
+
+// NewCorrelator creates a new Correlator backed by the given store.
+func NewCorrelator(store *Store, logger *zap.Logger) *Correlator {
+	return &Correlator{store: store, logger: logger}
+}
+
+// CorrelateDevice merges Scout agent services and application data for a device.
+// It upserts each discovered service and marks stale ones as unknown.
+func (c *Correlator) CorrelateDevice(
+	ctx context.Context,
+	deviceID string,
+	agentID string,
+	svcSource ServiceSource,
+	appSource AppSource,
+) error {
+	now := time.Now().UTC()
+
+	// Fetch Scout services if agent is linked.
+	if agentID != "" && svcSource != nil {
+		scoutServices, err := svcSource.GetServices(ctx, agentID)
+		if err != nil {
+			c.logger.Warn("failed to fetch scout services",
+				zap.String("agent_id", agentID),
+				zap.Error(err))
+		} else {
+			for i := range scoutServices {
+				if err := c.upsertScoutService(ctx, deviceID, &scoutServices[i], now); err != nil {
+					return fmt.Errorf("upsert scout service %q: %w", scoutServices[i].Name, err)
+				}
+			}
+		}
+	}
+
+	// Fetch application data.
+	if appSource != nil {
+		apps, err := appSource.ListApplicationsByDevice(ctx, deviceID)
+		if err != nil {
+			c.logger.Warn("failed to fetch applications",
+				zap.String("device_id", deviceID),
+				zap.Error(err))
+		} else {
+			for i := range apps {
+				if err := c.upsertAppService(ctx, deviceID, &apps[i], now); err != nil {
+					return fmt.Errorf("upsert app service %q: %w", apps[i].Name, err)
+				}
+			}
+		}
+	}
+
+	// Mark stale services.
+	cutoff := now.Add(-staleCutoff)
+	staleCount, err := c.store.MarkStaleServices(ctx, deviceID, cutoff)
+	if err != nil {
+		return fmt.Errorf("mark stale services: %w", err)
+	}
+	if staleCount > 0 {
+		c.logger.Debug("marked stale services",
+			zap.String("device_id", deviceID),
+			zap.Int64("count", staleCount))
+	}
+
+	return nil
+}
+
+func (c *Correlator) upsertScoutService(ctx context.Context, deviceID string, scout *ScoutService, now time.Time) error {
+	existing, err := c.store.FindByDeviceAndName(ctx, deviceID, scout.Name)
+	if err != nil {
+		return err
+	}
+
+	svcType := inferServiceType(scout)
+	status := mapScoutStatus(scout.Status)
+
+	if existing != nil {
+		existing.DisplayName = scout.DisplayName
+		existing.ServiceType = svcType
+		existing.Status = status
+		existing.CPUPercent = scout.CPUPercent
+		existing.MemoryBytes = scout.MemoryBytes
+		existing.Ports = scout.Ports
+		existing.LastSeen = now
+		return c.store.UpsertService(ctx, existing)
+	}
+
+	svc := &models.Service{
+		ID:           fmt.Sprintf("svc-%s-%s", deviceID[:8], scout.Name),
+		Name:         scout.Name,
+		DisplayName:  scout.DisplayName,
+		ServiceType:  svcType,
+		DeviceID:     deviceID,
+		Status:       status,
+		DesiredState: models.DesiredStateMonitoringOnly,
+		Ports:        scout.Ports,
+		CPUPercent:   scout.CPUPercent,
+		MemoryBytes:  scout.MemoryBytes,
+		FirstSeen:    now,
+		LastSeen:     now,
+	}
+	return c.store.UpsertService(ctx, svc)
+}
+
+func (c *Correlator) upsertAppService(ctx context.Context, deviceID string, app *AppInfo, now time.Time) error {
+	name := app.ContainerName
+	if name == "" {
+		name = app.Name
+	}
+
+	existing, err := c.store.FindByDeviceAndName(ctx, deviceID, name)
+	if err != nil {
+		return err
+	}
+
+	status := mapAppStatus(app.Status)
+
+	if existing != nil {
+		existing.ApplicationID = app.ID
+		existing.Status = status
+		existing.LastSeen = now
+		return c.store.UpsertService(ctx, existing)
+	}
+
+	svc := &models.Service{
+		ID:            fmt.Sprintf("svc-%s-%s", deviceID[:8], name),
+		Name:          name,
+		DisplayName:   app.Name,
+		ServiceType:   models.ServiceTypeDockerContainer,
+		DeviceID:      deviceID,
+		ApplicationID: app.ID,
+		Status:        status,
+		DesiredState:  models.DesiredStateMonitoringOnly,
+		FirstSeen:     now,
+		LastSeen:      now,
+	}
+	return c.store.UpsertService(ctx, svc)
+}
+
+func inferServiceType(scout *ScoutService) models.ServiceType {
+	switch scout.StartType {
+	case "auto", "manual", "disabled":
+		return models.ServiceTypeWindowsService
+	default:
+		return models.ServiceTypeApplication
+	}
+}
+
+func mapScoutStatus(status string) models.ServiceStatus {
+	switch status {
+	case "running":
+		return models.ServiceStatusRunning
+	case "stopped":
+		return models.ServiceStatusStopped
+	case "failed":
+		return models.ServiceStatusFailed
+	default:
+		return models.ServiceStatusUnknown
+	}
+}
+
+func mapAppStatus(status string) models.ServiceStatus {
+	switch status {
+	case "running":
+		return models.ServiceStatusRunning
+	case "exited", "stopped":
+		return models.ServiceStatusStopped
+	case "created":
+		return models.ServiceStatusUnknown
+	default:
+		return models.ServiceStatusUnknown
+	}
+}

--- a/internal/svcmap/store.go
+++ b/internal/svcmap/store.go
@@ -1,0 +1,261 @@
+package svcmap
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/HerbHall/subnetree/pkg/models"
+)
+
+// Store provides database operations for the service mapping module.
+type Store struct {
+	db *sql.DB
+}
+
+// NewStore creates a new Store and ensures the services table exists.
+func NewStore(db *sql.DB) (*Store, error) {
+	s := &Store{db: db}
+	if err := s.migrate(); err != nil {
+		return nil, fmt.Errorf("svcmap store migrate: %w", err)
+	}
+	return s, nil
+}
+
+func (s *Store) migrate() error {
+	_, err := s.db.Exec(`
+		CREATE TABLE IF NOT EXISTS services (
+			id            TEXT PRIMARY KEY,
+			name          TEXT NOT NULL,
+			display_name  TEXT NOT NULL DEFAULT '',
+			service_type  TEXT NOT NULL,
+			device_id     TEXT NOT NULL,
+			application_id TEXT NOT NULL DEFAULT '',
+			status        TEXT NOT NULL DEFAULT 'unknown',
+			desired_state TEXT NOT NULL DEFAULT 'monitoring-only',
+			ports_json    TEXT NOT NULL DEFAULT '[]',
+			cpu_percent   REAL NOT NULL DEFAULT 0,
+			memory_bytes  INTEGER NOT NULL DEFAULT 0,
+			first_seen    DATETIME NOT NULL,
+			last_seen     DATETIME NOT NULL
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_services_device_id ON services(device_id);
+		CREATE INDEX IF NOT EXISTS idx_services_service_type ON services(service_type);
+	`)
+	return err
+}
+
+// UpsertService inserts a new service or updates an existing one.
+func (s *Store) UpsertService(ctx context.Context, svc *models.Service) error {
+	portsJSON, err := json.Marshal(svc.Ports)
+	if err != nil {
+		return fmt.Errorf("marshal ports: %w", err)
+	}
+
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO services (
+			id, name, display_name, service_type, device_id,
+			application_id, status, desired_state, ports_json,
+			cpu_percent, memory_bytes, first_seen, last_seen
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT (id) DO UPDATE SET
+			name = excluded.name,
+			display_name = excluded.display_name,
+			service_type = excluded.service_type,
+			device_id = excluded.device_id,
+			application_id = excluded.application_id,
+			status = excluded.status,
+			desired_state = excluded.desired_state,
+			ports_json = excluded.ports_json,
+			cpu_percent = excluded.cpu_percent,
+			memory_bytes = excluded.memory_bytes,
+			last_seen = excluded.last_seen`,
+		svc.ID, svc.Name, svc.DisplayName, svc.ServiceType, svc.DeviceID,
+		svc.ApplicationID, svc.Status, svc.DesiredState, string(portsJSON),
+		svc.CPUPercent, svc.MemoryBytes, svc.FirstSeen, svc.LastSeen,
+	)
+	if err != nil {
+		return fmt.Errorf("upsert service: %w", err)
+	}
+	return nil
+}
+
+// GetService returns a service by ID. Returns nil, nil if not found.
+func (s *Store) GetService(ctx context.Context, id string) (*models.Service, error) {
+	var svc models.Service
+	var portsJSON string
+	err := s.db.QueryRowContext(ctx, `
+		SELECT id, name, display_name, service_type, device_id,
+			application_id, status, desired_state, ports_json,
+			cpu_percent, memory_bytes, first_seen, last_seen
+		FROM services WHERE id = ?`, id,
+	).Scan(
+		&svc.ID, &svc.Name, &svc.DisplayName, &svc.ServiceType, &svc.DeviceID,
+		&svc.ApplicationID, &svc.Status, &svc.DesiredState, &portsJSON,
+		&svc.CPUPercent, &svc.MemoryBytes, &svc.FirstSeen, &svc.LastSeen,
+	)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get service: %w", err)
+	}
+	if err := json.Unmarshal([]byte(portsJSON), &svc.Ports); err != nil {
+		return nil, fmt.Errorf("unmarshal ports: %w", err)
+	}
+	return &svc, nil
+}
+
+// ListServices returns all tracked services.
+func (s *Store) ListServices(ctx context.Context) ([]models.Service, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, name, display_name, service_type, device_id,
+			application_id, status, desired_state, ports_json,
+			cpu_percent, memory_bytes, first_seen, last_seen
+		FROM services ORDER BY device_id, name`)
+	if err != nil {
+		return nil, fmt.Errorf("list services: %w", err)
+	}
+	defer rows.Close()
+	return scanServices(rows)
+}
+
+// ListServicesByDevice returns all services for a specific device.
+func (s *Store) ListServicesByDevice(ctx context.Context, deviceID string) ([]models.Service, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, name, display_name, service_type, device_id,
+			application_id, status, desired_state, ports_json,
+			cpu_percent, memory_bytes, first_seen, last_seen
+		FROM services WHERE device_id = ? ORDER BY name`, deviceID)
+	if err != nil {
+		return nil, fmt.Errorf("list services by device: %w", err)
+	}
+	defer rows.Close()
+	return scanServices(rows)
+}
+
+// UpdateDesiredState changes the desired state for a service.
+func (s *Store) UpdateDesiredState(ctx context.Context, id string, state models.DesiredState) error {
+	res, err := s.db.ExecContext(ctx, `UPDATE services SET desired_state = ? WHERE id = ?`, state, id)
+	if err != nil {
+		return fmt.Errorf("update desired state: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+// DeleteService removes a service by ID.
+func (s *Store) DeleteService(ctx context.Context, id string) error {
+	res, err := s.db.ExecContext(ctx, `DELETE FROM services WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("delete service: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+// MarkStaleServices sets status to "unknown" for services on a device
+// that haven't been seen since the given cutoff time.
+func (s *Store) MarkStaleServices(ctx context.Context, deviceID string, cutoff time.Time) (int64, error) {
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE services SET status = ?
+		WHERE device_id = ? AND last_seen < ? AND status != ?`,
+		models.ServiceStatusUnknown, deviceID, cutoff, models.ServiceStatusUnknown,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("mark stale services: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}
+
+// FindByDeviceAndName looks up a service by device ID and name.
+// Returns nil, nil if not found.
+func (s *Store) FindByDeviceAndName(ctx context.Context, deviceID, name string) (*models.Service, error) {
+	var svc models.Service
+	var portsJSON string
+	err := s.db.QueryRowContext(ctx, `
+		SELECT id, name, display_name, service_type, device_id,
+			application_id, status, desired_state, ports_json,
+			cpu_percent, memory_bytes, first_seen, last_seen
+		FROM services WHERE device_id = ? AND name = ?`, deviceID, name,
+	).Scan(
+		&svc.ID, &svc.Name, &svc.DisplayName, &svc.ServiceType, &svc.DeviceID,
+		&svc.ApplicationID, &svc.Status, &svc.DesiredState, &portsJSON,
+		&svc.CPUPercent, &svc.MemoryBytes, &svc.FirstSeen, &svc.LastSeen,
+	)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("find by device and name: %w", err)
+	}
+	if err := json.Unmarshal([]byte(portsJSON), &svc.Ports); err != nil {
+		return nil, fmt.Errorf("unmarshal ports: %w", err)
+	}
+	return &svc, nil
+}
+
+// GetUtilizationSummaries returns per-device resource aggregation.
+func (s *Store) GetUtilizationSummaries(ctx context.Context) ([]DeviceServiceStats, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT device_id,
+			COUNT(*) as service_count,
+			COALESCE(SUM(cpu_percent), 0) as total_cpu,
+			COALESCE(SUM(memory_bytes), 0) as total_memory
+		FROM services
+		WHERE status = ?
+		GROUP BY device_id`, models.ServiceStatusRunning)
+	if err != nil {
+		return nil, fmt.Errorf("get utilization summaries: %w", err)
+	}
+	defer rows.Close()
+
+	var stats []DeviceServiceStats
+	for rows.Next() {
+		var ds DeviceServiceStats
+		if err := rows.Scan(&ds.DeviceID, &ds.ServiceCount, &ds.TotalCPU, &ds.TotalMemory); err != nil {
+			return nil, fmt.Errorf("scan utilization row: %w", err)
+		}
+		stats = append(stats, ds)
+	}
+	return stats, rows.Err()
+}
+
+// DeviceServiceStats holds aggregated service metrics for a device.
+type DeviceServiceStats struct {
+	DeviceID     string
+	ServiceCount int
+	TotalCPU     float64
+	TotalMemory  int64
+}
+
+// scanServices extracts services from database rows.
+func scanServices(rows *sql.Rows) ([]models.Service, error) {
+	var services []models.Service
+	for rows.Next() {
+		var svc models.Service
+		var portsJSON string
+		if err := rows.Scan(
+			&svc.ID, &svc.Name, &svc.DisplayName, &svc.ServiceType, &svc.DeviceID,
+			&svc.ApplicationID, &svc.Status, &svc.DesiredState, &portsJSON,
+			&svc.CPUPercent, &svc.MemoryBytes, &svc.FirstSeen, &svc.LastSeen,
+		); err != nil {
+			return nil, fmt.Errorf("scan service row: %w", err)
+		}
+		if err := json.Unmarshal([]byte(portsJSON), &svc.Ports); err != nil {
+			return nil, fmt.Errorf("unmarshal ports: %w", err)
+		}
+		services = append(services, svc)
+	}
+	return services, rows.Err()
+}

--- a/internal/svcmap/utilization.go
+++ b/internal/svcmap/utilization.go
@@ -1,0 +1,150 @@
+package svcmap
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/HerbHall/subnetree/pkg/models"
+)
+
+// HardwareSource provides hardware profile data for utilization calculations.
+type HardwareSource interface {
+	GetHardwareProfile(ctx context.Context, agentID string) (*HardwareInfo, error)
+}
+
+// DeviceInfo provides device metadata for utilization computations.
+type DeviceInfo struct {
+	DeviceID string
+	Hostname string
+	AgentID  string
+}
+
+// HardwareInfo is a lightweight DTO for hardware profile data relevant to utilization.
+type HardwareInfo struct {
+	TotalMemoryBytes int64
+	TotalDiskBytes   int64
+	UsedDiskBytes    int64
+	CPUCores         int
+}
+
+// ComputeGrade assigns a letter grade (A-F) based on the highest resource usage.
+// A: <30%, B: <60%, C: 60-80%, D: 80-90%, F: >90%
+func ComputeGrade(cpu, mem, disk float64) string {
+	peak := cpu
+	if mem > peak {
+		peak = mem
+	}
+	if disk > peak {
+		peak = disk
+	}
+
+	switch {
+	case peak < 30:
+		return "A"
+	case peak < 60:
+		return "B"
+	case peak < 80:
+		return "C"
+	case peak < 90:
+		return "D"
+	default:
+		return "F"
+	}
+}
+
+// ComputeDeviceUtilization calculates utilization for a single device.
+func ComputeDeviceUtilization(
+	ctx context.Context,
+	store *Store,
+	device DeviceInfo,
+	hwSource HardwareSource,
+) (*models.UtilizationSummary, error) {
+	// Get aggregated service stats from the store.
+	allStats, err := store.GetUtilizationSummaries(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get service stats: %w", err)
+	}
+
+	var stats *DeviceServiceStats
+	for i := range allStats {
+		if allStats[i].DeviceID == device.DeviceID {
+			stats = &allStats[i]
+			break
+		}
+	}
+
+	summary := &models.UtilizationSummary{
+		DeviceID: device.DeviceID,
+		Hostname: device.Hostname,
+	}
+
+	if stats == nil {
+		summary.Grade = "A"
+		summary.Headroom = 100
+		return summary, nil
+	}
+
+	summary.ServiceCount = stats.ServiceCount
+	summary.CPUPercent = stats.TotalCPU
+
+	// Get hardware info for percentage calculations.
+	if device.AgentID != "" && hwSource != nil {
+		hw, err := hwSource.GetHardwareProfile(ctx, device.AgentID)
+		if err == nil && hw != nil {
+			if hw.TotalMemoryBytes > 0 {
+				summary.MemoryPercent = float64(stats.TotalMemory) / float64(hw.TotalMemoryBytes) * 100
+			}
+			if hw.TotalDiskBytes > 0 {
+				summary.DiskPercent = float64(hw.UsedDiskBytes) / float64(hw.TotalDiskBytes) * 100
+			}
+		}
+	}
+
+	summary.Grade = ComputeGrade(summary.CPUPercent, summary.MemoryPercent, summary.DiskPercent)
+
+	// Headroom is 100 minus the highest utilization percentage.
+	peak := summary.CPUPercent
+	if summary.MemoryPercent > peak {
+		peak = summary.MemoryPercent
+	}
+	if summary.DiskPercent > peak {
+		peak = summary.DiskPercent
+	}
+	summary.Headroom = 100 - peak
+
+	return summary, nil
+}
+
+// ComputeFleetSummary aggregates utilization across all devices.
+func ComputeFleetSummary(summaries []models.UtilizationSummary) *models.FleetSummary {
+	fleet := &models.FleetSummary{
+		ByGrade: make(map[string]int),
+	}
+
+	if len(summaries) == 0 {
+		return fleet
+	}
+
+	fleet.TotalDevices = len(summaries)
+
+	var totalCPU, totalMem float64
+	for i := range summaries {
+		s := &summaries[i]
+		fleet.TotalServices += s.ServiceCount
+		totalCPU += s.CPUPercent
+		totalMem += s.MemoryPercent
+		fleet.ByGrade[s.Grade]++
+
+		switch s.Grade {
+		case "A":
+			fleet.Underutilized = append(fleet.Underutilized, s.Hostname)
+		case "D", "F":
+			fleet.Overloaded = append(fleet.Overloaded, s.Hostname)
+		}
+	}
+
+	fleet.AvgCPU = totalCPU / float64(fleet.TotalDevices)
+	fleet.AvgMemory = totalMem / float64(fleet.TotalDevices)
+
+	return fleet
+}

--- a/internal/svcmap/utilization_test.go
+++ b/internal/svcmap/utilization_test.go
@@ -1,0 +1,71 @@
+package svcmap
+
+import "testing"
+
+func TestComputeGrade(t *testing.T) {
+	tests := []struct {
+		name string
+		cpu  float64
+		mem  float64
+		disk float64
+		want string
+	}{
+		// Grade A: peak < 30%
+		{name: "all zeros", cpu: 0, mem: 0, disk: 0, want: "A"},
+		{name: "low usage", cpu: 10, mem: 15, disk: 20, want: "A"},
+		{name: "just under A boundary", cpu: 29, mem: 29, disk: 29, want: "A"},
+
+		// Grade B: 30% <= peak < 60%
+		{name: "at B boundary", cpu: 30, mem: 0, disk: 0, want: "B"},
+		{name: "mid B range", cpu: 45, mem: 30, disk: 20, want: "B"},
+		{name: "just under C boundary", cpu: 59, mem: 59, disk: 59, want: "B"},
+
+		// Grade C: 60% <= peak < 80%
+		{name: "at C boundary", cpu: 60, mem: 0, disk: 0, want: "C"},
+		{name: "mid C range", cpu: 70, mem: 65, disk: 50, want: "C"},
+		{name: "just under D boundary", cpu: 79, mem: 79, disk: 79, want: "C"},
+
+		// Grade D: 80% <= peak < 90%
+		{name: "at D boundary", cpu: 80, mem: 0, disk: 0, want: "D"},
+		{name: "mid D range", cpu: 85, mem: 70, disk: 60, want: "D"},
+		{name: "just under F boundary", cpu: 89, mem: 89, disk: 89, want: "D"},
+
+		// Grade F: peak >= 90%
+		{name: "at F boundary", cpu: 90, mem: 0, disk: 0, want: "F"},
+		{name: "over F boundary", cpu: 91, mem: 50, disk: 50, want: "F"},
+		{name: "full utilization", cpu: 100, mem: 100, disk: 100, want: "F"},
+
+		// Peak selection: highest metric determines grade
+		{name: "cpu is peak", cpu: 85, mem: 20, disk: 30, want: "D"},
+		{name: "mem is peak", cpu: 20, mem: 85, disk: 30, want: "D"},
+		{name: "disk is peak", cpu: 20, mem: 30, disk: 85, want: "D"},
+
+		// Edge cases
+		{name: "one metric at boundary rest zero", cpu: 0, mem: 0, disk: 30, want: "B"},
+		{name: "fractional values", cpu: 29.9, mem: 29.9, disk: 29.9, want: "A"},
+		{name: "just over boundary fractional", cpu: 30.1, mem: 0, disk: 0, want: "B"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ComputeGrade(tt.cpu, tt.mem, tt.disk)
+			if got != tt.want {
+				t.Errorf("ComputeGrade(%v, %v, %v) = %q, want %q",
+					tt.cpu, tt.mem, tt.disk, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestComputeFleetSummary_Empty(t *testing.T) {
+	fleet := ComputeFleetSummary(nil)
+	if fleet.TotalDevices != 0 {
+		t.Errorf("expected 0 devices, got %d", fleet.TotalDevices)
+	}
+	if fleet.TotalServices != 0 {
+		t.Errorf("expected 0 services, got %d", fleet.TotalServices)
+	}
+	if len(fleet.ByGrade) != 0 {
+		t.Errorf("expected empty grade map, got %v", fleet.ByGrade)
+	}
+}

--- a/pkg/models/service.go
+++ b/pkg/models/service.go
@@ -1,0 +1,72 @@
+package models
+
+import "time"
+
+// ServiceType categorizes a tracked service.
+type ServiceType string
+
+const (
+	ServiceTypeDockerContainer ServiceType = "docker-container"
+	ServiceTypeSystemdService  ServiceType = "systemd-service"
+	ServiceTypeWindowsService  ServiceType = "windows-service"
+	ServiceTypeApplication     ServiceType = "application"
+)
+
+// ServiceStatus represents the current state of a service.
+type ServiceStatus string
+
+const (
+	ServiceStatusRunning ServiceStatus = "running"
+	ServiceStatusStopped ServiceStatus = "stopped"
+	ServiceStatusFailed  ServiceStatus = "failed"
+	ServiceStatusUnknown ServiceStatus = "unknown"
+)
+
+// DesiredState represents the intended operational state of a service.
+type DesiredState string
+
+const (
+	DesiredStateShouldRun      DesiredState = "should-run"
+	DesiredStateShouldStop     DesiredState = "should-stop"
+	DesiredStateMonitoringOnly DesiredState = "monitoring-only"
+)
+
+// Service represents a tracked service on a device.
+type Service struct {
+	ID            string        `json:"id" example:"svc-550e8400-e29b-41d4-a716-446655440000"`
+	Name          string        `json:"name" example:"nginx"`
+	DisplayName   string        `json:"display_name" example:"NGINX Web Server"`
+	ServiceType   ServiceType   `json:"service_type" example:"docker-container"`
+	DeviceID      string        `json:"device_id" example:"550e8400-e29b-41d4-a716-446655440000"`
+	ApplicationID string        `json:"application_id,omitempty" example:"app-001"`
+	Status        ServiceStatus `json:"status" example:"running"`
+	DesiredState  DesiredState  `json:"desired_state" example:"should-run"`
+	Ports         []string      `json:"ports,omitempty"`
+	CPUPercent    float64       `json:"cpu_percent" example:"12.5"`
+	MemoryBytes   int64         `json:"memory_bytes" example:"134217728"`
+	FirstSeen     time.Time     `json:"first_seen" example:"2026-01-10T08:00:00Z"`
+	LastSeen      time.Time     `json:"last_seen" example:"2026-02-13T10:30:00Z"`
+}
+
+// UtilizationSummary provides resource usage and grading for a single device.
+type UtilizationSummary struct {
+	DeviceID      string  `json:"device_id" example:"550e8400-e29b-41d4-a716-446655440000"`
+	Hostname      string  `json:"hostname" example:"web-server-01"`
+	CPUPercent    float64 `json:"cpu_percent" example:"45.2"`
+	MemoryPercent float64 `json:"memory_percent" example:"62.8"`
+	DiskPercent   float64 `json:"disk_percent" example:"38.1"`
+	ServiceCount  int     `json:"service_count" example:"12"`
+	Grade         string  `json:"grade" example:"B"`
+	Headroom      float64 `json:"headroom" example:"37.2"`
+}
+
+// FleetSummary aggregates utilization across all devices.
+type FleetSummary struct {
+	TotalDevices  int            `json:"total_devices" example:"8"`
+	TotalServices int            `json:"total_services" example:"42"`
+	AvgCPU        float64        `json:"avg_cpu" example:"35.4"`
+	AvgMemory     float64        `json:"avg_memory" example:"52.1"`
+	ByGrade       map[string]int `json:"by_grade"`
+	Underutilized []string       `json:"underutilized,omitempty"`
+	Overloaded    []string       `json:"overloaded,omitempty"`
+}


### PR DESCRIPTION
## Summary

- Adds `pkg/models/service.go` with Service model, ServiceType/ServiceStatus/DesiredState enums, UtilizationSummary, and FleetSummary structs
- Adds `internal/svcmap/store.go` with SQLite store: migration, UpsertService, GetService, ListServices, ListServicesByDevice, UpdateDesiredState, DeleteService, MarkStaleServices, FindByDeviceAndName, and GetUtilizationSummaries
- Adds `internal/svcmap/correlator.go` with correlation engine that merges Scout agent services and application data, using consumer-side interfaces (ServiceSource, AppSource)
- Adds `internal/svcmap/utilization.go` with A-F utilization grading (ComputeGrade, ComputeDeviceUtilization, ComputeFleetSummary) based on peak resource usage
- Adds `internal/svcmap/utilization_test.go` with 22 table-driven tests covering all grade boundaries and edge cases

## Test plan

- [x] `go build ./pkg/models/...` passes
- [x] `go build ./internal/svcmap/...` passes
- [x] `go vet ./internal/svcmap/...` passes
- [x] `go test ./internal/svcmap/... -v` -- 22 tests pass
- [x] `golangci-lint run ./internal/svcmap/... ./pkg/models/` -- clean
- [x] `go build ./...` -- full project builds clean

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)