### PR TITLE
fix: improve Docker quick start UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,23 +46,21 @@ That's it. No databases, no config files, no dependencies to install.
 ## Quick Start
 
 ```console
+docker run -d --name subnetree -p 8080:8080 -v subnetree-data:/data ghcr.io/herbhall/subnetree:latest
+```
+
+Open [http://localhost:8080](http://localhost:8080) -- the setup wizard will guide you through creating an admin account.
+
+<details>
+<summary>Using host networking (Linux only -- recommended for full discovery)</summary>
+
+Host networking gives SubNetree direct access to your LAN for ARP/ICMP device discovery. This is the recommended setup for Linux home servers:
+
+```console
 docker run -d --name subnetree --network host -v subnetree-data:/data ghcr.io/herbhall/subnetree:latest
 ```
 
-Open `http://your-server-ip:8080` -- the setup wizard will guide you through creating an admin account.
-
-> **Note:** Host networking gives SubNetree direct access to your LAN for device discovery. This is the recommended setup for home networks.
-
-<details>
-<summary>Using bridge networking instead</summary>
-
-If host networking is not available (e.g., macOS, Windows Docker Desktop):
-
-```console
-docker run -d --name subnetree -p 8080:8080 -v subnetree-data:/data --cap-add NET_RAW --cap-add NET_ADMIN ghcr.io/herbhall/subnetree:latest
-```
-
-Bridge mode requires `NET_RAW` and `NET_ADMIN` capabilities for network scanning. Discovery may be limited to the Docker bridge subnet.
+> **Note:** `--network host` is not supported on Docker Desktop (macOS/Windows). Use the default bridge command above instead.
 
 </details>
 

--- a/cmd/subnetree/main.go
+++ b/cmd/subnetree/main.go
@@ -207,7 +207,7 @@ func main() {
 			logger.Fatal("failed to generate JWT secret", zap.Error(err))
 		}
 		jwtSecret = hex.EncodeToString(b)
-		logger.Warn("no auth.jwt_secret configured; using ephemeral secret (tokens will not survive restarts)",
+		logger.Info("using auto-generated JWT secret (normal for first run; set auth.jwt_secret in config to persist sessions across restarts)",
 			zap.String("component", "auth"),
 		)
 	} else {
@@ -304,6 +304,13 @@ func main() {
 	}()
 
 	logger.Info("SubNetree server ready", zap.String("addr", addr))
+
+	// Print human-readable banner for users watching docker logs.
+	port := viperCfg.GetString("server.port")
+	if port == "" {
+		port = "8080"
+	}
+	fmt.Fprintf(os.Stderr, "\n  SubNetree %s is ready!\n  Open http://localhost:%s in your browser.\n\n", version.Short(), port)
 
 	// Wait for shutdown signal
 	sigCh := make(chan os.Signal, 1)

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -56,7 +56,7 @@ func TestLoggingMiddleware(t *testing.T) {
 		w.WriteHeader(http.StatusCreated)
 	})
 
-	handler := LoggingMiddleware(logger)(inner)
+	handler := LoggingMiddleware(logger, nil)(inner)
 
 	req := httptest.NewRequest("GET", "/test", http.NoBody)
 	w := httptest.NewRecorder()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -87,7 +87,7 @@ func New(addr string, plugins PluginSource, logger *zap.Logger, ready ReadinessC
 	middlewares := []Middleware{
 		RecoveryMiddleware(logger),
 		RequestIDMiddleware,
-		LoggingMiddleware(logger),
+		LoggingMiddleware(logger, []string{"/healthz", "/readyz", "/metrics"}),
 		SecurityHeadersMiddleware,
 		VersionHeaderMiddleware,
 		RateLimitMiddleware(100, 200, []string{"/healthz", "/readyz", "/metrics"}),


### PR DESCRIPTION
## Summary

- Suppress healthcheck log spam: `/healthz`, `/readyz`, `/metrics` no longer logged at INFO level (Prometheus metrics still collected for all paths)
- Add plain-text startup banner visible in `docker logs` so users know when the server is ready
- Change README Quick Start default to bridge networking (`-p 8080:8080`) since `--network host` silently fails on Docker Desktop (Windows/macOS)
- Downgrade ephemeral JWT secret message from Warn to Info (expected on first run)

## Context

Running the Quick Start `docker run` command appeared "stuck" -- the server booted in 50ms but `docker logs` showed nothing but `/healthz` healthcheck lines every 28 seconds (130 identical lines/hour). On Docker Desktop, `--network host` silently does nothing, so `localhost:8080` was unreachable.

## Test plan

- [ ] `go build ./...` compiles
- [ ] `go test ./internal/server/...` passes (middleware test updated)
- [ ] `golangci-lint run` clean
- [ ] Docker: startup banner visible in `docker logs`
- [ ] Docker: no `/healthz` spam in logs
- [ ] Docker: UI accessible at `http://localhost:8080` with bridge networking

🤖 Generated with [Claude Code](https://claude.com/claude-code)