### PR TITLE
docs: v0.4.0 release notes

### DIFF
--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -1,0 +1,126 @@
+# v0.4.0 Release Notes
+
+**Release Date:** February 2026
+**Tag:** `v0.4.0`
+
+## Overview
+
+v0.4.0 is a major feature release delivering expanded network discovery,
+monitoring intelligence, AI-powered analytics with multi-provider LLM support,
+mTLS agent security, and a complete documentation overhaul. 24 PRs merged
+since v0.3.0.
+
+## New Discovery Methods
+
+### mDNS/Bonjour Discovery (PR #248)
+
+- Passive discovery via mDNS service announcements on the local network
+- Queries 14 well-known service types (HTTP, SSH, AirPlay, HomeKit, etc.)
+- Automatic device upsert with hostname and service metadata
+- Configurable query interval (default 5 minutes)
+- Platform: Linux/macOS (Windows stub -- mDNS unreliable on Windows)
+
+## Monitoring Enhancements
+
+### Time-Series Metrics API (PR #243)
+
+- Historical metrics storage with configurable retention
+- Downsampling API for efficient graph rendering (1m, 5m, 15m, 1h, 6h, 1d)
+- Per-device, per-metric time-series queries
+- Dashboard metric charts with selectable time ranges
+
+### Dependency-Aware Alert Suppression (PR #261)
+
+- Define check dependencies (e.g., server depends on router)
+- When a parent device goes down, downstream alerts are automatically suppressed
+- Prevents alert storms during network outages
+- Visual dependency indicators in monitoring dashboard
+
+## AI and Analytics
+
+### Multi-Provider LLM Support (PRs #271, #273)
+
+- **OpenAI** provider: GPT-4o-mini default, Bearer token auth, streaming support
+- **Anthropic** provider: Claude Sonnet default, x-api-key auth, content blocks
+- **BYOK configuration**: Store API keys in Vault, select provider in Settings
+- Settings UI: Provider dropdown, conditional fields, "Test Connection" button
+- Graceful degradation: All features work without any LLM configured
+
+### Natural Language Query Bar (PR #272)
+
+- Dashboard widget for asking questions about your network in plain English
+- Powered by configured LLM provider (Ollama, OpenAI, or Anthropic)
+- Handles unconfigured state gracefully with helpful setup message
+- Sparkles icon for AI branding
+
+### AI Optimization Recommendations (PR #274)
+
+- Threshold-based resource analysis: CPU >80%, memory >85%, disk >90%
+- Severity levels: info, warning, critical
+- Dashboard widget with auto-refresh (5-minute interval)
+- REST API: `GET /api/v1/insight/recommendations`
+
+## Agent Security
+
+### mTLS Certificate Authority (PRs #207-210)
+
+- Built-in CA for Scout agent mutual TLS authentication
+- Automated certificate enrollment during agent registration
+- Certificate renewal before expiration
+- Secure gRPC communication between server and agents
+
+### Linux Scout Agent (PR #262)
+
+- Native Linux agent (x64, ARM64) with real system collectors
+- CPU, memory, disk, network interface metrics
+- Service discovery (systemd units, Docker containers)
+- Hardware profiling (DMI/sysfs-based)
+
+## Vault UI
+
+### Credential Manager Frontend (PR #264)
+
+- Full CRUD interface for managing encrypted credentials
+- Device credential assignment
+- Credential type filtering and search
+- Audit log viewer
+
+## Documentation Overhaul
+
+### MkDocs Material Site (PR #270)
+
+- Migrated from Hugo to MkDocs Material theme
+- Forest green brand palette with slate scheme
+- 50+ documentation pages organized into 7 navigation sections
+- Table of contents with permalinks on all long documents
+- Custom checkbox styling for roadmap checklists
+- Search, code copy, and responsive navigation
+
+### Guides and References (PRs #247, #265, #267, #268, #269)
+
+- Getting Started guide with Quick Start flow
+- Troubleshooting guide with common issues
+- Common Tasks reference
+- Quick Reference card (single-page cheat sheet)
+- Platform installation notes (Windows, Linux, macOS, Docker)
+- Example configuration with full documentation
+- Mermaid workflow diagrams in CONTRIBUTING guide
+
+### Project Identity (PRs #266, #275, #276)
+
+- Logo integration: README, MkDocs site, OpenGraph social card
+- GitHub repository topics and metadata for discoverability
+- Power monitoring research document (MQTT, SNMP PDU, electricity rates)
+
+## Bug Fixes
+
+- Fix theme switching race condition and topology zoom limits (PR #245)
+- Improve Docker quick start UX (PR #244)
+
+## Statistics
+
+- **24 PRs merged** since v0.3.0
+- **New discovery:** mDNS/Bonjour passive discovery
+- **New providers:** OpenAI, Anthropic LLM integration
+- **New platform:** Linux Scout agent (x64 + ARM64)
+- **Security:** mTLS certificate authority for agent communication

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,6 +100,7 @@ nav:
       - Non-Functional Requirements: requirements/27-non-functional-requirements.md
       - Documentation Requirements: requirements/28-documentation-requirements.md
   - Releases:
+      - v0.4.0: releases/v0.4.0.md
       - v0.2.1: releases/v0.2.1.md
       - v0.2.0: releases/v0.2.0.md
       - v0.1.0-alpha: releases/v0.1.0-alpha.md


### PR DESCRIPTION
## Summary

- Add v0.4.0 release notes documenting 24 PRs since v0.3.0
- Add v0.4.0 to MkDocs navigation

Prerequisite for tagging v0.4.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)