### PR TITLE
feat: SNMP discovery implementation with gosnmp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/go-openapi/spec v0.20.6 // indirect
 	github.com/go-openapi/swag v0.19.15 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
+	github.com/gosnmp/gosnmp v1.43.2 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17k
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gosnmp/gosnmp v1.43.2 h1:F9loz6uMCNtIQj0RNO5wz/mZ+FZt2WyNKJYOvw+Zosw=
+github.com/gosnmp/gosnmp v1.43.2/go.mod h1:smHIwoaqr1M+HTAEd7+mKkPs8lp3Lf/U+htPUql1Q3c=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=

--- a/internal/recon/snmp_collector.go
+++ b/internal/recon/snmp_collector.go
@@ -6,10 +6,17 @@ package recon
 import (
 	"context"
 	"fmt"
+	"net"
+	"sort"
+	"strconv"
+	"strings"
 	"time"
 
-	"github.com/HerbHall/subnetree/pkg/models"
+	"github.com/google/uuid"
+	"github.com/gosnmp/gosnmp"
 	"go.uber.org/zap"
+
+	"github.com/HerbHall/subnetree/pkg/models"
 )
 
 // CredentialAccessor retrieves stored credentials for SNMP authentication.
@@ -26,13 +33,13 @@ type SNMPCredential struct {
 	Community string
 
 	// SNMPv3 fields.
-	Username             string
-	AuthProtocol         string // "MD5", "SHA", "SHA-256", etc.
-	AuthPassphrase       string
-	PrivacyProtocol      string // "DES", "AES", "AES-256", etc.
-	PrivacyPassphrase    string
-	SecurityLevel        string // "noAuthNoPriv", "authNoPriv", "authPriv"
-	ContextName          string
+	Username              string
+	AuthProtocol          string // "MD5", "SHA", "SHA-256", etc.
+	AuthPassphrase        string
+	PrivacyProtocol       string // "DES", "AES", "AES-256", etc.
+	PrivacyPassphrase     string
+	SecurityLevel         string // "noAuthNoPriv", "authNoPriv", "authPriv"
+	ContextName           string
 	AuthoritativeEngineID string
 }
 
@@ -68,32 +75,443 @@ func NewSNMPCollector(logger *zap.Logger) *SNMPCollector {
 	return &SNMPCollector{logger: logger}
 }
 
-// Discover uses SNMP to discover devices at the given target IP.
-// It queries standard system MIB objects and returns device information.
-func (c *SNMPCollector) Discover(ctx context.Context, target string, cred CredentialAccessor, credID string) ([]models.Device, error) {
-	_ = ctx
-	_ = target
-	_ = cred
-	_ = credID
-	return nil, fmt.Errorf("SNMP discovery not implemented: pending gosnmp integration")
+// newGoSNMP creates a configured GoSNMP instance for the given target and credential.
+// The returned GoSNMP is not yet connected; the caller must call Connect().
+func (c *SNMPCollector) newGoSNMP(target string, cred *SNMPCredential) (*gosnmp.GoSNMP, error) {
+	host, portStr, err := net.SplitHostPort(target)
+	if err != nil {
+		// No port specified, default to 161.
+		host = target
+		portStr = "161"
+	}
+
+	port, err := strconv.ParseUint(portStr, 10, 16)
+	if err != nil {
+		return nil, fmt.Errorf("invalid port %q: %w", portStr, err)
+	}
+
+	g := &gosnmp.GoSNMP{
+		Target:  host,
+		Port:    uint16(port),
+		Timeout: 5 * time.Second,
+		Retries: 1,
+	}
+
+	switch cred.Type {
+	case "snmp_v2c":
+		g.Version = gosnmp.Version2c
+		g.Community = cred.Community
+
+	case "snmp_v3":
+		g.Version = gosnmp.Version3
+		g.SecurityModel = gosnmp.UserSecurityModel
+
+		// Map security level to MsgFlags.
+		switch cred.SecurityLevel {
+		case "noAuthNoPriv":
+			g.MsgFlags = gosnmp.NoAuthNoPriv
+		case "authNoPriv":
+			g.MsgFlags = gosnmp.AuthNoPriv
+		case "authPriv":
+			g.MsgFlags = gosnmp.AuthPriv
+		default:
+			g.MsgFlags = gosnmp.AuthPriv
+		}
+
+		g.SecurityParameters = &gosnmp.UsmSecurityParameters{
+			UserName:                 cred.Username,
+			AuthenticationProtocol:   mapAuthProtocol(cred.AuthProtocol),
+			AuthenticationPassphrase: cred.AuthPassphrase,
+			PrivacyProtocol:          mapPrivProtocol(cred.PrivacyProtocol),
+			PrivacyPassphrase:        cred.PrivacyPassphrase,
+			AuthoritativeEngineID:    cred.AuthoritativeEngineID,
+		}
+
+		if cred.ContextName != "" {
+			g.ContextName = cred.ContextName
+		}
+
+	default:
+		return nil, fmt.Errorf("unsupported SNMP credential type: %s", cred.Type)
+	}
+
+	return g, nil
+}
+
+// mapAuthProtocol converts an auth protocol string to the gosnmp constant.
+func mapAuthProtocol(s string) gosnmp.SnmpV3AuthProtocol {
+	switch strings.ToUpper(s) {
+	case "MD5":
+		return gosnmp.MD5
+	case "SHA":
+		return gosnmp.SHA
+	case "SHA-224", "SHA224":
+		return gosnmp.SHA224
+	case "SHA-256", "SHA256":
+		return gosnmp.SHA256
+	case "SHA-384", "SHA384":
+		return gosnmp.SHA384
+	case "SHA-512", "SHA512":
+		return gosnmp.SHA512
+	default:
+		return gosnmp.SHA
+	}
+}
+
+// mapPrivProtocol converts a privacy protocol string to the gosnmp constant.
+func mapPrivProtocol(s string) gosnmp.SnmpV3PrivProtocol {
+	switch strings.ToUpper(s) {
+	case "DES":
+		return gosnmp.DES
+	case "AES", "AES-128", "AES128":
+		return gosnmp.AES
+	case "AES-192", "AES192":
+		return gosnmp.AES192
+	case "AES-256", "AES256":
+		return gosnmp.AES256
+	case "AES-192C", "AES192C":
+		return gosnmp.AES192C
+	case "AES-256C", "AES256C":
+		return gosnmp.AES256C
+	default:
+		return gosnmp.AES
+	}
 }
 
 // GetSystemInfo retrieves basic system information from an SNMP-enabled device.
 // Queries: sysDescr, sysObjectID, sysUpTime, sysContact, sysName, sysLocation.
 func (c *SNMPCollector) GetSystemInfo(ctx context.Context, target string, cred CredentialAccessor, credID string) (*SNMPSystemInfo, error) {
-	_ = ctx
-	_ = target
-	_ = cred
-	_ = credID
-	return nil, fmt.Errorf("SNMP GetSystemInfo not implemented: pending gosnmp integration")
+	credential, err := cred.GetCredential(ctx, credID)
+	if err != nil {
+		return nil, fmt.Errorf("get credential: %w", err)
+	}
+
+	g, err := c.newGoSNMP(target, credential)
+	if err != nil {
+		return nil, fmt.Errorf("configure SNMP: %w", err)
+	}
+
+	if err := g.Connect(); err != nil {
+		return nil, fmt.Errorf("connect to %s: %w", target, err)
+	}
+	defer func() { _ = g.Conn.Close() }()
+
+	oids := []string{
+		OIDSysDescr,
+		OIDSysObjectID,
+		OIDSysUpTime,
+		OIDSysContact,
+		OIDSysName,
+		OIDSysLocation,
+	}
+
+	result, err := g.Get(oids)
+	if err != nil {
+		return nil, fmt.Errorf("SNMP GET system info: %w", err)
+	}
+
+	info := &SNMPSystemInfo{}
+	for _, pdu := range result.Variables {
+		switch pdu.Name {
+		case "." + OIDSysDescr:
+			info.Description = parsePDUString(pdu)
+		case "." + OIDSysObjectID:
+			info.ObjectID = parsePDUString(pdu)
+		case "." + OIDSysUpTime:
+			info.UpTime = parsePDUUpTime(pdu)
+		case "." + OIDSysContact:
+			info.Contact = parsePDUString(pdu)
+		case "." + OIDSysName:
+			info.Name = parsePDUString(pdu)
+		case "." + OIDSysLocation:
+			info.Location = parsePDUString(pdu)
+		}
+	}
+
+	c.logger.Debug("SNMP system info retrieved",
+		zap.String("target", target),
+		zap.String("name", info.Name),
+		zap.String("descr", info.Description),
+	)
+
+	return info, nil
 }
 
 // GetInterfaces retrieves the interface table from an SNMP-enabled device.
 // Walks the IF-MIB ifTable for interface descriptions, types, status, and counters.
 func (c *SNMPCollector) GetInterfaces(ctx context.Context, target string, cred CredentialAccessor, credID string) ([]SNMPInterface, error) {
-	_ = ctx
-	_ = target
-	_ = cred
-	_ = credID
-	return nil, fmt.Errorf("SNMP GetInterfaces not implemented: pending gosnmp integration")
+	credential, err := cred.GetCredential(ctx, credID)
+	if err != nil {
+		return nil, fmt.Errorf("get credential: %w", err)
+	}
+
+	g, err := c.newGoSNMP(target, credential)
+	if err != nil {
+		return nil, fmt.Errorf("configure SNMP: %w", err)
+	}
+
+	if err := g.Connect(); err != nil {
+		return nil, fmt.Errorf("connect to %s: %w", target, err)
+	}
+	defer func() { _ = g.Conn.Close() }()
+
+	pdus, err := g.BulkWalkAll("1.3.6.1.2.1.2.2.1")
+	if err != nil {
+		return nil, fmt.Errorf("SNMP walk IF-MIB: %w", err)
+	}
+
+	// Group PDUs by interface index.
+	ifMap := make(map[int]*SNMPInterface)
+
+	for _, pdu := range pdus {
+		// Extract ifIndex from OID suffix (last number after last dot).
+		idx := extractOIDIndex(pdu.Name)
+		if idx < 0 {
+			continue
+		}
+
+		iface, ok := ifMap[idx]
+		if !ok {
+			iface = &SNMPInterface{Index: idx}
+			ifMap[idx] = iface
+		}
+
+		// Match OID prefix to determine which field this PDU populates.
+		oidPrefix := extractOIDPrefix(pdu.Name)
+		switch oidPrefix {
+		case "."+OIDIfIndex, OIDIfIndex:
+			iface.Index = parsePDUInt(pdu)
+		case "."+OIDIfDescr, OIDIfDescr:
+			iface.Description = parsePDUString(pdu)
+		case "."+OIDIfType, OIDIfType:
+			iface.Type = parsePDUInt(pdu)
+		case "."+OIDIfMtu, OIDIfMtu:
+			iface.MTU = parsePDUInt(pdu)
+		case "."+OIDIfSpeed, OIDIfSpeed:
+			iface.Speed = parsePDUUint64(pdu)
+		case "."+OIDIfPhysAddress, OIDIfPhysAddress:
+			if b, ok := pdu.Value.([]byte); ok {
+				iface.PhysAddress = formatMAC(b)
+			}
+		case "."+OIDIfAdminStatus, OIDIfAdminStatus:
+			iface.AdminStatus = parsePDUInt(pdu)
+		case "."+OIDIfOperStatus, OIDIfOperStatus:
+			iface.OperStatus = parsePDUInt(pdu)
+		}
+	}
+
+	// Convert map to sorted slice.
+	interfaces := make([]SNMPInterface, 0, len(ifMap))
+	for _, iface := range ifMap {
+		interfaces = append(interfaces, *iface)
+	}
+	sort.Slice(interfaces, func(i, j int) bool {
+		return interfaces[i].Index < interfaces[j].Index
+	})
+
+	c.logger.Debug("SNMP interfaces retrieved",
+		zap.String("target", target),
+		zap.Int("count", len(interfaces)),
+	)
+
+	return interfaces, nil
+}
+
+// Discover uses SNMP to discover devices at the given target IP.
+// It queries standard system MIB objects and returns device information.
+func (c *SNMPCollector) Discover(ctx context.Context, target string, cred CredentialAccessor, credID string) ([]models.Device, error) {
+	sysInfo, err := c.GetSystemInfo(ctx, target, cred, credID)
+	if err != nil {
+		return nil, fmt.Errorf("get system info: %w", err)
+	}
+
+	interfaces, err := c.GetInterfaces(ctx, target, cred, credID)
+	if err != nil {
+		c.logger.Warn("failed to get interfaces, continuing with system info only",
+			zap.String("target", target),
+			zap.Error(err),
+		)
+		interfaces = nil
+	}
+
+	// Determine hostname.
+	hostname := sysInfo.Name
+	if hostname == "" {
+		// Strip port from target if present.
+		h, _, splitErr := net.SplitHostPort(target)
+		if splitErr != nil {
+			hostname = target
+		} else {
+			hostname = h
+		}
+	}
+
+	// Find first non-loopback MAC address.
+	var macAddr string
+	for i := range interfaces {
+		// ifType 24 = softwareLoopback.
+		if interfaces[i].Type == 24 {
+			continue
+		}
+		if interfaces[i].PhysAddress != "" && interfaces[i].PhysAddress != "00:00:00:00:00:00" {
+			macAddr = interfaces[i].PhysAddress
+			break
+		}
+	}
+
+	// Extract IP (strip port if present).
+	ip := target
+	if h, _, splitErr := net.SplitHostPort(target); splitErr == nil {
+		ip = h
+	}
+
+	now := time.Now()
+
+	device := models.Device{
+		ID:              uuid.New().String(),
+		Hostname:        hostname,
+		DeviceType:      inferDeviceType(sysInfo.Description),
+		DiscoveryMethod: models.DiscoverySNMP,
+		IPAddresses:     []string{ip},
+		MACAddress:      macAddr,
+		Status:          models.DeviceStatusOnline,
+		FirstSeen:       now,
+		LastSeen:        now,
+	}
+
+	c.logger.Info("SNMP device discovered",
+		zap.String("target", target),
+		zap.String("hostname", device.Hostname),
+		zap.String("type", string(device.DeviceType)),
+		zap.String("mac", device.MACAddress),
+	)
+
+	return []models.Device{device}, nil
+}
+
+// inferDeviceType attempts to determine the device type from the sysDescr string.
+func inferDeviceType(sysDescr string) models.DeviceType {
+	lower := strings.ToLower(sysDescr)
+
+	switch {
+	case strings.Contains(lower, "router"):
+		return models.DeviceTypeRouter
+	case strings.Contains(lower, "switch"):
+		return models.DeviceTypeSwitch
+	case strings.Contains(lower, "firewall"):
+		return models.DeviceTypeFirewall
+	case strings.Contains(lower, "printer"):
+		return models.DeviceTypePrinter
+	case strings.Contains(lower, "access point") || strings.Contains(lower, "wireless"):
+		return models.DeviceTypeAccessPoint
+	case strings.Contains(lower, "nas") || strings.Contains(lower, "storage"):
+		return models.DeviceTypeNAS
+	case strings.Contains(lower, "linux") || strings.Contains(lower, "windows") || strings.Contains(lower, "freebsd"):
+		return models.DeviceTypeServer
+	default:
+		return models.DeviceTypeUnknown
+	}
+}
+
+// formatMAC formats a byte slice as a colon-separated MAC address (XX:XX:XX:XX:XX:XX).
+func formatMAC(b []byte) string {
+	if len(b) == 0 {
+		return ""
+	}
+	parts := make([]string, len(b))
+	for i, v := range b {
+		parts[i] = fmt.Sprintf("%02X", v)
+	}
+	return strings.Join(parts, ":")
+}
+
+// parsePDUString extracts a string value from an SNMP PDU.
+func parsePDUString(pdu gosnmp.SnmpPDU) string {
+	switch v := pdu.Value.(type) {
+	case []byte:
+		return string(v)
+	case string:
+		return v
+	default:
+		if v == nil {
+			return ""
+		}
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+// parsePDUUpTime extracts a TimeTicks value (hundredths of a second) from
+// an SNMP PDU and converts it to a time.Duration.
+func parsePDUUpTime(pdu gosnmp.SnmpPDU) time.Duration {
+	switch v := pdu.Value.(type) {
+	case uint32:
+		return time.Duration(v) * 10 * time.Millisecond
+	case uint:
+		return time.Duration(int64(v)) * 10 * time.Millisecond //nolint:gosec // G115: SNMP TimeTicks fits in int64
+	case int:
+		return time.Duration(v) * 10 * time.Millisecond
+	default:
+		return 0
+	}
+}
+
+// parsePDUInt extracts an integer value from an SNMP PDU.
+func parsePDUInt(pdu gosnmp.SnmpPDU) int {
+	switch v := pdu.Value.(type) {
+	case int:
+		return v
+	case int64:
+		return int(v)
+	case uint:
+		return int(v) //nolint:gosec // G115: SNMP integer values (ifIndex, ifType, etc.) fit in int
+	case uint32:
+		return int(v)
+	case uint64:
+		return int(v) //nolint:gosec // G115: SNMP integer values (ifIndex, ifType, etc.) fit in int
+	default:
+		return 0
+	}
+}
+
+// parsePDUUint64 extracts a uint64 value from an SNMP PDU.
+func parsePDUUint64(pdu gosnmp.SnmpPDU) uint64 {
+	switch v := pdu.Value.(type) {
+	case uint64:
+		return v
+	case uint32:
+		return uint64(v)
+	case uint:
+		return uint64(v)
+	case int:
+		if v >= 0 {
+			return uint64(v)
+		}
+		return 0
+	default:
+		return 0
+	}
+}
+
+// extractOIDIndex extracts the last numeric segment from an OID string.
+// For example, ".1.3.6.1.2.1.2.2.1.2.3" returns 3.
+func extractOIDIndex(oid string) int {
+	lastDot := strings.LastIndex(oid, ".")
+	if lastDot < 0 || lastDot == len(oid)-1 {
+		return -1
+	}
+	idx, err := strconv.Atoi(oid[lastDot+1:])
+	if err != nil {
+		return -1
+	}
+	return idx
+}
+
+// extractOIDPrefix returns the OID with the last segment removed.
+// For example, ".1.3.6.1.2.1.2.2.1.2.3" returns ".1.3.6.1.2.1.2.2.1.2".
+func extractOIDPrefix(oid string) string {
+	lastDot := strings.LastIndex(oid, ".")
+	if lastDot < 0 {
+		return oid
+	}
+	return oid[:lastDot]
 }

--- a/internal/recon/snmp_collector_test.go
+++ b/internal/recon/snmp_collector_test.go
@@ -1,0 +1,417 @@
+package recon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gosnmp/gosnmp"
+	"github.com/HerbHall/subnetree/pkg/models"
+)
+
+func TestNewGoSNMP_V2c(t *testing.T) {
+	c := NewSNMPCollector(nil)
+	cred := &SNMPCredential{
+		Type:      "snmp_v2c",
+		Community: "public",
+	}
+
+	g, err := c.newGoSNMP("192.168.1.1", cred)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if g.Target != "192.168.1.1" {
+		t.Errorf("target = %q, want %q", g.Target, "192.168.1.1")
+	}
+	if g.Port != 161 {
+		t.Errorf("port = %d, want 161", g.Port)
+	}
+	if g.Version != gosnmp.Version2c {
+		t.Errorf("version = %v, want Version2c", g.Version)
+	}
+	if g.Community != "public" {
+		t.Errorf("community = %q, want %q", g.Community, "public")
+	}
+	if g.Timeout != 5*time.Second {
+		t.Errorf("timeout = %v, want 5s", g.Timeout)
+	}
+	if g.Retries != 1 {
+		t.Errorf("retries = %d, want 1", g.Retries)
+	}
+}
+
+func TestNewGoSNMP_V2c_WithPort(t *testing.T) {
+	c := NewSNMPCollector(nil)
+	cred := &SNMPCredential{
+		Type:      "snmp_v2c",
+		Community: "public",
+	}
+
+	g, err := c.newGoSNMP("192.168.1.1:1161", cred)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if g.Target != "192.168.1.1" {
+		t.Errorf("target = %q, want %q", g.Target, "192.168.1.1")
+	}
+	if g.Port != 1161 {
+		t.Errorf("port = %d, want 1161", g.Port)
+	}
+}
+
+func TestNewGoSNMP_V3(t *testing.T) {
+	c := NewSNMPCollector(nil)
+	cred := &SNMPCredential{
+		Type:              "snmp_v3",
+		Username:          "admin",
+		AuthProtocol:      "SHA-256",
+		AuthPassphrase:    "authpass123",
+		PrivacyProtocol:   "AES-256",
+		PrivacyPassphrase: "privpass123",
+		SecurityLevel:     "authPriv",
+		ContextName:       "mycontext",
+	}
+
+	g, err := c.newGoSNMP("10.0.0.1", cred)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if g.Version != gosnmp.Version3 {
+		t.Errorf("version = %v, want Version3", g.Version)
+	}
+	if g.SecurityModel != gosnmp.UserSecurityModel {
+		t.Errorf("security model = %v, want UserSecurityModel", g.SecurityModel)
+	}
+	if g.MsgFlags != gosnmp.AuthPriv {
+		t.Errorf("msg flags = %v, want AuthPriv", g.MsgFlags)
+	}
+	if g.ContextName != "mycontext" {
+		t.Errorf("context name = %q, want %q", g.ContextName, "mycontext")
+	}
+
+	usp, ok := g.SecurityParameters.(*gosnmp.UsmSecurityParameters)
+	if !ok {
+		t.Fatal("security parameters is not *UsmSecurityParameters")
+	}
+	if usp.UserName != "admin" {
+		t.Errorf("username = %q, want %q", usp.UserName, "admin")
+	}
+	if usp.AuthenticationProtocol != gosnmp.SHA256 {
+		t.Errorf("auth protocol = %v, want SHA256", usp.AuthenticationProtocol)
+	}
+	if usp.AuthenticationPassphrase != "authpass123" {
+		t.Errorf("auth passphrase = %q, want %q", usp.AuthenticationPassphrase, "authpass123")
+	}
+	if usp.PrivacyProtocol != gosnmp.AES256 {
+		t.Errorf("priv protocol = %v, want AES256", usp.PrivacyProtocol)
+	}
+	if usp.PrivacyPassphrase != "privpass123" {
+		t.Errorf("priv passphrase = %q, want %q", usp.PrivacyPassphrase, "privpass123")
+	}
+}
+
+func TestNewGoSNMP_V3_SecurityLevels(t *testing.T) {
+	c := NewSNMPCollector(nil)
+	tests := []struct {
+		level string
+		want  gosnmp.SnmpV3MsgFlags
+	}{
+		{"noAuthNoPriv", gosnmp.NoAuthNoPriv},
+		{"authNoPriv", gosnmp.AuthNoPriv},
+		{"authPriv", gosnmp.AuthPriv},
+		{"unknown", gosnmp.AuthPriv}, // default
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.level, func(t *testing.T) {
+			cred := &SNMPCredential{
+				Type:          "snmp_v3",
+				Username:      "user",
+				SecurityLevel: tt.level,
+			}
+			g, err := c.newGoSNMP("10.0.0.1", cred)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if g.MsgFlags != tt.want {
+				t.Errorf("MsgFlags = %v, want %v", g.MsgFlags, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewGoSNMP_InvalidType(t *testing.T) {
+	c := NewSNMPCollector(nil)
+	cred := &SNMPCredential{
+		Type: "snmp_v1",
+	}
+
+	_, err := c.newGoSNMP("192.168.1.1", cred)
+	if err == nil {
+		t.Fatal("expected error for unsupported type, got nil")
+	}
+}
+
+func TestMapAuthProtocol(t *testing.T) {
+	tests := []struct {
+		input string
+		want  gosnmp.SnmpV3AuthProtocol
+	}{
+		{"MD5", gosnmp.MD5},
+		{"md5", gosnmp.MD5},
+		{"SHA", gosnmp.SHA},
+		{"sha", gosnmp.SHA},
+		{"SHA-224", gosnmp.SHA224},
+		{"SHA224", gosnmp.SHA224},
+		{"SHA-256", gosnmp.SHA256},
+		{"SHA256", gosnmp.SHA256},
+		{"SHA-384", gosnmp.SHA384},
+		{"SHA384", gosnmp.SHA384},
+		{"SHA-512", gosnmp.SHA512},
+		{"SHA512", gosnmp.SHA512},
+		{"", gosnmp.SHA},       // default
+		{"unknown", gosnmp.SHA}, // default
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := mapAuthProtocol(tt.input)
+			if got != tt.want {
+				t.Errorf("mapAuthProtocol(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMapPrivProtocol(t *testing.T) {
+	tests := []struct {
+		input string
+		want  gosnmp.SnmpV3PrivProtocol
+	}{
+		{"DES", gosnmp.DES},
+		{"des", gosnmp.DES},
+		{"AES", gosnmp.AES},
+		{"aes", gosnmp.AES},
+		{"AES-128", gosnmp.AES},
+		{"AES128", gosnmp.AES},
+		{"AES-192", gosnmp.AES192},
+		{"AES192", gosnmp.AES192},
+		{"AES-256", gosnmp.AES256},
+		{"AES256", gosnmp.AES256},
+		{"AES-192C", gosnmp.AES192C},
+		{"AES192C", gosnmp.AES192C},
+		{"AES-256C", gosnmp.AES256C},
+		{"AES256C", gosnmp.AES256C},
+		{"", gosnmp.AES},       // default
+		{"unknown", gosnmp.AES}, // default
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := mapPrivProtocol(tt.input)
+			if got != tt.want {
+				t.Errorf("mapPrivProtocol(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParsePDUString(t *testing.T) {
+	tests := []struct {
+		name  string
+		value any
+		want  string
+	}{
+		{"byte_slice", []byte("hello"), "hello"},
+		{"string", "world", "world"},
+		{"int", 42, "42"},
+		{"nil", nil, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pdu := gosnmp.SnmpPDU{Value: tt.value}
+			got := parsePDUString(pdu)
+			if got != tt.want {
+				t.Errorf("parsePDUString() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParsePDUUpTime(t *testing.T) {
+	tests := []struct {
+		name  string
+		value any
+		want  time.Duration
+	}{
+		{"uint32", uint32(100), time.Second},          // 100 centiseconds = 1s
+		{"uint32_large", uint32(360000), time.Hour},   // 360000 * 10ms = 1h
+		{"uint", uint(500), 5 * time.Second},
+		{"int", int(200), 2 * time.Second},
+		{"nil", nil, 0},
+		{"string", "not a number", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pdu := gosnmp.SnmpPDU{Value: tt.value}
+			got := parsePDUUpTime(pdu)
+			if got != tt.want {
+				t.Errorf("parsePDUUpTime() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatMAC(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []byte
+		want  string
+	}{
+		{"standard_6_bytes", []byte{0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E}, "00:1A:2B:3C:4D:5E"},
+		{"all_zeros", []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, "00:00:00:00:00:00"},
+		{"all_ff", []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}, "FF:FF:FF:FF:FF:FF"},
+		{"empty", []byte{}, ""},
+		{"nil", nil, ""},
+		{"single_byte", []byte{0xAB}, "AB"},
+		{"eight_bytes", []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}, "01:02:03:04:05:06:07:08"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatMAC(tt.input)
+			if got != tt.want {
+				t.Errorf("formatMAC() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInferDeviceType(t *testing.T) {
+	tests := []struct {
+		sysDescr string
+		want     models.DeviceType
+	}{
+		{"Cisco IOS Software, Router", models.DeviceTypeRouter},
+		{"ROUTER firmware v2.1", models.DeviceTypeRouter},
+		{"HP ProCurve Switch", models.DeviceTypeSwitch},
+		{"Juniper Firewall SRX", models.DeviceTypeFirewall},
+		{"HP LaserJet Printer", models.DeviceTypePrinter},
+		{"Ubiquiti Access Point", models.DeviceTypeAccessPoint},
+		{"Wireless Controller", models.DeviceTypeAccessPoint},
+		{"Synology NAS DS920+", models.DeviceTypeNAS},
+		{"NetApp Storage System", models.DeviceTypeNAS},
+		{"Linux 5.15.0-generic", models.DeviceTypeServer},
+		{"Microsoft Windows Server 2022", models.DeviceTypeServer},
+		{"FreeBSD 14.0-RELEASE", models.DeviceTypeServer},
+		{"Some Unknown Device", models.DeviceTypeUnknown},
+		{"", models.DeviceTypeUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.sysDescr, func(t *testing.T) {
+			got := inferDeviceType(tt.sysDescr)
+			if got != tt.want {
+				t.Errorf("inferDeviceType(%q) = %v, want %v", tt.sysDescr, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractOIDIndex(t *testing.T) {
+	tests := []struct {
+		oid  string
+		want int
+	}{
+		{".1.3.6.1.2.1.2.2.1.2.3", 3},
+		{".1.3.6.1.2.1.2.2.1.1.1", 1},
+		{".1.3.6.1.2.1.2.2.1.6.10", 10},
+		{"invalid", -1},
+		{"", -1},
+		{".1.3.6.1.2.1.2.2.1.2.", -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.oid, func(t *testing.T) {
+			got := extractOIDIndex(tt.oid)
+			if got != tt.want {
+				t.Errorf("extractOIDIndex(%q) = %d, want %d", tt.oid, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractOIDPrefix(t *testing.T) {
+	tests := []struct {
+		oid  string
+		want string
+	}{
+		{".1.3.6.1.2.1.2.2.1.2.3", ".1.3.6.1.2.1.2.2.1.2"},
+		{".1.3.6.1.2.1.2.2.1.1.1", ".1.3.6.1.2.1.2.2.1.1"},
+		{"nodots", "nodots"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.oid, func(t *testing.T) {
+			got := extractOIDPrefix(tt.oid)
+			if got != tt.want {
+				t.Errorf("extractOIDPrefix(%q) = %q, want %q", tt.oid, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParsePDUInt(t *testing.T) {
+	tests := []struct {
+		name  string
+		value any
+		want  int
+	}{
+		{"int", int(42), 42},
+		{"int64", int64(100), 100},
+		{"uint", uint(7), 7},
+		{"uint32", uint32(255), 255},
+		{"uint64", uint64(1000), 1000},
+		{"nil", nil, 0},
+		{"string", "not a number", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pdu := gosnmp.SnmpPDU{Value: tt.value}
+			got := parsePDUInt(pdu)
+			if got != tt.want {
+				t.Errorf("parsePDUInt() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParsePDUUint64(t *testing.T) {
+	tests := []struct {
+		name  string
+		value any
+		want  uint64
+	}{
+		{"uint64", uint64(1000000), 1000000},
+		{"uint32", uint32(500), 500},
+		{"uint", uint(42), 42},
+		{"int_positive", int(99), 99},
+		{"int_negative", int(-1), 0},
+		{"nil", nil, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pdu := gosnmp.SnmpPDU{Value: tt.value}
+			got := parsePDUUint64(pdu)
+			if got != tt.want {
+				t.Errorf("parsePDUUint64() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/recon/snmp_oids.go
+++ b/internal/recon/snmp_oids.go
@@ -1,0 +1,25 @@
+package recon
+
+// Standard SNMP OIDs for device discovery.
+
+// SNMPv2-MIB system group (1.3.6.1.2.1.1).
+const (
+	OIDSysDescr    = "1.3.6.1.2.1.1.1.0"
+	OIDSysObjectID = "1.3.6.1.2.1.1.2.0"
+	OIDSysUpTime   = "1.3.6.1.2.1.1.3.0"
+	OIDSysContact  = "1.3.6.1.2.1.1.4.0"
+	OIDSysName     = "1.3.6.1.2.1.1.5.0"
+	OIDSysLocation = "1.3.6.1.2.1.1.6.0"
+)
+
+// IF-MIB interface table (1.3.6.1.2.1.2.2.1).
+const (
+	OIDIfIndex       = "1.3.6.1.2.1.2.2.1.1"
+	OIDIfDescr       = "1.3.6.1.2.1.2.2.1.2"
+	OIDIfType        = "1.3.6.1.2.1.2.2.1.3"
+	OIDIfMtu         = "1.3.6.1.2.1.2.2.1.4"
+	OIDIfSpeed       = "1.3.6.1.2.1.2.2.1.5"
+	OIDIfPhysAddress = "1.3.6.1.2.1.2.2.1.6"
+	OIDIfAdminStatus = "1.3.6.1.2.1.2.2.1.7"
+	OIDIfOperStatus  = "1.3.6.1.2.1.2.2.1.8"
+)

--- a/internal/recon/vault_adapter.go
+++ b/internal/recon/vault_adapter.go
@@ -1,0 +1,76 @@
+package recon
+
+import (
+	"context"
+	"fmt"
+)
+
+// CredentialDecrypter retrieves decrypted credential data from the vault.
+type CredentialDecrypter interface {
+	DecryptCredential(ctx context.Context, id string) (map[string]any, error)
+}
+
+// VaultCredentialAdapter implements CredentialAccessor by using the vault
+// to retrieve and decrypt SNMP credentials.
+type VaultCredentialAdapter struct {
+	decrypter CredentialDecrypter
+}
+
+// NewVaultCredentialAdapter creates a new adapter.
+func NewVaultCredentialAdapter(dec CredentialDecrypter) *VaultCredentialAdapter {
+	return &VaultCredentialAdapter{decrypter: dec}
+}
+
+// Compile-time interface guard.
+var _ CredentialAccessor = (*VaultCredentialAdapter)(nil)
+
+// GetCredential retrieves and parses an SNMP credential from the vault.
+func (a *VaultCredentialAdapter) GetCredential(ctx context.Context, id string) (*SNMPCredential, error) {
+	data, err := a.decrypter.DecryptCredential(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt credential %s: %w", id, err)
+	}
+
+	cred := &SNMPCredential{}
+
+	// Parse type field.
+	if t, ok := data["type"].(string); ok {
+		cred.Type = t
+	}
+
+	switch cred.Type {
+	case "snmp_v2c":
+		if v, ok := data["community"].(string); ok {
+			cred.Community = v
+		}
+	case "snmp_v3":
+		if v, ok := data["username"].(string); ok {
+			cred.Username = v
+		}
+		if v, ok := data["auth_protocol"].(string); ok {
+			cred.AuthProtocol = v
+		}
+		if v, ok := data["auth_passphrase"].(string); ok {
+			cred.AuthPassphrase = v
+		}
+		if v, ok := data["privacy_protocol"].(string); ok {
+			cred.PrivacyProtocol = v
+		}
+		if v, ok := data["privacy_passphrase"].(string); ok {
+			cred.PrivacyPassphrase = v
+		}
+		if v, ok := data["security_level"].(string); ok {
+			cred.SecurityLevel = v
+		}
+		if v, ok := data["context_name"].(string); ok {
+			cred.ContextName = v
+		}
+		if v, ok := data["authoritative_engine_id"].(string); ok {
+			cred.AuthoritativeEngineID = v
+		}
+	default:
+		return nil, fmt.Errorf("unsupported credential type: %s", cred.Type)
+	}
+
+	return cred, nil
+}

--- a/internal/recon/vault_adapter_test.go
+++ b/internal/recon/vault_adapter_test.go
@@ -1,0 +1,123 @@
+package recon
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// mockDecrypter implements CredentialDecrypter for testing.
+type mockDecrypter struct {
+	data map[string]any
+	err  error
+}
+
+func (m *mockDecrypter) DecryptCredential(_ context.Context, _ string) (map[string]any, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.data, nil
+}
+
+func TestVaultCredentialAdapter_SNMPv2c(t *testing.T) {
+	dec := &mockDecrypter{
+		data: map[string]any{
+			"type":      "snmp_v2c",
+			"community": "public",
+		},
+	}
+
+	adapter := NewVaultCredentialAdapter(dec)
+	cred, err := adapter.GetCredential(context.Background(), "cred-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cred.Type != "snmp_v2c" {
+		t.Errorf("type = %q, want %q", cred.Type, "snmp_v2c")
+	}
+	if cred.Community != "public" {
+		t.Errorf("community = %q, want %q", cred.Community, "public")
+	}
+}
+
+func TestVaultCredentialAdapter_SNMPv3(t *testing.T) {
+	dec := &mockDecrypter{
+		data: map[string]any{
+			"type":                     "snmp_v3",
+			"username":                 "admin",
+			"auth_protocol":            "SHA-256",
+			"auth_passphrase":          "secret123",
+			"privacy_protocol":         "AES-256",
+			"privacy_passphrase":       "privpass",
+			"security_level":           "authPriv",
+			"context_name":             "ctx1",
+			"authoritative_engine_id":  "engine01",
+		},
+	}
+
+	adapter := NewVaultCredentialAdapter(dec)
+	cred, err := adapter.GetCredential(context.Background(), "cred-2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cred.Type != "snmp_v3" {
+		t.Errorf("type = %q, want %q", cred.Type, "snmp_v3")
+	}
+	if cred.Username != "admin" {
+		t.Errorf("username = %q, want %q", cred.Username, "admin")
+	}
+	if cred.AuthProtocol != "SHA-256" {
+		t.Errorf("auth_protocol = %q, want %q", cred.AuthProtocol, "SHA-256")
+	}
+	if cred.AuthPassphrase != "secret123" {
+		t.Errorf("auth_passphrase = %q, want %q", cred.AuthPassphrase, "secret123")
+	}
+	if cred.PrivacyProtocol != "AES-256" {
+		t.Errorf("privacy_protocol = %q, want %q", cred.PrivacyProtocol, "AES-256")
+	}
+	if cred.PrivacyPassphrase != "privpass" {
+		t.Errorf("privacy_passphrase = %q, want %q", cred.PrivacyPassphrase, "privpass")
+	}
+	if cred.SecurityLevel != "authPriv" {
+		t.Errorf("security_level = %q, want %q", cred.SecurityLevel, "authPriv")
+	}
+	if cred.ContextName != "ctx1" {
+		t.Errorf("context_name = %q, want %q", cred.ContextName, "ctx1")
+	}
+	if cred.AuthoritativeEngineID != "engine01" {
+		t.Errorf("authoritative_engine_id = %q, want %q", cred.AuthoritativeEngineID, "engine01")
+	}
+}
+
+func TestVaultCredentialAdapter_UnsupportedType(t *testing.T) {
+	dec := &mockDecrypter{
+		data: map[string]any{
+			"type": "ssh_key",
+		},
+	}
+
+	adapter := NewVaultCredentialAdapter(dec)
+	_, err := adapter.GetCredential(context.Background(), "cred-3")
+	if err == nil {
+		t.Fatal("expected error for unsupported type, got nil")
+	}
+}
+
+func TestVaultCredentialAdapter_DecryptError(t *testing.T) {
+	dec := &mockDecrypter{
+		err: fmt.Errorf("vault is sealed"),
+	}
+
+	adapter := NewVaultCredentialAdapter(dec)
+	_, err := adapter.GetCredential(context.Background(), "cred-4")
+	if err == nil {
+		t.Fatal("expected error from decrypter, got nil")
+	}
+}
+
+func TestVaultCredentialAdapter_InterfaceGuard(t *testing.T) {
+	// Verify compile-time interface guard works.
+	var _ CredentialAccessor = (*VaultCredentialAdapter)(nil)
+}


### PR DESCRIPTION
## Summary

- Implements SNMP v2c/v3 device discovery using `gosnmp/gosnmp` (BSD-2-Clause)
- Replaces stub methods in `snmp_collector.go` with working implementations
- Adds vault credential adapter for decrypting SNMP credentials at runtime
- Wires SNMP credential access through composition root in `main.go`

## Changes

| File | What |
|------|------|
| `snmp_oids.go` | OID constants for SNMPv2-MIB and IF-MIB |
| `snmp_collector.go` | Full GetSystemInfo, GetInterfaces, Discover with v2c/v3 support |
| `vault_adapter.go` | VaultCredentialAdapter + CredentialDecrypter interface |
| `recon.go` | Added snmpCollector + credAccessor fields, SetCredentialAccessor() |
| `vault.go` | Added DecryptCredentialData() for programmatic credential access |
| `main.go` | vaultDecryptAdapter wiring in composition root |
| `snmp_collector_test.go` | 15 test functions (protocol mapping, PDU parsing, device inference) |
| `vault_adapter_test.go` | 5 test functions (v2c, v3, error handling, interface guard) |

## Test plan

- [x] All 20 new tests pass (`go test ./internal/recon/...`)
- [x] `go build ./...` succeeds (no import cycles)
- [x] `golangci-lint run` clean
- [ ] CI passes

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)