### PR TITLE
feat: SNMP API endpoints and dashboard integration

### DIFF
--- a/api/swagger/docs.go
+++ b/api/swagger/docs.go
@@ -2280,6 +2280,167 @@ const docTemplate = `{
                 }
             }
         },
+        "/recon/snmp/discover": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Discover a device via SNMP using the given credentials.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "recon"
+                ],
+                "summary": "SNMP discover",
+                "parameters": [
+                    {
+                        "description": "SNMP target and credentials",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_recon.SNMPDiscoverRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Discovered devices",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.Device"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    }
+                }
+            }
+        },
+        "/recon/snmp/interfaces/{device_id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Query SNMP interface table from a device.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "recon"
+                ],
+                "summary": "SNMP interfaces",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Device ID",
+                        "name": "device_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Interface list",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/internal_recon.SNMPInterfaceResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    }
+                }
+            }
+        },
+        "/recon/snmp/system/{device_id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Query SNMP system information from a device.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "recon"
+                ],
+                "summary": "SNMP system info",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Device ID",
+                        "name": "device_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "System information",
+                        "schema": {
+                            "$ref": "#/definitions/internal_recon.SNMPSystemInfoResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    }
+                }
+            }
+        },
         "/recon/topology": {
             "get": {
                 "security": [
@@ -4320,6 +4481,71 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "total_devices": {
+                    "type": "integer"
+                }
+            }
+        },
+        "internal_recon.SNMPDiscoverRequest": {
+            "type": "object",
+            "properties": {
+                "credential_id": {
+                    "type": "string",
+                    "example": "cred-snmp-001"
+                },
+                "target": {
+                    "type": "string",
+                    "example": "192.168.1.1"
+                }
+            }
+        },
+        "internal_recon.SNMPInterfaceResponse": {
+            "type": "object",
+            "properties": {
+                "admin_status": {
+                    "type": "integer"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "index": {
+                    "type": "integer"
+                },
+                "mtu": {
+                    "type": "integer"
+                },
+                "oper_status": {
+                    "type": "integer"
+                },
+                "phys_address": {
+                    "type": "string"
+                },
+                "speed": {
+                    "type": "integer"
+                },
+                "type": {
+                    "type": "integer"
+                }
+            }
+        },
+        "internal_recon.SNMPSystemInfoResponse": {
+            "type": "object",
+            "properties": {
+                "contact": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "location": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "object_id": {
+                    "type": "string"
+                },
+                "up_time_ms": {
                     "type": "integer"
                 }
             }

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -2273,6 +2273,167 @@
                 }
             }
         },
+        "/recon/snmp/discover": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Discover a device via SNMP using the given credentials.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "recon"
+                ],
+                "summary": "SNMP discover",
+                "parameters": [
+                    {
+                        "description": "SNMP target and credentials",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_recon.SNMPDiscoverRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Discovered devices",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.Device"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    }
+                }
+            }
+        },
+        "/recon/snmp/interfaces/{device_id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Query SNMP interface table from a device.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "recon"
+                ],
+                "summary": "SNMP interfaces",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Device ID",
+                        "name": "device_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Interface list",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/internal_recon.SNMPInterfaceResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    }
+                }
+            }
+        },
+        "/recon/snmp/system/{device_id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Query SNMP system information from a device.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "recon"
+                ],
+                "summary": "SNMP system info",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Device ID",
+                        "name": "device_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "System information",
+                        "schema": {
+                            "$ref": "#/definitions/internal_recon.SNMPSystemInfoResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    }
+                }
+            }
+        },
         "/recon/topology": {
             "get": {
                 "security": [
@@ -4313,6 +4474,71 @@
                     "type": "integer"
                 },
                 "total_devices": {
+                    "type": "integer"
+                }
+            }
+        },
+        "internal_recon.SNMPDiscoverRequest": {
+            "type": "object",
+            "properties": {
+                "credential_id": {
+                    "type": "string",
+                    "example": "cred-snmp-001"
+                },
+                "target": {
+                    "type": "string",
+                    "example": "192.168.1.1"
+                }
+            }
+        },
+        "internal_recon.SNMPInterfaceResponse": {
+            "type": "object",
+            "properties": {
+                "admin_status": {
+                    "type": "integer"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "index": {
+                    "type": "integer"
+                },
+                "mtu": {
+                    "type": "integer"
+                },
+                "oper_status": {
+                    "type": "integer"
+                },
+                "phys_address": {
+                    "type": "string"
+                },
+                "speed": {
+                    "type": "integer"
+                },
+                "type": {
+                    "type": "integer"
+                }
+            }
+        },
+        "internal_recon.SNMPSystemInfoResponse": {
+            "type": "object",
+            "properties": {
+                "contact": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "location": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "object_id": {
+                    "type": "string"
+                },
+                "up_time_ms": {
                     "type": "integer"
                 }
             }

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -804,6 +804,49 @@ definitions:
       total_devices:
         type: integer
     type: object
+  internal_recon.SNMPDiscoverRequest:
+    properties:
+      credential_id:
+        example: cred-snmp-001
+        type: string
+      target:
+        example: 192.168.1.1
+        type: string
+    type: object
+  internal_recon.SNMPInterfaceResponse:
+    properties:
+      admin_status:
+        type: integer
+      description:
+        type: string
+      index:
+        type: integer
+      mtu:
+        type: integer
+      oper_status:
+        type: integer
+      phys_address:
+        type: string
+      speed:
+        type: integer
+      type:
+        type: integer
+    type: object
+  internal_recon.SNMPSystemInfoResponse:
+    properties:
+      contact:
+        type: string
+      description:
+        type: string
+      location:
+        type: string
+      name:
+        type: string
+      object_id:
+        type: string
+      up_time_ms:
+        type: integer
+    type: object
   internal_recon.ScanRequest:
     properties:
       subnet:
@@ -2512,6 +2555,108 @@ paths:
       security:
       - BearerAuth: []
       summary: Get scan
+      tags:
+      - recon
+  /recon/snmp/discover:
+    post:
+      consumes:
+      - application/json
+      description: Discover a device via SNMP using the given credentials.
+      parameters:
+      - description: SNMP target and credentials
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/internal_recon.SNMPDiscoverRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Discovered devices
+          schema:
+            items:
+              $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_models.Device'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem'
+      security:
+      - BearerAuth: []
+      summary: SNMP discover
+      tags:
+      - recon
+  /recon/snmp/interfaces/{device_id}:
+    get:
+      description: Query SNMP interface table from a device.
+      parameters:
+      - description: Device ID
+        in: path
+        name: device_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Interface list
+          schema:
+            items:
+              $ref: '#/definitions/internal_recon.SNMPInterfaceResponse'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem'
+      security:
+      - BearerAuth: []
+      summary: SNMP interfaces
+      tags:
+      - recon
+  /recon/snmp/system/{device_id}:
+    get:
+      description: Query SNMP system information from a device.
+      parameters:
+      - description: Device ID
+        in: path
+        name: device_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: System information
+          schema:
+            $ref: '#/definitions/internal_recon.SNMPSystemInfoResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem'
+      security:
+      - BearerAuth: []
+      summary: SNMP system info
       tags:
       - recon
   /recon/topology:

--- a/cmd/subnetree/main.go
+++ b/cmd/subnetree/main.go
@@ -257,6 +257,7 @@ func main() {
 	}
 	if reconMod != nil && vaultMod != nil {
 		reconMod.SetCredentialAccessor(recon.NewVaultCredentialAdapter(&vaultDecryptAdapter{vault: vaultMod}))
+		reconMod.SetCredentialProvider(vaultMod)
 		logger.Info("SNMP credential adapter wired", zap.String("component", "recon"))
 	}
 

--- a/internal/recon/recon.go
+++ b/internal/recon/recon.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/HerbHall/subnetree/pkg/plugin"
+	"github.com/HerbHall/subnetree/pkg/roles"
 	"go.uber.org/zap"
 )
 
@@ -27,6 +28,7 @@ type Module struct {
 	orchestrator  *ScanOrchestrator
 	snmpCollector *SNMPCollector
 	credAccessor  CredentialAccessor
+	credProvider  roles.CredentialProvider
 	activeScans   sync.Map // scanID -> context.CancelFunc
 	wg            sync.WaitGroup
 	scanCtx       context.Context
@@ -149,6 +151,9 @@ func (m *Module) Routes() []plugin.Route {
 		{Method: "GET", Path: "/devices/{id}/scans", Handler: m.handleDeviceScans},
 		{Method: "GET", Path: "/inventory/summary", Handler: m.handleInventorySummary},
 		{Method: "PATCH", Path: "/devices/bulk", Handler: m.handleBulkUpdateDevices},
+		{Method: "POST", Path: "/snmp/discover", Handler: m.handleSNMPDiscover},
+		{Method: "GET", Path: "/snmp/system/{device_id}", Handler: m.handleSNMPSystemInfo},
+		{Method: "GET", Path: "/snmp/interfaces/{device_id}", Handler: m.handleSNMPInterfaces},
 	}
 }
 

--- a/web/src/api/recon.ts
+++ b/web/src/api/recon.ts
@@ -1,0 +1,17 @@
+import { api } from './client'
+import type { Device, SNMPSystemInfo, SNMPInterface, SNMPDiscoverRequest } from './types'
+
+/** Discover a device via SNMP. */
+export async function discoverSNMP(req: SNMPDiscoverRequest): Promise<Device[]> {
+  return api.post<Device[]>('/recon/snmp/discover', req)
+}
+
+/** Get SNMP system information for a device. */
+export async function getSNMPSystemInfo(deviceId: string): Promise<SNMPSystemInfo> {
+  return api.get<SNMPSystemInfo>(`/recon/snmp/system/${deviceId}`)
+}
+
+/** Get SNMP interface table for a device. */
+export async function getSNMPInterfaces(deviceId: string): Promise<SNMPInterface[]> {
+  return api.get<SNMPInterface[]>(`/recon/snmp/interfaces/${deviceId}`)
+}

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -412,3 +412,35 @@ export interface MonitoringStatus {
   message: string
   checked_at?: string
 }
+
+// ============================================================================
+// SNMP Types
+// ============================================================================
+
+/** SNMP system information from device query. */
+export interface SNMPSystemInfo {
+  description: string
+  object_id: string
+  up_time_ms: number
+  contact: string
+  name: string
+  location: string
+}
+
+/** SNMP network interface from device query. */
+export interface SNMPInterface {
+  index: number
+  description: string
+  type: number
+  mtu: number
+  speed: number
+  phys_address: string
+  admin_status: number
+  oper_status: number
+}
+
+/** Request body for SNMP discover endpoint. */
+export interface SNMPDiscoverRequest {
+  target: string
+  credential_id: string
+}


### PR DESCRIPTION
## Summary

- Adds 3 REST endpoints for SNMP operations (discover, system info, interfaces)
- Integrates SNMP data into device detail page with system info cards and interface table
- Wires credential provider for per-device SNMP credential lookup
- Creates recon TypeScript API client for frontend SNMP operations

## Changes

| Area | File | What |
|------|------|------|
| Go | `handlers.go` | 3 SNMP handlers + response types + credential lookup helper |
| Go | `recon.go` | credProvider field + SetCredentialProvider() + route registration |
| Go | `main.go` | Wire vault as credential provider for recon |
| Go | `api/swagger/` | Regenerated swagger spec with SNMP endpoints |
| TS | `types.ts` | SNMPSystemInfo, SNMPInterface, SNMPDiscoverRequest types |
| TS | `recon.ts` | New API client with discoverSNMP, getSNMPSystemInfo, getSNMPInterfaces |
| React | `[id].tsx` | SNMP system info section + interface table on device detail page |

## Test plan

- [x] `go build ./...` succeeds
- [x] `go test ./internal/recon/...` passes
- [x] `golangci-lint run` clean
- [x] `pnpm run build` succeeds (tsc + vite)
- [x] `pnpm run lint` clean
- [ ] CI passes

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)