### PR TITLE
fix: theme switching race condition and topology zoom limits

### DIFF
--- a/web/src/components/settings/theme-selector.tsx
+++ b/web/src/components/settings/theme-selector.tsx
@@ -52,6 +52,10 @@ export function ThemeSelector({ onCustomize }: ThemeSelectorProps) {
     },
     onSuccess: (theme) => {
       setStoreTheme(theme)
+      // Update ThemeProvider's cached queries so its useEffect sees the new
+      // theme immediately and doesn't revert to the stale server value.
+      queryClient.setQueryData(['theme', 'active'], { theme_id: theme.id })
+      queryClient.setQueryData(['theme', theme.id], theme)
       toast.success(`Switched to "${theme.name}"`)
       queryClient.invalidateQueries({ queryKey: ['settings', 'themes'] })
     },

--- a/web/src/pages/topology.tsx
+++ b/web/src/pages/topology.tsx
@@ -603,8 +603,10 @@ export function TopologyPage() {
         onPaneClick={handlePaneClick}
         nodeTypes={nodeTypes}
         edgeTypes={edgeTypes}
+        minZoom={0.1}
+        maxZoom={4}
         fitView
-        fitViewOptions={{ padding: 0.2 }}
+        fitViewOptions={{ padding: 0.2, maxZoom: 1.5 }}
         proOptions={{ hideAttribution: true }}
         className="rounded-lg"
         style={{ backgroundColor: 'var(--nv-bg-surface)' }}


### PR DESCRIPTION
## Summary

- **Theme switching bug**: Clicking "Use" on a theme showed a success toast but didn't visually apply the theme. Root cause: ThemeProvider's stale React Query cache (`staleTime: 60s`) reverted the Zustand store update. Fix: update the query cache (`setQueryData`) in the mutation's `onSuccess` so the ThemeProvider's `useEffect` sees matching data and skips the revert.

- **Topology zoom**: React Flow's default `maxZoom: 2.0` prevented users from zooming into large topologies. Added `minZoom={0.1}` and `maxZoom={4}` for proper overview and detail views. Also capped `fitView` at `maxZoom: 1.5` to prevent over-zooming on small topologies.

## Test plan

- [ ] Go to Settings > Themes, click "Use" on a different theme -- verify visual change persists
- [ ] Switch between multiple themes rapidly -- no revert flicker
- [ ] Reload page -- theme persists from localStorage
- [ ] Open Topology page with multiple nodes -- verify scroll wheel zooms in past 2x
- [ ] Verify fit-to-view button works and doesn't over-zoom on small graphs

🤖 Generated with [Claude Code](https://claude.com/claude-code)