### PR TITLE
feat: dependency-aware alert suppression

### DIFF
--- a/api/swagger/docs.go
+++ b/api/swagger/docs.go
@@ -1083,6 +1083,151 @@ const docTemplate = `{
                 }
             }
         },
+        "/pulse/checks/{check_id}/dependencies": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns all upstream device dependencies for a check.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "pulse"
+                ],
+                "summary": "List check dependencies",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Check ID",
+                        "name": "check_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/internal_pulse.CheckDependency"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Adds an upstream device dependency. When the upstream device has an active critical alert, this check's alerts are suppressed.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "pulse"
+                ],
+                "summary": "Add check dependency",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Check ID",
+                        "name": "check_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Dependency definition",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_pulse.addDependencyRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/pulse/checks/{check_id}/dependencies/{device_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Removes an upstream device dependency from a check.",
+                "tags": [
+                    "pulse"
+                ],
+                "summary": "Remove check dependency",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Check ID",
+                        "name": "check_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Upstream device ID",
+                        "name": "device_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/pulse/checks/{device_id}": {
             "get": {
                 "security": [
@@ -4266,6 +4411,12 @@ const docTemplate = `{
                 "severity": {
                     "type": "string"
                 },
+                "suppressed": {
+                    "type": "boolean"
+                },
+                "suppressed_by": {
+                    "type": "string"
+                },
                 "triggered_at": {
                     "type": "string"
                 }
@@ -4296,6 +4447,20 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_pulse.CheckDependency": {
+            "type": "object",
+            "properties": {
+                "check_id": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "depends_on_device_id": {
                     "type": "string"
                 }
             }
@@ -4384,6 +4549,14 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_pulse.addDependencyRequest": {
+            "type": "object",
+            "properties": {
+                "depends_on_device_id": {
                     "type": "string"
                 }
             }

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -1076,6 +1076,151 @@
                 }
             }
         },
+        "/pulse/checks/{check_id}/dependencies": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns all upstream device dependencies for a check.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "pulse"
+                ],
+                "summary": "List check dependencies",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Check ID",
+                        "name": "check_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/internal_pulse.CheckDependency"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Adds an upstream device dependency. When the upstream device has an active critical alert, this check's alerts are suppressed.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "pulse"
+                ],
+                "summary": "Add check dependency",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Check ID",
+                        "name": "check_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Dependency definition",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_pulse.addDependencyRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/pulse/checks/{check_id}/dependencies/{device_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Removes an upstream device dependency from a check.",
+                "tags": [
+                    "pulse"
+                ],
+                "summary": "Remove check dependency",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Check ID",
+                        "name": "check_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Upstream device ID",
+                        "name": "device_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/pulse/checks/{device_id}": {
             "get": {
                 "security": [
@@ -4259,6 +4404,12 @@
                 "severity": {
                     "type": "string"
                 },
+                "suppressed": {
+                    "type": "boolean"
+                },
+                "suppressed_by": {
+                    "type": "string"
+                },
                 "triggered_at": {
                     "type": "string"
                 }
@@ -4289,6 +4440,20 @@
                     "type": "string"
                 },
                 "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_pulse.CheckDependency": {
+            "type": "object",
+            "properties": {
+                "check_id": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "depends_on_device_id": {
                     "type": "string"
                 }
             }
@@ -4377,6 +4542,14 @@
                     "type": "string"
                 },
                 "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_pulse.addDependencyRequest": {
+            "type": "object",
+            "properties": {
+                "depends_on_device_id": {
                     "type": "string"
                 }
             }

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -613,6 +613,10 @@ definitions:
         type: string
       severity:
         type: string
+      suppressed:
+        type: boolean
+      suppressed_by:
+        type: string
       triggered_at:
         type: string
     type: object
@@ -633,6 +637,15 @@ definitions:
       target:
         type: string
       updated_at:
+        type: string
+    type: object
+  internal_pulse.CheckDependency:
+    properties:
+      check_id:
+        type: string
+      created_at:
+        type: string
+      depends_on_device_id:
         type: string
     type: object
   internal_pulse.CheckResult:
@@ -691,6 +704,11 @@ definitions:
         description: '"webhook", "email"'
         type: string
       updated_at:
+        type: string
+    type: object
+  internal_pulse.addDependencyRequest:
+    properties:
+      depends_on_device_id:
         type: string
     type: object
   internal_pulse.createCheckRequest:
@@ -1801,6 +1819,101 @@ paths:
       security:
       - BearerAuth: []
       summary: Create check
+      tags:
+      - pulse
+  /pulse/checks/{check_id}/dependencies:
+    get:
+      description: Returns all upstream device dependencies for a check.
+      parameters:
+      - description: Check ID
+        in: path
+        name: check_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/internal_pulse.CheckDependency'
+            type: array
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - BearerAuth: []
+      summary: List check dependencies
+      tags:
+      - pulse
+    post:
+      consumes:
+      - application/json
+      description: Adds an upstream device dependency. When the upstream device has
+        an active critical alert, this check's alerts are suppressed.
+      parameters:
+      - description: Check ID
+        in: path
+        name: check_id
+        required: true
+        type: string
+      - description: Dependency definition
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_pulse.addDependencyRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Add check dependency
+      tags:
+      - pulse
+  /pulse/checks/{check_id}/dependencies/{device_id}:
+    delete:
+      description: Removes an upstream device dependency from a check.
+      parameters:
+      - description: Check ID
+        in: path
+        name: check_id
+        required: true
+        type: string
+      - description: Upstream device ID
+        in: path
+        name: device_id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Remove check dependency
       tags:
       - pulse
   /pulse/checks/{device_id}:

--- a/internal/pulse/events.go
+++ b/internal/pulse/events.go
@@ -10,4 +10,5 @@ const (
 	TopicMetricsCollected = "pulse.metrics.collected"
 	TopicAlertTriggered   = "pulse.alert.triggered"
 	TopicAlertResolved    = "pulse.alert.resolved"
+	TopicAlertSuppressed  = "pulse.alert.suppressed"
 )

--- a/web/src/api/pulse.ts
+++ b/web/src/api/pulse.ts
@@ -1,6 +1,7 @@
 import { api } from './client'
 import type {
   Check,
+  CheckDependency,
   CheckResult,
   Alert,
   CreateCheckRequest,
@@ -79,12 +80,14 @@ export async function listAlerts(params?: {
   device_id?: string
   severity?: string
   active?: boolean
+  suppressed?: boolean
   limit?: number
 }): Promise<Alert[]> {
   const query = new URLSearchParams()
   if (params?.device_id) query.set('device_id', params.device_id)
   if (params?.severity) query.set('severity', params.severity)
   if (params?.active !== undefined) query.set('active', params.active.toString())
+  if (params?.suppressed !== undefined) query.set('suppressed', params.suppressed.toString())
   if (params?.limit) query.set('limit', params.limit.toString())
   const qs = query.toString()
   return api.get<Alert[]>(`/pulse/alerts${qs ? `?${qs}` : ''}`)
@@ -109,6 +112,41 @@ export async function acknowledgeAlert(id: string): Promise<Alert> {
  */
 export async function resolveAlert(id: string): Promise<Alert> {
   return api.post<Alert>(`/pulse/alerts/${id}/resolve`, {})
+}
+
+// ============================================================================
+// Check Dependencies
+// ============================================================================
+
+/**
+ * List dependencies for a check.
+ */
+export async function listCheckDependencies(
+  checkId: string
+): Promise<CheckDependency[]> {
+  return api.get<CheckDependency[]>(`/pulse/checks/${checkId}/dependencies`)
+}
+
+/**
+ * Add a dependency between a check and an upstream device.
+ */
+export async function addCheckDependency(
+  checkId: string,
+  deviceId: string
+): Promise<void> {
+  await api.post(`/pulse/checks/${checkId}/dependencies`, {
+    depends_on_device_id: deviceId,
+  })
+}
+
+/**
+ * Remove a dependency between a check and an upstream device.
+ */
+export async function removeCheckDependency(
+  checkId: string,
+  deviceId: string
+): Promise<void> {
+  await api.delete(`/pulse/checks/${checkId}/dependencies/${deviceId}`)
 }
 
 /**

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -387,6 +387,15 @@ export interface Alert {
   resolved_at?: string
   acknowledged_at?: string
   consecutive_failures: number
+  suppressed: boolean
+  suppressed_by?: string
+}
+
+/** A dependency between a check and an upstream device for alert suppression. */
+export interface CheckDependency {
+  check_id: string
+  depends_on_device_id: string
+  created_at: string
 }
 
 /** Request body for creating a new check. */


### PR DESCRIPTION
## Summary

Closes #236

- **Data model**: Migration v4 adds `pulse_check_dependencies` table and `suppressed`/`suppressed_by` columns on `pulse_alerts`
- **Store**: CRUD for check dependencies, `IsSuppressed()` JOIN query checking upstream devices for active critical alerts
- **Alerter**: Fail-open suppression check before inserting alerts; suppressed alerts publish `TopicAlertSuppressed` instead of `TopicAlertTriggered`
- **API**: 3 dependency endpoints (`GET/POST /checks/{id}/dependencies`, `DELETE /checks/{id}/dependencies/{device_id}`), `?suppressed` filter on list alerts
- **Dashboard**: "Show Suppressed" toggle (hidden by default), reduced-opacity rows and amber badge for suppressed alerts
- **Events**: New `pulse.alert.suppressed` topic

## Test plan

- [x] `go build ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] `pnpm run build` + `pnpm run lint` clean
- [x] Swagger spec regenerated
- [ ] CI passes (12 checks)
- [ ] Pre-existing flaky `TestHTTPChecker_Non2xx` failure is on main, not caused by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)