### PR TITLE
docs: repo metadata and GitHub topics for discoverability

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,5 +1,22 @@
 {
   "name": "subnetree-dashboard",
+  "description": "SubNetree Dashboard - Network monitoring and management web interface",
+  "keywords": [
+    "network-monitoring",
+    "homelab",
+    "dashboard",
+    "react",
+    "typescript",
+    "self-hosted"
+  ],
+  "homepage": "https://github.com/HerbHall/subnetree",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/HerbHall/subnetree.git",
+    "directory": "web"
+  },
+  "license": "BSL-1.1",
+  "author": "Herb Hall",
   "private": true,
   "version": "0.0.0",
   "type": "module",


### PR DESCRIPTION
## Summary

- Added description, keywords, homepage, repository, license, and author fields to `web/package.json`
- Added 15 GitHub topics via API (network-monitoring, homelab, self-hosted, golang, react, etc.)
- Verified comparison table setup time values are realistic (no changes needed)
- `.github/FUNDING.yml` already exists with correct content

Closes #260, Closes #225

## Test plan

- [ ] `pnpm run build` passes (validates package.json)
- [ ] GitHub topics visible on repo page
- [ ] Comparison table values match actual deployment experience

:robot: Generated with [Claude Code](https://claude.com/claude-code)