### PR TITLE
docs: adopt three-tier documentation model

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -57,10 +57,11 @@ Requirements are split into `docs/requirements/` with per-section files. Read ON
 These principles govern every development decision. When in doubt, refer here:
 
 1. **Ease of use first.** No tech degree required. Intuitive for non-technical users, powerful for experts. If it needs a manual to understand, simplify the UI.
-2. **Sensible defaults, deep customization.** Ship preconfigured for instant deployment. Every aspect is user-configurable. Defaults get you running; customization makes it yours.
-3. **Stability and security are non-negotiable.** Every release must be stable enough for production infrastructure and secure enough to trust with credentials. If a feature compromises either, it does not ship.
-4. **Plugin-powered architecture.** Every major feature is a plugin. The core is minimal. Users and developers can replace, extend, or supplement any module.
-5. **Progressive disclosure.** Simple by default, advanced on demand. Never overwhelm a first-time user.
+2. **Three-tier documentation.** README is a landing page (~2,000 words max). The docs site (MkDocs Material on GitHub Pages) holds all guides, tutorials, and references organized by skill level. In-repo `/docs/` is for contributors only. See `.claude/rules/novice-ux-principles.md` and [28-documentation-requirements.md](docs/requirements/28-documentation-requirements.md) for the full model.
+3. **Sensible defaults, deep customization.** Ship preconfigured for instant deployment. Every aspect is user-configurable. Defaults get you running; customization makes it yours.
+4. **Stability and security are non-negotiable.** Every release must be stable enough for production infrastructure and secure enough to trust with credentials. If a feature compromises either, it does not ship.
+5. **Plugin-powered architecture.** Every major feature is a plugin. The core is minimal. Users and developers can replace, extend, or supplement any module.
+6. **Progressive disclosure.** Simple by default, advanced on demand. Never overwhelm a first-time user.
 
 ## Architecture
 

--- a/.claude/rules/novice-ux-principles.md
+++ b/.claude/rules/novice-ux-principles.md
@@ -1,0 +1,83 @@
+# Documentation UX Principles
+
+SubNetree uses a **three-tier documentation model** proven by high-adoption open-source projects (Home Assistant, Grafana, Traefik, Uptime Kuma). Each tier has a distinct purpose, audience, and scope.
+
+## Three-Tier Model
+
+| Tier | Surface | Purpose | Audience | Target Length |
+| ---- | ------- | ------- | -------- | ------------- |
+| 1 | **README.md** | Hook, Quick Start, links out | Everyone (30 seconds) | ~2,000 words max |
+| 2 | **Docs site** (MkDocs Material, GitHub Pages) | Guides, tutorials, config reference, troubleshooting | Users by skill level | Unlimited, searchable |
+| 3 | **In-repo `/docs/`** | Requirements, ADRs, internal design | Contributors only | As needed |
+
+### Tier 1: README
+
+The README is a landing page, not a manual. Its job is to answer three questions in 30 seconds: What is this? Why should I care? How do I try it?
+
+- Badges, one-sentence tagline, 1-2 screenshots/GIFs
+- "Why SubNetree?" value proposition (bullets, not paragraphs)
+- Single copy-paste Quick Start command
+- Feature highlights in user-benefit language
+- Links to docs site for everything else
+- License clarity
+- Developer content below a visible separator (`--- For Contributors ---`)
+
+**Rule: If content doesn't help someone decide to install or get running, it belongs on the docs site, not the README.**
+
+### Tier 2: Docs Site
+
+The docs site is organized by skill level in the sidebar navigation:
+
+- **Getting Started** (beginners): Install, first scan, dashboard tour
+- **User Guide** (intermediate): Modules, configuration, alerts, vault, themes
+- **Operations** (advanced): Backup, upgrade, troubleshooting, platform-specific notes
+- **Developer Guide** (contributors): Architecture, plugin SDK, API reference, ADRs
+
+Within each page, use these patterns for mixed-level audiences:
+
+- **Tabbed content** for install method (Docker / Binary / Source) and platform (Linux / macOS / Pi)
+- **Collapsible `<details>` blocks** for explanatory "why" content -- advanced users see a clean page, novices expand for context
+- **TL;DR blocks** at the top of long guides -- 2-3 lines with the essential command or config
+- **Reference tables after prose** -- narrative explanation followed by a compact scannable table
+
+### Tier 3: In-Repo Docs
+
+`/docs/requirements/`, `/docs/adr/`, internal design documents. These are for contributors and Claude Code sessions. They don't need to be beginner-friendly -- technical precision matters here.
+
+## Content Rules
+
+These apply across all three tiers:
+
+1. **User-benefit language over technical specs.** Feature lists describe what the user gains. "Alerts you when device behavior changes" not "EWMA baselines with Z-score anomaly detection." Technical terms get parenthetical explanations or glossary links.
+
+2. **One recommended path first.** When multiple options exist, present the recommended option prominently. Alternatives go in tabs, collapsible blocks, or secondary sections.
+
+3. **Show expected outcomes.** After every setup step, describe what the user should see. "After running this command, open http://your-server-ip:8080 and you should see the setup wizard."
+
+4. **Platform-aware.** Call out when behavior differs on macOS, Windows, Raspberry Pi, NAS, or LXC. Use tabs or callout boxes, not inline paragraphs.
+
+5. **Short paragraphs + bullets.** Scannable, not dense. No paragraph should exceed 3-4 sentences.
+
+## UI/UX Rules
+
+6. **Progressive disclosure.** Simple by default, advanced on demand. Don't show every option at once. Use expandable sections, tabs, or "Advanced" toggles.
+
+7. **Error messages should suggest fixes.** "No devices found" should link to troubleshooting or suggest checking network mode. Never show a bare error without guidance.
+
+8. **First-run experience is critical.** The path from install to seeing your first device scan should be frictionless. Every extra click or decision point is a potential drop-off.
+
+## API/Config Rules
+
+9. **Sensible defaults for everything.** A user should be able to run SubNetree with zero configuration and get a useful result. Config files are for customization, not requirements.
+
+10. **Comment example configs heavily.** Every setting should explain what it does, what the default is, and when you'd change it. Use plain language, not just the field name.
+
+## Litmus Tests
+
+**README:** "Can someone decide whether to install SubNetree within 30 seconds of landing on this page?"
+
+**Docs site (beginner):** "Would a homelab user who found this on Reddit at 11pm understand this without Googling?"
+
+**Docs site (advanced):** "Can an experienced sysadmin find the answer they need within 10 seconds of opening this page?"
+
+**In-repo docs:** "Does this give a contributor enough context to implement correctly?"

--- a/docs/requirements/21-phased-roadmap.md
+++ b/docs/requirements/21-phased-roadmap.md
@@ -254,6 +254,48 @@
 - [x] Dashboard Documentation tab with timeline, diff viewer, collector controls
 - [ ] Additional collectors: systemd, Home Assistant, Plex (future)
 
+### Documentation and UX (Cross-Cutting)
+
+**Status:** Three-tier model adopted 2026-02-14. Issues #213-#225 created. MkDocs site not yet scaffolded.
+
+**Goal:** Follow the three-tier documentation model (README landing page, MkDocs docs site, in-repo contributor docs). Remove barriers for first-time homelab users while keeping experienced users efficient.
+
+**Source:** Novice UX Review (2026-02-14), competitive research of 9 high-adoption OSS projects.
+
+**Reference:** [28-documentation-requirements.md](28-documentation-requirements.md), `.claude/rules/novice-ux-principles.md`
+
+#### P0 - Infrastructure
+
+- [ ] Set up MkDocs Material scaffolding (`mkdocs.yml`, `docs-site/` directory)
+- [ ] Deploy docs site to GitHub Pages (`herbhall.github.io/subnetree`)
+- [ ] Verify Docker image is pullable on GHCR (#215)
+- [ ] Simplify Quick Start to single recommended Docker path (#214)
+
+#### P1 - README and First Experience
+
+- [ ] Trim README to ~2,000 words landing page with docs site links (#219)
+- [ ] Add "What You'll Need" prerequisites section to README (#213)
+- [ ] Replace jargon with user-benefit language in README (#220)
+- [ ] Separate user vs dev docker-compose files (#217)
+
+#### P2 - Docs Site Content
+
+- [ ] Getting Started: Installation page (tabbed Docker/Binary/Source) (#216)
+- [ ] Getting Started: First Scan walkthrough
+- [ ] Getting Started: Dashboard Tour
+- [ ] Getting Started: FAQ
+- [ ] Operations: Troubleshooting with common novice issues (#218)
+- [ ] Operations: Platform-specific notes (#223)
+- [ ] User Guide: Common tasks for day-2 operations (#221)
+- [ ] Expand example config with novice-friendly comments (#222)
+- [ ] Add .env.example for Docker Compose users (#224)
+
+#### P3 - Polish
+
+- [ ] Update comparison table setup time to be realistic (#225)
+- [ ] Migrate existing `docs/guides/` content to docs site
+- [ ] Auto-generated API reference from OpenAPI spec
+
 ### Phase 2: Core Monitoring + Multi-Tenancy
 
 **Status:** Active development as of 2026-02-14. SNMP discovery (PRs #204-205), TCP/HTTP checks (#196, #202), webhook notifications (#203), monitoring dashboard (#206), and service mapping (#193-195) shipped. Multi-tenancy, Tailscale plugin, and PostgreSQL not yet started.
@@ -264,7 +306,7 @@
 
 - [ ] Evaluate PostgreSQL + TimescaleDB: migration tooling (golang-migrate), hypertable performance, connection pooling
 - [ ] Research Docker multi-arch build pipeline (buildx, QEMU, manifest lists)
-- [ ] Scaffold Hugo + Docsy documentation site, configure GitHub Pages deployment
+- [ ] Scaffold MkDocs Material documentation site, configure GitHub Pages deployment (see Cross-Cutting section)
 - [ ] Evaluate Plausible Analytics: self-hosted vs cloud, deployment requirements
 - [ ] Research OpenTelemetry Go SDK integration patterns for tracing
 - [ ] Evaluate SBOM generation tooling (Syft) and signing (Cosign) for release pipeline

--- a/docs/requirements/28-documentation-requirements.md
+++ b/docs/requirements/28-documentation-requirements.md
@@ -1,87 +1,186 @@
 ## Documentation Requirements
 
-### User-Facing Documentation
+### Three-Tier Documentation Model
 
-| Document | Description | Phase |
-|----------|-------------|-------|
-| README.md | Quick start, feature overview, screenshots | 1 |
-| Installation Guide | Single binary, Docker, Docker Compose | 1 |
-| Configuration Reference | All YAML keys, env vars, defaults | 1 |
-| User Guide | Dashboard walkthrough, common workflows | 1 |
-| Admin Guide | User management, backup/restore, upgrades | 2 |
-| API Reference | OpenAPI 3.0 spec, auto-generated | 1 |
-| Agent Deployment Guide | Windows, Linux, macOS installation | 1b/2/3 |
+SubNetree follows the documentation pattern used by high-adoption open-source projects (Home Assistant, Grafana, Traefik, Uptime Kuma). Each tier has a distinct purpose and audience.
 
-### Developer Documentation
+| Tier | Surface | Purpose | Audience |
+| ---- | ------- | ------- | -------- |
+| 1 | **README.md** | Hook, Quick Start, links out | Everyone (30 seconds) |
+| 2 | **Docs site** (MkDocs Material on GitHub Pages) | Guides, tutorials, config reference | Users by skill level |
+| 3 | **In-repo `/docs/`** | Requirements, ADRs, internal design | Contributors only |
 
-| Document | Description | Phase |
-|----------|-------------|-------|
-| Architecture Overview | System design, plugin system, data flow | 1 |
-| Plugin Developer Guide | Creating custom modules, role interfaces, SDK | 2 |
-| Contributing Guide (CONTRIBUTING.md) | Development setup, code style, PR process, testing, CLA | 1 |
-| Plugin API Changelog | Breaking changes by API version | 2 |
-| Example Plugins | Webhook notifier, Prometheus exporter, alternative credential store | 2 |
+**Key rule:** README length inversely correlates with project maturity. Keep the README under ~2,000 words. Everything else lives on the docs site.
 
-### Community Health Files (GitHub)
+See `.claude/rules/novice-ux-principles.md` for full content rules, patterns, and litmus tests.
 
-Standard files that GitHub recognizes and surfaces in the repository UI. These establish project professionalism and reduce friction for contributors and evaluators.
+### Tier 1: README (~2,000 words max)
 
-| File | Description | Phase |
-|------|-------------|-------|
-| `CONTRIBUTING.md` | Development setup, PR process, code style, testing expectations, CLA | 1 |
-| `SECURITY.md` | Vulnerability disclosure process, supported versions, security contacts | 1 |
-| `.github/pull_request_template.md` | PR checklist: description, tests, lint, breaking changes | 1 |
-| `.github/ISSUE_TEMPLATE/bug_report.md` | Bug report template (exists) | 1 |
-| `.github/ISSUE_TEMPLATE/feature_request.md` | Feature request template (exists) | 1 |
-| `.github/FUNDING.yml` | Sponsor button configuration (exists) | 1 |
-| `.github/workflows/ci.yml` | CI pipeline: lint, test, build, license check | 1 |
-| `.github/workflows/release.yml` | Release pipeline: GoReleaser, Docker, SBOM, signing | 1 |
-| `CODE_OF_CONDUCT.md` | Contributor Covenant or similar code of conduct | 1 |
-| `SUPPORTERS.md` | Financial supporter recognition (exists) | 1 |
-| `LICENSING.md` | Human-readable licensing explanation (exists) | 1 |
+The README is a landing page, not a manual. It answers: What is this? Why should I care? How do I try it?
 
-### README Structure (Target State)
-
-The README is the project's front door. It must convert a skeptical visitor into someone who tries the software. Target structure for Phase 1:
-
-```
+```text
 # SubNetree
-[badges: CI | Go version | License | Latest Release | Docker Pulls]
+[badges: CI | Go version | License | Latest Release | Docker Image]
 
-One-sentence description + key screenshot/GIF
+One-sentence tagline + 1-2 screenshots/GIFs
 
 ## Why SubNetree?
-- Feature comparison table (vs Zabbix, LibreNMS, Uptime Kuma, Domotz)
-- "One tool instead of five" value proposition
-
-## Current Status
-- What works today (honest)
-- What's in progress
-- Link to roadmap
-
-## Quick Start
-### Binary
-### Docker (one-liner)
-### Docker Compose
+Bullet-point value prop + comparison table
 
 ## Screenshots
-Dashboard, topology map, device detail, scan in progress
+2-3 key screens (dashboard, topology, device detail)
 
-## Architecture
-[existing architecture diagram]
+## Quick Start
+Single copy-paste docker command (host networking recommended)
+Bridge mode in collapsible <details> block
 
-## Modules
-[existing module table]
+## Features
+User-benefit language, not technical specs
+Link to docs site for details
 
-## Development
+## Documentation
+Link to docs site with section overview
+
+## Community + Support
+Links to Discussions, Issues, Discord
+
+--- For Contributors ---
+
+## Building from Source
 Build, test, lint commands
 
 ## Contributing
 Link to CONTRIBUTING.md
 
-## Support the Project
-Sponsor links
-
 ## License
-Clear BSL 1.1 explanation with "free for personal, home-lab, and non-competing production use"
+BSL 1.1 clarity
 ```
+
+### Tier 2: Docs Site (MkDocs Material)
+
+Organized by skill level in the sidebar. Hosted on GitHub Pages at `docs.subnetree.io` or `herbhall.github.io/subnetree`.
+
+#### Getting Started (beginners)
+
+| Page | Content |
+| ---- | ------- |
+| Installation | Tabbed: Docker / Binary / Source, per-platform notes |
+| First Scan | Step-by-step from login to seeing devices |
+| Dashboard Tour | What each panel shows, how to navigate |
+| FAQ | Common questions from new users |
+
+#### User Guide (intermediate)
+
+| Page | Content |
+| ---- | ------- |
+| Discovery | Scan types (ARP, ICMP, SNMP), scheduling |
+| Monitoring | Checks, alerts, notification channels |
+| Topology | Network map, layout, export |
+| Credential Vault | Storing and using device credentials |
+| Remote Access | SSH-in-browser, HTTP proxy |
+| Themes | Built-in themes, customization |
+| Configuration Reference | All YAML keys, env vars, defaults |
+
+#### Operations (advanced)
+
+| Page | Content |
+| ---- | ------- |
+| Backup and Restore | CLI commands, scheduling |
+| Upgrading | Version migration, breaking changes |
+| Troubleshooting | Expanded scenarios with fixes |
+| Platform Notes | UnRAID, Proxmox, Synology, Pi, NAS, macOS/Windows |
+| Performance Tuning | Profiles, concurrency, resource limits |
+| Scout Agent | Deployment, enrollment, mTLS |
+
+#### Developer Guide (contributors)
+
+| Page | Content |
+| ---- | ------- |
+| Architecture | System design, plugin system, data flow |
+| Plugin Development | Creating modules, role interfaces, SDK |
+| API Reference | REST endpoints, auto-generated from OpenAPI |
+| gRPC Protocol | Agent-server communication, proto definitions |
+| Contributing | Development setup, code style, testing |
+
+### Tier 3: In-Repo Documentation
+
+| Location | Content | Audience |
+| -------- | ------- | -------- |
+| `docs/requirements/` | Product requirements (28 files) | Contributors, Claude Code |
+| `docs/adr/` | Architecture Decision Records | Contributors |
+| `docs/guides/` | Deployment guides (Tailscale, etc.) | Transitional (move to docs site) |
+| `.claude/` | Claude Code project config, rules | Claude Code sessions |
+
+### Community Health Files (GitHub)
+
+Standard files that GitHub recognizes and surfaces in the repository UI.
+
+| File | Description | Status |
+| ---- | ----------- | ------ |
+| `CONTRIBUTING.md` | Development setup, PR process, code style, testing, CLA | Exists |
+| `SECURITY.md` | Vulnerability disclosure process | Exists |
+| `CODE_OF_CONDUCT.md` | Contributor Covenant v2.1 | Exists |
+| `.github/pull_request_template.md` | PR checklist | Exists |
+| `.github/ISSUE_TEMPLATE/` | Bug report, feature request, plugin idea | Exists |
+| `.github/FUNDING.yml` | Sponsor button | Exists |
+| `SUPPORTERS.md` | Financial supporter recognition | Exists |
+| `LICENSING.md` | Human-readable licensing explanation | Exists |
+
+### MkDocs Material Configuration
+
+```yaml
+# mkdocs.yml (target configuration)
+site_name: SubNetree Documentation
+site_url: https://herbhall.github.io/subnetree
+repo_url: https://github.com/HerbHall/subnetree
+
+theme:
+  name: material
+  features:
+    - navigation.tabs         # Top-level skill-level tabs
+    - navigation.sections     # Grouped sidebar
+    - navigation.expand       # Auto-expand current section
+    - search.suggest          # Search autocomplete
+    - content.tabs.link       # Linked content tabs (Docker/Binary/Source)
+    - content.code.copy       # Copy button on code blocks
+
+markdown_extensions:
+  - admonition               # Callout boxes (tip, warning, note)
+  - pymdownx.details         # Collapsible sections
+  - pymdownx.tabbed:         # Tabbed content (platform/method switching)
+      alternate_style: true
+  - pymdownx.superfences     # Fenced code blocks with titles
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - Installation: getting-started/installation.md
+      - First Scan: getting-started/first-scan.md
+      - Dashboard Tour: getting-started/dashboard-tour.md
+      - FAQ: getting-started/faq.md
+  - User Guide:
+      - Discovery: guide/discovery.md
+      - Monitoring: guide/monitoring.md
+      - Topology: guide/topology.md
+      - Credential Vault: guide/vault.md
+      - Remote Access: guide/remote-access.md
+      - Configuration: guide/configuration.md
+  - Operations:
+      - Backup & Restore: ops/backup-restore.md
+      - Upgrading: ops/upgrading.md
+      - Troubleshooting: ops/troubleshooting.md
+      - Platform Notes: ops/platforms.md
+      - Scout Agent: ops/scout-agent.md
+  - Developer Guide:
+      - Architecture: dev/architecture.md
+      - Plugin Development: dev/plugins.md
+      - API Reference: dev/api-reference.md
+      - Contributing: dev/contributing.md
+```
+
+### Migration Path
+
+1. **Phase 1:** Set up MkDocs Material scaffolding, deploy to GitHub Pages
+2. **Phase 2:** Trim README to ~2,000 words, add docs site links
+3. **Phase 3:** Migrate existing `docs/guides/` content to docs site pages
+4. **Phase 4:** Expand with tutorials, auto-generated API docs from OpenAPI spec


### PR DESCRIPTION
## Summary

- Adopts three-tier documentation model (README landing page, MkDocs docs site, in-repo contributor docs) based on research of 9 high-adoption OSS projects
- Rewrites documentation requirements with full MkDocs Material config and migration path
- Creates `.claude/rules/novice-ux-principles.md` with content rules and litmus tests
- Updates CLAUDE.md guiding principle #2 to reference three-tier model
- Reorganizes roadmap "Novice UX" section into "Documentation and UX" with MkDocs setup as P0

## Test plan

- [x] Verify doc files render correctly in markdown
- [x] No code changes -- documentation only

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)