### PR TITLE
feat: TCP/HTTP check types and SNMP collector skeleton

### DIFF
--- a/internal/pulse/http_checker.go
+++ b/internal/pulse/http_checker.go
@@ -1,0 +1,72 @@
+package pulse
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// Compile-time interface guard.
+var _ Checker = (*HTTPChecker)(nil)
+
+// HTTPChecker tests HTTP/HTTPS endpoint reachability by sending GET requests.
+type HTTPChecker struct {
+	client *http.Client
+}
+
+// NewHTTPChecker creates a new HTTP checker with the given timeout.
+// Self-signed TLS certificates are accepted (InsecureSkipVerify).
+func NewHTTPChecker(timeout time.Duration) *HTTPChecker {
+	return &HTTPChecker{
+		client: &http.Client{
+			Timeout: timeout,
+			Transport: &http.Transport{
+				TLSClientConfig:   &tls.Config{MinVersion: tls.VersionTLS12, InsecureSkipVerify: true}, //nolint:gosec // G402: monitoring must work with self-signed certs
+				DisableKeepAlives: true,
+			},
+		},
+	}
+}
+
+// Check sends a GET request to the target URL and checks for a 2xx response.
+func (c *HTTPChecker) Check(ctx context.Context, target string) (*CheckResult, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, http.NoBody)
+	if err != nil {
+		return &CheckResult{
+			Success:      false,
+			ErrorMessage: fmt.Sprintf("invalid URL %q: %v", target, err),
+			CheckedAt:    time.Now().UTC(),
+		}, fmt.Errorf("invalid URL %q: %w", target, err)
+	}
+
+	start := time.Now()
+	resp, err := c.client.Do(req)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		return &CheckResult{
+			Success:      false,
+			LatencyMs:    float64(elapsed) / float64(time.Millisecond),
+			ErrorMessage: err.Error(),
+			CheckedAt:    time.Now().UTC(),
+		}, fmt.Errorf("http get %s: %w", target, err)
+	}
+	resp.Body.Close()
+
+	result := &CheckResult{
+		LatencyMs: float64(elapsed) / float64(time.Millisecond),
+		CheckedAt: time.Now().UTC(),
+	}
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		result.Success = true
+	} else {
+		result.Success = false
+		result.ErrorMessage = fmt.Sprintf("HTTP %d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
+		return result, fmt.Errorf("http %s: status %d", target, resp.StatusCode)
+	}
+
+	return result, nil
+}

--- a/internal/pulse/http_checker_test.go
+++ b/internal/pulse/http_checker_test.go
@@ -1,0 +1,206 @@
+package pulse
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestHTTPChecker_InterfaceCompliance(t *testing.T) {
+	var _ Checker = (*HTTPChecker)(nil)
+
+	checker := NewHTTPChecker(5 * time.Second)
+	var _ Checker = checker
+}
+
+func TestNewHTTPChecker(t *testing.T) {
+	checker := NewHTTPChecker(10 * time.Second)
+	if checker == nil {
+		t.Fatal("NewHTTPChecker() returned nil")
+	}
+	if checker.client == nil {
+		t.Fatal("NewHTTPChecker() client is nil")
+	}
+	if checker.client.Timeout != 10*time.Second {
+		t.Errorf("client.Timeout = %v, want 10s", checker.client.Timeout)
+	}
+}
+
+func TestHTTPChecker_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	checker := NewHTTPChecker(5 * time.Second)
+	result, err := checker.Check(context.Background(), server.URL)
+
+	if err != nil {
+		t.Errorf("Check() error = %v, want nil", err)
+	}
+	if result == nil {
+		t.Fatal("Check() returned nil result")
+	}
+	if !result.Success {
+		t.Errorf("Check() Success = false, want true")
+	}
+	if result.LatencyMs <= 0 {
+		t.Errorf("Check() LatencyMs = %v, want > 0", result.LatencyMs)
+	}
+	if result.ErrorMessage != "" {
+		t.Errorf("Check() ErrorMessage = %q, want empty", result.ErrorMessage)
+	}
+	if result.CheckedAt.IsZero() {
+		t.Error("Check() CheckedAt is zero")
+	}
+}
+
+func TestHTTPChecker_Non2xx(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+	}{
+		{"server error", http.StatusInternalServerError},
+		{"service unavailable", http.StatusServiceUnavailable},
+		{"not found", http.StatusNotFound},
+		{"forbidden", http.StatusForbidden},
+		{"redirect", http.StatusMovedPermanently},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+			}))
+			defer server.Close()
+
+			checker := NewHTTPChecker(5 * time.Second)
+			result, err := checker.Check(context.Background(), server.URL)
+
+			if err == nil {
+				t.Error("Check() error = nil, want error for non-2xx response")
+			}
+			if result == nil {
+				t.Fatal("Check() returned nil result")
+			}
+			if result.Success {
+				t.Error("Check() Success = true, want false")
+			}
+			if result.ErrorMessage == "" {
+				t.Error("Check() ErrorMessage is empty, want non-empty")
+			}
+			if result.LatencyMs <= 0 {
+				t.Errorf("Check() LatencyMs = %v, want > 0", result.LatencyMs)
+			}
+		})
+	}
+}
+
+func TestHTTPChecker_ConnectionRefused(t *testing.T) {
+	// Use a URL that will refuse the connection.
+	checker := NewHTTPChecker(2 * time.Second)
+	result, err := checker.Check(context.Background(), "http://127.0.0.1:1")
+
+	if err == nil {
+		t.Error("Check() error = nil, want error for connection refused")
+	}
+	if result == nil {
+		t.Fatal("Check() returned nil result")
+	}
+	if result.Success {
+		t.Error("Check() Success = true, want false")
+	}
+	if result.ErrorMessage == "" {
+		t.Error("Check() ErrorMessage is empty, want non-empty")
+	}
+}
+
+func TestHTTPChecker_InvalidURL(t *testing.T) {
+	checker := NewHTTPChecker(2 * time.Second)
+	result, err := checker.Check(context.Background(), "://invalid")
+
+	if err == nil {
+		t.Error("Check() error = nil, want error for invalid URL")
+	}
+	if result == nil {
+		t.Fatal("Check() returned nil result")
+	}
+	if result.Success {
+		t.Error("Check() Success = true, want false")
+	}
+}
+
+func TestHTTPChecker_HTTPS_SelfSigned(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	checker := NewHTTPChecker(5 * time.Second)
+	result, err := checker.Check(context.Background(), server.URL)
+
+	if err != nil {
+		t.Errorf("Check() error = %v, want nil (self-signed certs should be accepted)", err)
+	}
+	if result == nil {
+		t.Fatal("Check() returned nil result")
+	}
+	if !result.Success {
+		t.Errorf("Check() Success = false, want true (self-signed cert should be accepted)")
+	}
+}
+
+func TestHTTPChecker_ContextCancelled(t *testing.T) {
+	// Server that delays response.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	checker := NewHTTPChecker(30 * time.Second)
+	start := time.Now()
+	result, err := checker.Check(ctx, server.URL)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Error("Check() error = nil, want error for cancelled context")
+	}
+	if result == nil {
+		t.Fatal("Check() returned nil result")
+	}
+	if result.Success {
+		t.Error("Check() Success = true, want false")
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("Check() took %v, want < 2s (should respect context cancellation)", elapsed)
+	}
+}
+
+func TestHTTPChecker_2xxRange(t *testing.T) {
+	// Test that all 2xx codes are considered success.
+	codes := []int{200, 201, 202, 204}
+	for _, code := range codes {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(code)
+		}))
+
+		checker := NewHTTPChecker(5 * time.Second)
+		result, err := checker.Check(context.Background(), server.URL)
+		server.Close()
+
+		if err != nil {
+			t.Errorf("status %d: Check() error = %v, want nil", code, err)
+		}
+		if result == nil {
+			t.Fatalf("status %d: Check() returned nil result", code)
+		}
+		if !result.Success {
+			t.Errorf("status %d: Check() Success = false, want true", code)
+		}
+	}
+}

--- a/internal/pulse/tcp_checker.go
+++ b/internal/pulse/tcp_checker.go
@@ -1,0 +1,57 @@
+package pulse
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+)
+
+// Compile-time interface guard.
+var _ Checker = (*TCPChecker)(nil)
+
+// TCPChecker tests TCP connectivity to host:port targets.
+type TCPChecker struct {
+	timeout time.Duration
+}
+
+// NewTCPChecker creates a new TCP checker with the given connection timeout.
+func NewTCPChecker(timeout time.Duration) *TCPChecker {
+	return &TCPChecker{timeout: timeout}
+}
+
+// Check connects to the target (host:port) and measures connection time.
+func (c *TCPChecker) Check(ctx context.Context, target string) (*CheckResult, error) {
+	// Validate target format: must include a port.
+	_, _, err := net.SplitHostPort(target)
+	if err != nil {
+		return &CheckResult{
+			Success:      false,
+			ErrorMessage: fmt.Sprintf("invalid target %q: %v", target, err),
+			CheckedAt:    time.Now().UTC(),
+		}, fmt.Errorf("invalid target %q: %w", target, err)
+	}
+
+	start := time.Now()
+
+	// Use a dialer with context for clean cancellation.
+	dialer := net.Dialer{Timeout: c.timeout}
+	conn, err := dialer.DialContext(ctx, "tcp", target)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		return &CheckResult{
+			Success:      false,
+			LatencyMs:    float64(elapsed) / float64(time.Millisecond),
+			ErrorMessage: err.Error(),
+			CheckedAt:    time.Now().UTC(),
+		}, fmt.Errorf("tcp connect %s: %w", target, err)
+	}
+	conn.Close()
+
+	return &CheckResult{
+		Success:   true,
+		LatencyMs: float64(elapsed) / float64(time.Millisecond),
+		CheckedAt: time.Now().UTC(),
+	}, nil
+}

--- a/internal/pulse/tcp_checker_test.go
+++ b/internal/pulse/tcp_checker_test.go
@@ -1,0 +1,164 @@
+package pulse
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestTCPChecker_InterfaceCompliance(t *testing.T) {
+	var _ Checker = (*TCPChecker)(nil)
+
+	checker := NewTCPChecker(5 * time.Second)
+	var _ Checker = checker
+}
+
+func TestNewTCPChecker(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout time.Duration
+	}{
+		{"default", 5 * time.Second},
+		{"short", 1 * time.Second},
+		{"zero", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checker := NewTCPChecker(tt.timeout)
+			if checker == nil {
+				t.Fatal("NewTCPChecker() returned nil")
+			}
+			if checker.timeout != tt.timeout {
+				t.Errorf("timeout = %v, want %v", checker.timeout, tt.timeout)
+			}
+		})
+	}
+}
+
+func TestTCPChecker_Success(t *testing.T) {
+	// Start a local TCP listener.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to create listener: %v", err)
+	}
+	defer ln.Close()
+
+	// Accept connections in background.
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			conn.Close()
+		}
+	}()
+
+	checker := NewTCPChecker(5 * time.Second)
+	result, err := checker.Check(context.Background(), ln.Addr().String())
+
+	if err != nil {
+		t.Errorf("Check() error = %v, want nil", err)
+	}
+	if result == nil {
+		t.Fatal("Check() returned nil result")
+	}
+	if !result.Success {
+		t.Errorf("Check() Success = false, want true")
+	}
+	if result.LatencyMs < 0 {
+		t.Errorf("Check() LatencyMs = %v, want >= 0", result.LatencyMs)
+	}
+	if result.ErrorMessage != "" {
+		t.Errorf("Check() ErrorMessage = %q, want empty", result.ErrorMessage)
+	}
+	if result.CheckedAt.IsZero() {
+		t.Error("Check() CheckedAt is zero")
+	}
+}
+
+func TestTCPChecker_ConnectionRefused(t *testing.T) {
+	// Find a port that's definitely not listening by binding then closing.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to create listener: %v", err)
+	}
+	addr := ln.Addr().String()
+	ln.Close() // Close immediately so port is not listening.
+
+	checker := NewTCPChecker(2 * time.Second)
+	result, err := checker.Check(context.Background(), addr)
+
+	if err == nil {
+		t.Error("Check() error = nil, want error for refused connection")
+	}
+	if result == nil {
+		t.Fatal("Check() returned nil result")
+	}
+	if result.Success {
+		t.Error("Check() Success = true, want false")
+	}
+	if result.ErrorMessage == "" {
+		t.Error("Check() ErrorMessage is empty, want non-empty")
+	}
+}
+
+func TestTCPChecker_InvalidTarget(t *testing.T) {
+	tests := []struct {
+		name   string
+		target string
+	}{
+		{"no port", "192.168.1.1"},
+		{"empty", ""},
+		{"just port", ":"},
+		{"invalid format", "not-a-host-port"},
+	}
+
+	checker := NewTCPChecker(2 * time.Second)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := checker.Check(context.Background(), tt.target)
+
+			if err == nil {
+				t.Error("Check() error = nil, want error for invalid target")
+			}
+			if result == nil {
+				t.Fatal("Check() returned nil result")
+			}
+			if result.Success {
+				t.Error("Check() Success = true, want false")
+			}
+			if result.ErrorMessage == "" {
+				t.Error("Check() ErrorMessage is empty, want non-empty")
+			}
+		})
+	}
+}
+
+func TestTCPChecker_ContextCancelled(t *testing.T) {
+	// Use a non-routable IP that will cause the dial to hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	checker := NewTCPChecker(30 * time.Second) // Long timeout, context should cancel first.
+	start := time.Now()
+	result, err := checker.Check(ctx, "10.255.255.1:80")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Error("Check() error = nil, want error for cancelled context")
+	}
+	if result == nil {
+		t.Fatal("Check() returned nil result")
+	}
+	if result.Success {
+		t.Error("Check() Success = true, want false")
+	}
+	// Should return within a reasonable time after context cancellation.
+	if elapsed > 2*time.Second {
+		t.Errorf("Check() took %v, want < 2s (should respect context cancellation)", elapsed)
+	}
+}

--- a/internal/recon/snmp_collector.go
+++ b/internal/recon/snmp_collector.go
@@ -1,0 +1,99 @@
+// Phase 2: implement SNMP discovery using gosnmp/gosnmp (BSD-2-Clause).
+// See .planning/phases/04-phase2-foundation/04-01-FINDINGS.md for research and API examples.
+
+package recon
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/HerbHall/subnetree/pkg/models"
+	"go.uber.org/zap"
+)
+
+// CredentialAccessor retrieves stored credentials for SNMP authentication.
+// Defined here (consumer-side) to avoid importing the vault package.
+type CredentialAccessor interface {
+	GetCredential(ctx context.Context, id string) (*SNMPCredential, error)
+}
+
+// SNMPCredential holds the fields needed for SNMP authentication.
+type SNMPCredential struct {
+	Type string // "snmp_v2c" or "snmp_v3"
+
+	// SNMPv2c fields.
+	Community string
+
+	// SNMPv3 fields.
+	Username             string
+	AuthProtocol         string // "MD5", "SHA", "SHA-256", etc.
+	AuthPassphrase       string
+	PrivacyProtocol      string // "DES", "AES", "AES-256", etc.
+	PrivacyPassphrase    string
+	SecurityLevel        string // "noAuthNoPriv", "authNoPriv", "authPriv"
+	ContextName          string
+	AuthoritativeEngineID string
+}
+
+// SNMPSystemInfo holds basic system information retrieved via SNMP.
+type SNMPSystemInfo struct {
+	Description string        // sysDescr (1.3.6.1.2.1.1.1.0)
+	ObjectID    string        // sysObjectID (1.3.6.1.2.1.1.2.0)
+	UpTime      time.Duration // sysUpTime (1.3.6.1.2.1.1.3.0)
+	Contact     string        // sysContact (1.3.6.1.2.1.1.4.0)
+	Name        string        // sysName (1.3.6.1.2.1.1.5.0)
+	Location    string        // sysLocation (1.3.6.1.2.1.1.6.0)
+}
+
+// SNMPInterface represents a network interface discovered via SNMP IF-MIB.
+type SNMPInterface struct {
+	Index       int    // ifIndex
+	Description string // ifDescr
+	Type        int    // ifType (e.g., 6=ethernet, 24=loopback)
+	MTU         int    // ifMtu
+	Speed       uint64 // ifSpeed (bits per second)
+	PhysAddress string // ifPhysAddress (MAC)
+	AdminStatus int    // ifAdminStatus (1=up, 2=down, 3=testing)
+	OperStatus  int    // ifOperStatus (1=up, 2=down, 3=testing, etc.)
+}
+
+// SNMPCollector discovers device information using SNMP queries.
+type SNMPCollector struct {
+	logger *zap.Logger
+}
+
+// NewSNMPCollector creates a new SNMP collector.
+func NewSNMPCollector(logger *zap.Logger) *SNMPCollector {
+	return &SNMPCollector{logger: logger}
+}
+
+// Discover uses SNMP to discover devices at the given target IP.
+// It queries standard system MIB objects and returns device information.
+func (c *SNMPCollector) Discover(ctx context.Context, target string, cred CredentialAccessor, credID string) ([]models.Device, error) {
+	_ = ctx
+	_ = target
+	_ = cred
+	_ = credID
+	return nil, fmt.Errorf("SNMP discovery not implemented: pending gosnmp integration")
+}
+
+// GetSystemInfo retrieves basic system information from an SNMP-enabled device.
+// Queries: sysDescr, sysObjectID, sysUpTime, sysContact, sysName, sysLocation.
+func (c *SNMPCollector) GetSystemInfo(ctx context.Context, target string, cred CredentialAccessor, credID string) (*SNMPSystemInfo, error) {
+	_ = ctx
+	_ = target
+	_ = cred
+	_ = credID
+	return nil, fmt.Errorf("SNMP GetSystemInfo not implemented: pending gosnmp integration")
+}
+
+// GetInterfaces retrieves the interface table from an SNMP-enabled device.
+// Walks the IF-MIB ifTable for interface descriptions, types, status, and counters.
+func (c *SNMPCollector) GetInterfaces(ctx context.Context, target string, cred CredentialAccessor, credID string) ([]SNMPInterface, error) {
+	_ = ctx
+	_ = target
+	_ = cred
+	_ = credID
+	return nil, fmt.Errorf("SNMP GetInterfaces not implemented: pending gosnmp integration")
+}


### PR DESCRIPTION
## Summary

Closes #189

- **TCP checker**: `TCPChecker` uses `net.DialContext` to test host:port connectivity with latency measurement
- **HTTP checker**: `HTTPChecker` sends GET requests, validates 2xx responses, accepts self-signed TLS certs
- **Multi-checker registry**: Refactored `pulse.Module` from single `checker Checker` to `checkers map[string]Checker` -- `executeCheck` dispatches by `check.CheckType`
- **SNMP collector skeleton**: `SNMPCollector` in Recon with `Discover`, `GetSystemInfo`, `GetInterfaces` stubs and data structures (`SNMPSystemInfo`, `SNMPInterface`, `SNMPCredential`)
- **SNMP research**: Evaluated Go SNMP libraries, recommending `gosnmp/gosnmp` (BSD-2, 1.2k stars, full v2c/v3 support)

## Files

| File | Change |
|------|--------|
| `internal/pulse/tcp_checker.go` | New -- TCPChecker implementation |
| `internal/pulse/tcp_checker_test.go` | New -- 6 test cases (success, refused, invalid, timeout) |
| `internal/pulse/http_checker.go` | New -- HTTPChecker implementation |
| `internal/pulse/http_checker_test.go` | New -- 9 test cases (2xx, non-2xx, TLS, timeout) |
| `internal/pulse/pulse.go` | Modified -- checker registry, type-aware dispatch and metrics |
| `internal/recon/snmp_collector.go` | New -- SNMP collector skeleton with types |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/pulse/... -count=1` passes (all 15 new + existing tests)
- [x] `go test ./internal/recon/... -count=1` passes
- [x] `go vet ./internal/pulse/... ./internal/recon/...` clean
- [x] `golangci-lint run ./internal/pulse/... ./internal/recon/...` clean
- [ ] CI workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)