### PR TITLE
feat: proto certificate fields and Dispatch CA enrollment

### DIFF
--- a/api/proto/v1/scout.pb.go
+++ b/api/proto/v1/scout.pb.go
@@ -76,16 +76,17 @@ func (VersionStatus) EnumDescriptor() ([]byte, []int) {
 }
 
 type CheckInRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	AgentId       string                 `protobuf:"bytes,1,opt,name=agent_id,json=agentId,proto3" json:"agent_id,omitempty"`
-	Hostname      string                 `protobuf:"bytes,2,opt,name=hostname,proto3" json:"hostname,omitempty"`
-	Platform      string                 `protobuf:"bytes,3,opt,name=platform,proto3" json:"platform,omitempty"`
-	AgentVersion  string                 `protobuf:"bytes,4,opt,name=agent_version,json=agentVersion,proto3" json:"agent_version,omitempty"`
-	Metrics       *SystemMetrics         `protobuf:"bytes,5,opt,name=metrics,proto3" json:"metrics,omitempty"`
-	ProtoVersion  uint32                 `protobuf:"varint,6,opt,name=proto_version,json=protoVersion,proto3" json:"proto_version,omitempty"`
-	EnrollToken   string                 `protobuf:"bytes,7,opt,name=enroll_token,json=enrollToken,proto3" json:"enroll_token,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	AgentId            string                 `protobuf:"bytes,1,opt,name=agent_id,json=agentId,proto3" json:"agent_id,omitempty"`
+	Hostname           string                 `protobuf:"bytes,2,opt,name=hostname,proto3" json:"hostname,omitempty"`
+	Platform           string                 `protobuf:"bytes,3,opt,name=platform,proto3" json:"platform,omitempty"`
+	AgentVersion       string                 `protobuf:"bytes,4,opt,name=agent_version,json=agentVersion,proto3" json:"agent_version,omitempty"`
+	Metrics            *SystemMetrics         `protobuf:"bytes,5,opt,name=metrics,proto3" json:"metrics,omitempty"`
+	ProtoVersion       uint32                 `protobuf:"varint,6,opt,name=proto_version,json=protoVersion,proto3" json:"proto_version,omitempty"`
+	EnrollToken        string                 `protobuf:"bytes,7,opt,name=enroll_token,json=enrollToken,proto3" json:"enroll_token,omitempty"`
+	CertificateRequest []byte                 `protobuf:"bytes,8,opt,name=certificate_request,json=certificateRequest,proto3" json:"certificate_request,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *CheckInRequest) Reset() {
@@ -167,6 +168,13 @@ func (x *CheckInRequest) GetEnrollToken() string {
 	return ""
 }
 
+func (x *CheckInRequest) GetCertificateRequest() []byte {
+	if x != nil {
+		return x.CertificateRequest
+	}
+	return nil
+}
+
 type CheckInResponse struct {
 	state                protoimpl.MessageState `protogen:"open.v1"`
 	Acknowledged         bool                   `protobuf:"varint,1,opt,name=acknowledged,proto3" json:"acknowledged,omitempty"`
@@ -176,6 +184,8 @@ type CheckInResponse struct {
 	ServerVersion        string                 `protobuf:"bytes,5,opt,name=server_version,json=serverVersion,proto3" json:"server_version,omitempty"`
 	UpgradeMessage       string                 `protobuf:"bytes,6,opt,name=upgrade_message,json=upgradeMessage,proto3" json:"upgrade_message,omitempty"`
 	AssignedAgentId      string                 `protobuf:"bytes,7,opt,name=assigned_agent_id,json=assignedAgentId,proto3" json:"assigned_agent_id,omitempty"`
+	SignedCertificate    []byte                 `protobuf:"bytes,8,opt,name=signed_certificate,json=signedCertificate,proto3" json:"signed_certificate,omitempty"`
+	CaCertificate        []byte                 `protobuf:"bytes,9,opt,name=ca_certificate,json=caCertificate,proto3" json:"ca_certificate,omitempty"`
 	unknownFields        protoimpl.UnknownFields
 	sizeCache            protoimpl.SizeCache
 }
@@ -257,6 +267,20 @@ func (x *CheckInResponse) GetAssignedAgentId() string {
 		return x.AssignedAgentId
 	}
 	return ""
+}
+
+func (x *CheckInResponse) GetSignedCertificate() []byte {
+	if x != nil {
+		return x.SignedCertificate
+	}
+	return nil
+}
+
+func (x *CheckInResponse) GetCaCertificate() []byte {
+	if x != nil {
+		return x.CaCertificate
+	}
+	return nil
 }
 
 type SystemMetrics struct {
@@ -1459,7 +1483,7 @@ var File_api_proto_v1_scout_proto protoreflect.FileDescriptor
 
 const file_api_proto_v1_scout_proto_rawDesc = "" +
 	"\n" +
-	"\x18api/proto/v1/scout.proto\x12\fsubnetree.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\x87\x02\n" +
+	"\x18api/proto/v1/scout.proto\x12\fsubnetree.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\xb8\x02\n" +
 	"\x0eCheckInRequest\x12\x19\n" +
 	"\bagent_id\x18\x01 \x01(\tR\aagentId\x12\x1a\n" +
 	"\bhostname\x18\x02 \x01(\tR\bhostname\x12\x1a\n" +
@@ -1467,7 +1491,7 @@ const file_api_proto_v1_scout_proto_rawDesc = "" +
 	"\ragent_version\x18\x04 \x01(\tR\fagentVersion\x125\n" +
 	"\ametrics\x18\x05 \x01(\v2\x1b.subnetree.v1.SystemMetricsR\ametrics\x12#\n" +
 	"\rproto_version\x18\x06 \x01(\rR\fprotoVersion\x12!\n" +
-	"\fenroll_token\x18\a \x01(\tR\venrollToken\"\xd6\x02\n" +
+	"\fenroll_token\x18\a \x01(\tR\venrollToken\x12/\n\x13certificate_request\x18\b \x01(\x0cR\x12certificateRequest\"\xac\x03\n" +
 	"\x0fCheckInResponse\x12\"\n" +
 	"\facknowledged\x18\x01 \x01(\bR\facknowledged\x124\n" +
 	"\x16check_interval_seconds\x18\x02 \x01(\x05R\x14checkIntervalSeconds\x12)\n" +
@@ -1475,7 +1499,7 @@ const file_api_proto_v1_scout_proto_rawDesc = "" +
 	"\x0eversion_status\x18\x04 \x01(\x0e2\x1b.subnetree.v1.VersionStatusR\rversionStatus\x12%\n" +
 	"\x0eserver_version\x18\x05 \x01(\tR\rserverVersion\x12'\n" +
 	"\x0fupgrade_message\x18\x06 \x01(\tR\x0eupgradeMessage\x12*\n" +
-	"\x11assigned_agent_id\x18\a \x01(\tR\x0fassignedAgentId\"\x9a\x02\n" +
+	"\x11assigned_agent_id\x18\a \x01(\tR\x0fassignedAgentId\x12-\n\x12signed_certificate\x18\b \x01(\x0cR\x11signedCertificate\x12%\n\x0eca_certificate\x18\t \x01(\x0cR\rcaCertificate\"\x9a\x02\n" +
 	"\rSystemMetrics\x12\x1f\n" +
 	"\vcpu_percent\x18\x01 \x01(\x01R\n" +
 	"cpuPercent\x12%\n" +

--- a/api/proto/v1/scout.proto
+++ b/api/proto/v1/scout.proto
@@ -37,6 +37,7 @@ message CheckInRequest {
   SystemMetrics metrics = 5;
   uint32 proto_version = 6;
   string enroll_token = 7;
+  bytes certificate_request = 8;  // DER-encoded PKCS#10 CSR (sent during enrollment/renewal)
 }
 
 message CheckInResponse {
@@ -47,6 +48,8 @@ message CheckInResponse {
   string server_version = 5;
   string upgrade_message = 6;
   string assigned_agent_id = 7;
+  bytes signed_certificate = 8;   // DER-encoded X.509 certificate (returned after CSR signing)
+  bytes ca_certificate = 9;       // DER-encoded CA root certificate (agent needs for TLS verification)
 }
 
 message SystemMetrics {

--- a/internal/dispatch/config.go
+++ b/internal/dispatch/config.go
@@ -1,19 +1,29 @@
 package dispatch
 
-import "time"
+import (
+	"time"
+
+	"github.com/HerbHall/subnetree/internal/ca"
+)
 
 // DispatchConfig holds configuration for the Dispatch module.
 type DispatchConfig struct {
 	GRPCAddr              string        `mapstructure:"grpc_addr"`
 	AgentTimeout          time.Duration `mapstructure:"agent_timeout"`
 	EnrollmentTokenExpiry time.Duration `mapstructure:"enrollment_token_expiry"`
+	CAConfig              ca.Config     `mapstructure:"ca"`
 }
 
 // DefaultConfig returns the default Dispatch configuration.
+// CA paths are empty by default; set them in config to enable mTLS cert issuance.
 func DefaultConfig() DispatchConfig {
 	return DispatchConfig{
 		GRPCAddr:              ":9090",
 		AgentTimeout:          5 * time.Minute,
 		EnrollmentTokenExpiry: 24 * time.Hour,
+		CAConfig: ca.Config{
+			Validity:     ca.DefaultValidity,
+			Organization: ca.DefaultOrganization,
+		},
 	}
 }

--- a/internal/dispatch/grpc_test.go
+++ b/internal/dispatch/grpc_test.go
@@ -2,13 +2,19 @@ package dispatch
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/sha256"
+	"crypto/x509"
 	"fmt"
 	"net"
+	"path/filepath"
 	"testing"
 	"time"
 
 	scoutpb "github.com/HerbHall/subnetree/api/proto/v1"
+	"github.com/HerbHall/subnetree/internal/ca"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -17,7 +23,42 @@ import (
 
 const bufSize = 1024 * 1024
 
+// testCA creates a temporary CA for testing.
+func testCA(t *testing.T) *ca.Authority {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := ca.Config{
+		CertPath:     filepath.Join(dir, "ca.crt"),
+		KeyPath:      filepath.Join(dir, "ca.key"),
+		Organization: "TestOrg",
+	}
+	authority, err := ca.GenerateCA(cfg, zap.NewNop())
+	if err != nil {
+		t.Fatalf("generate test CA: %v", err)
+	}
+	return authority
+}
+
+// testCSR generates an ECDSA keypair and returns a DER-encoded CSR.
+func testCSR(t *testing.T, agentID string) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate agent key: %v", err)
+	}
+	csrDER, err := ca.CreateCSR(key, agentID, "test-host")
+	if err != nil {
+		t.Fatalf("create CSR: %v", err)
+	}
+	return csrDER
+}
+
 func testGRPCServer(t *testing.T) (scoutpb.ScoutServiceClient, *DispatchStore) {
+	t.Helper()
+	return testGRPCServerWithCA(t, nil)
+}
+
+func testGRPCServerWithCA(t *testing.T, authority *ca.Authority) (scoutpb.ScoutServiceClient, *DispatchStore) {
 	t.Helper()
 
 	store := testStore(t)
@@ -27,9 +68,10 @@ func testGRPCServer(t *testing.T) (scoutpb.ScoutServiceClient, *DispatchStore) {
 
 	srv := grpc.NewServer()
 	scoutpb.RegisterScoutServiceServer(srv, &scoutServer{
-		store:  store,
-		logger: zap.NewNop(),
-		cfg:    DefaultConfig(),
+		store:     store,
+		logger:    zap.NewNop(),
+		cfg:       DefaultConfig(),
+		authority: authority,
 	})
 	t.Cleanup(func() { srv.Stop() })
 
@@ -110,7 +152,7 @@ func TestGRPC_CheckIn_Enrollment(t *testing.T) {
 		t.Fatalf("create token: %v", err)
 	}
 
-	// Enroll with the token.
+	// Enroll with the token (no CSR -- backward compat).
 	resp, err := client.CheckIn(ctx, &scoutpb.CheckInRequest{
 		Hostname:     "new-agent-host",
 		Platform:     "windows/amd64",
@@ -129,6 +171,14 @@ func TestGRPC_CheckIn_Enrollment(t *testing.T) {
 		t.Fatal("expected non-empty assigned_agent_id")
 	}
 
+	// No CSR was sent, so no certificate should be returned.
+	if len(resp.SignedCertificate) != 0 {
+		t.Errorf("expected empty signed_certificate without CSR, got %d bytes", len(resp.SignedCertificate))
+	}
+	if len(resp.CaCertificate) != 0 {
+		t.Errorf("expected empty ca_certificate without CSR, got %d bytes", len(resp.CaCertificate))
+	}
+
 	// Verify agent was created in store.
 	agent, err := store.GetAgent(ctx, resp.AssignedAgentId)
 	if err != nil {
@@ -142,6 +192,190 @@ func TestGRPC_CheckIn_Enrollment(t *testing.T) {
 	}
 	if agent.Platform != "windows/amd64" {
 		t.Errorf("platform = %q, want %q", agent.Platform, "windows/amd64")
+	}
+	// No CSR => no cert fields.
+	if agent.CertSerial != "" {
+		t.Errorf("cert_serial = %q, want empty (no CSR)", agent.CertSerial)
+	}
+	if agent.CertExpires != nil {
+		t.Errorf("cert_expires = %v, want nil (no CSR)", agent.CertExpires)
+	}
+}
+
+func TestGRPC_CheckIn_EnrollmentWithCSR(t *testing.T) {
+	authority := testCA(t)
+	client, store := testGRPCServerWithCA(t, authority)
+	ctx := context.Background()
+
+	// Create enrollment token.
+	rawToken := "test-enrollment-csr-token"
+	tokenHash := fmt.Sprintf("%x", sha256.Sum256([]byte(rawToken)))
+	now := time.Now().UTC()
+	expires := now.Add(24 * time.Hour)
+	if err := store.CreateEnrollmentToken(ctx, &EnrollmentToken{
+		ID:          "tok-csr",
+		TokenHash:   tokenHash,
+		Description: "CSR enrollment token",
+		CreatedAt:   now,
+		ExpiresAt:   &expires,
+		MaxUses:     1,
+	}); err != nil {
+		t.Fatalf("create token: %v", err)
+	}
+
+	// Generate a CSR for enrollment. Use a placeholder agent ID since
+	// the real one is assigned by the server.
+	csrDER := testCSR(t, "pending-agent")
+
+	// Enroll with CSR.
+	resp, err := client.CheckIn(ctx, &scoutpb.CheckInRequest{
+		Hostname:           "csr-agent-host",
+		Platform:           "linux/amd64",
+		AgentVersion:       "0.1.0",
+		ProtoVersion:       1,
+		EnrollToken:        rawToken,
+		CertificateRequest: csrDER,
+	})
+	if err != nil {
+		t.Fatalf("CheckIn (enroll with CSR): %v", err)
+	}
+
+	if !resp.Acknowledged {
+		t.Error("expected acknowledged=true")
+	}
+	if resp.AssignedAgentId == "" {
+		t.Fatal("expected non-empty assigned_agent_id")
+	}
+
+	// Verify signed certificate was returned.
+	if len(resp.SignedCertificate) == 0 {
+		t.Fatal("expected non-empty signed_certificate")
+	}
+	if len(resp.CaCertificate) == 0 {
+		t.Fatal("expected non-empty ca_certificate")
+	}
+
+	// Parse and verify the signed certificate.
+	cert, err := x509.ParseCertificate(resp.SignedCertificate)
+	if err != nil {
+		t.Fatalf("parse signed certificate: %v", err)
+	}
+	if cert.Subject.CommonName != resp.AssignedAgentId {
+		t.Errorf("cert CN = %q, want %q", cert.Subject.CommonName, resp.AssignedAgentId)
+	}
+
+	// Verify the CA cert can be parsed.
+	caCert, err := x509.ParseCertificate(resp.CaCertificate)
+	if err != nil {
+		t.Fatalf("parse CA certificate: %v", err)
+	}
+	if !caCert.IsCA {
+		t.Error("expected CA certificate to have IsCA=true")
+	}
+
+	// Verify the agent cert chains to the CA.
+	roots := x509.NewCertPool()
+	roots.AddCert(caCert)
+	if _, err := cert.Verify(x509.VerifyOptions{
+		Roots:     roots,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}); err != nil {
+		t.Errorf("agent cert does not chain to CA: %v", err)
+	}
+
+	// Verify agent record has cert fields populated.
+	agent, err := store.GetAgent(ctx, resp.AssignedAgentId)
+	if err != nil {
+		t.Fatalf("GetAgent: %v", err)
+	}
+	if agent == nil {
+		t.Fatal("expected agent in store")
+	}
+	if agent.CertSerial == "" {
+		t.Error("cert_serial is empty, expected populated after CSR enrollment")
+	}
+	if agent.CertExpires == nil {
+		t.Error("cert_expires is nil, expected populated after CSR enrollment")
+	}
+	if agent.CertExpires != nil && agent.CertExpires.Before(time.Now()) {
+		t.Error("cert_expires is in the past")
+	}
+}
+
+func TestGRPC_CheckIn_RenewalWithCSR(t *testing.T) {
+	authority := testCA(t)
+	client, store := testGRPCServerWithCA(t, authority)
+	ctx := context.Background()
+
+	// Pre-create an agent with an existing certificate.
+	now := time.Now().UTC()
+	oldExpiry := now.Add(24 * time.Hour)
+	if err := store.UpsertAgent(ctx, &Agent{
+		ID:           "agent-renew",
+		Hostname:     "renew-host",
+		Platform:     "linux/amd64",
+		AgentVersion: "0.1.0",
+		ProtoVersion: 1,
+		Status:       "connected",
+		EnrolledAt:   now,
+		CertSerial:   "old-serial-abc",
+		CertExpires:  &oldExpiry,
+		ConfigJSON:   "{}",
+	}); err != nil {
+		t.Fatalf("setup agent: %v", err)
+	}
+
+	// Generate a new CSR for renewal.
+	csrDER := testCSR(t, "agent-renew")
+
+	// Check in with CSR (certificate renewal).
+	resp, err := client.CheckIn(ctx, &scoutpb.CheckInRequest{
+		AgentId:            "agent-renew",
+		Hostname:           "renew-host",
+		Platform:           "linux/amd64",
+		AgentVersion:       "0.1.0",
+		ProtoVersion:       1,
+		CertificateRequest: csrDER,
+	})
+	if err != nil {
+		t.Fatalf("CheckIn (renewal): %v", err)
+	}
+
+	if !resp.Acknowledged {
+		t.Error("expected acknowledged=true")
+	}
+	// Not a new enrollment -- assigned_agent_id should be empty.
+	if resp.AssignedAgentId != "" {
+		t.Errorf("assigned_agent_id = %q, want empty for renewal", resp.AssignedAgentId)
+	}
+
+	// Verify renewed certificate was returned.
+	if len(resp.SignedCertificate) == 0 {
+		t.Fatal("expected non-empty signed_certificate for renewal")
+	}
+	if len(resp.CaCertificate) == 0 {
+		t.Fatal("expected non-empty ca_certificate for renewal")
+	}
+
+	// Verify the agent record was updated with new cert fields.
+	agent, err := store.GetAgent(ctx, "agent-renew")
+	if err != nil {
+		t.Fatalf("GetAgent: %v", err)
+	}
+	if agent == nil {
+		t.Fatal("expected agent in store")
+	}
+	if agent.CertSerial == "old-serial-abc" {
+		t.Error("cert_serial was not updated after renewal")
+	}
+	if agent.CertSerial == "" {
+		t.Error("cert_serial is empty after renewal")
+	}
+	if agent.CertExpires == nil {
+		t.Fatal("cert_expires is nil after renewal")
+	}
+	if !agent.CertExpires.After(oldExpiry) {
+		t.Errorf("cert_expires (%v) should be after old expiry (%v)", agent.CertExpires, oldExpiry)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Extended `CheckInRequest` with `certificate_request` field (DER-encoded CSR)
- Extended `CheckInResponse` with `signed_certificate` and `ca_certificate` fields
- Dispatch initializes internal CA on startup via `ca.LoadOrGenerate()`
- Enrollment handler signs agent CSRs and returns certificates
- Added `UpdateAgentCert()` to store for cert serial/expiry tracking
- Certificate renewal via regular check-in (existing agent sends new CSR)
- Backward compatible: enrollment without CSR still works

Stacked on #208 (CA package).

## Test plan

- [x] `TestGRPC_CheckIn_EnrollmentWithCSR` -- enrollment with CSR returns signed cert
- [x] `TestGRPC_CheckIn_RenewalWithCSR` -- renewal via check-in returns new cert
- [x] Existing enrollment tests still pass (backward compat)
- [x] 28 dispatch tests + 21 CA tests pass
- [x] `golangci-lint run` clean

Closes phase 1b mTLS plan 07-02.

🤖 Generated with [Claude Code](https://claude.com/claude-code)