### PR TITLE
feat: UPnP/SSDP device discovery

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gosnmp/gosnmp v1.43.2
 	github.com/hashicorp/mdns v1.0.6
+	github.com/huin/goupnp v1.3.0
 	github.com/prometheus-community/pro-bing v0.8.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/viper v1.21.0

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/mdns v1.0.6 h1:SV8UcjnQ/+C7KeJ/QeVD/mdN2EmzYfcGfufcuzxfCLQ=
 github.com/hashicorp/mdns v1.0.6/go.mod h1:X4+yWh+upFECLOki1doUPaKpgNQII9gy4bUdCYKNhmM=
+github.com/huin/goupnp v1.3.0 h1:UvLUlWDNpoUdYzb2TCn+MuTWtcjXKSza2n6CBdQ0xXc=
+github.com/huin/goupnp v1.3.0/go.mod h1:gnGPsThkYa7bFi/KWmEysQRf48l2dvR5bxr2OFckNX8=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
@@ -173,6 +175,7 @@ golang.org/x/net v0.34.0/go.mod h1:di0qlW3YNM5oh6GqDGQr92MyTozJPmybPK4Ev/Gm31k=
 golang.org/x/net v0.49.0 h1:eeHFmOGUTtaaPSGNmjBKpbng9MulQsJURQUAfUwY++o=
 golang.org/x/net v0.49.0/go.mod h1:/ysNB2EvaqvesRkuLAyjI1ycPZlQHM3q01F02UY/MV8=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=

--- a/internal/recon/config.go
+++ b/internal/recon/config.go
@@ -12,6 +12,8 @@ type ReconConfig struct {
 	DeviceLostAfter time.Duration `mapstructure:"device_lost_after"`
 	MDNSEnabled     bool          `mapstructure:"mdns_enabled"`
 	MDNSInterval    time.Duration `mapstructure:"mdns_interval"`
+	UPNPEnabled     bool          `mapstructure:"upnp_enabled"`
+	UPNPInterval    time.Duration `mapstructure:"upnp_interval"`
 }
 
 // DefaultConfig returns the default configuration for the Recon module.
@@ -25,5 +27,7 @@ func DefaultConfig() ReconConfig {
 		DeviceLostAfter: 24 * time.Hour,
 		MDNSEnabled:     true,
 		MDNSInterval:    60 * time.Second,
+		UPNPEnabled:     true,
+		UPNPInterval:    5 * time.Minute,
 	}
 }

--- a/internal/recon/upnp.go
+++ b/internal/recon/upnp.go
@@ -1,0 +1,253 @@
+package recon
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/huin/goupnp"
+	"go.uber.org/zap"
+
+	"github.com/HerbHall/subnetree/pkg/models"
+	"github.com/HerbHall/subnetree/pkg/plugin"
+)
+
+// UPNPDiscoverer discovers devices via UPnP/SSDP multicast queries.
+// Pattern: same as MDNSListener in mdns.go.
+type UPNPDiscoverer struct {
+	store    *ReconStore
+	bus      plugin.EventBus
+	logger   *zap.Logger
+	interval time.Duration
+
+	mu   sync.Mutex
+	seen map[string]time.Time // UDN -> last seen time (deduplication)
+}
+
+// NewUPNPDiscoverer creates a new UPnP discoverer that periodically queries for
+// UPnP/SSDP devices and upserts discovered devices into the store.
+func NewUPNPDiscoverer(store *ReconStore, bus plugin.EventBus, logger *zap.Logger, interval time.Duration) *UPNPDiscoverer {
+	return &UPNPDiscoverer{
+		store:    store,
+		bus:      bus,
+		logger:   logger,
+		interval: interval,
+		seen:     make(map[string]time.Time),
+	}
+}
+
+// Run starts the periodic UPnP discovery loop. It blocks until ctx is cancelled.
+// The caller is responsible for running this in a goroutine and calling wg.Done.
+func (d *UPNPDiscoverer) Run(ctx context.Context) {
+	d.logger.Info("UPnP discoverer started",
+		zap.Duration("interval", d.interval),
+	)
+
+	// Run an initial scan immediately, then on a ticker.
+	d.discoverAll(ctx)
+
+	ticker := time.NewTicker(d.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			d.logger.Info("UPnP discoverer stopped")
+			return
+		case <-ticker.C:
+			d.discoverAll(ctx)
+		}
+	}
+}
+
+// discoverAll performs a full UPnP/SSDP discovery sweep.
+func (d *UPNPDiscoverer) discoverAll(ctx context.Context) {
+	d.logger.Debug("UPnP scan starting")
+
+	devices, err := goupnp.DiscoverDevicesCtx(ctx, "ssdp:all")
+	if err != nil {
+		// Context cancellation is expected during shutdown.
+		if ctx.Err() != nil {
+			return
+		}
+		d.logger.Warn("UPnP discovery failed", zap.Error(err))
+		return
+	}
+
+	var discovered int
+	for i := range devices {
+		if ctx.Err() != nil {
+			return
+		}
+		if d.processDevice(ctx, &devices[i]) {
+			discovered++
+		}
+	}
+
+	d.logger.Debug("UPnP scan complete", zap.Int("devices_found", discovered))
+	d.cleanSeen()
+}
+
+// processDevice converts a UPnP discovery result into a device and upserts it.
+// Returns true if the device was new or updated (not deduplicated).
+func (d *UPNPDiscoverer) processDevice(ctx context.Context, maybe *goupnp.MaybeRootDevice) bool {
+	if maybe.Err != nil {
+		d.logger.Debug("UPnP device probe error",
+			zap.String("usn", maybe.USN),
+			zap.Error(maybe.Err),
+		)
+		return false
+	}
+
+	if maybe.Root == nil {
+		return false
+	}
+
+	dev := &maybe.Root.Device
+	udn := dev.UDN
+	if udn == "" {
+		// Fall back to USN if UDN is not available.
+		udn = maybe.USN
+	}
+	if udn == "" {
+		return false
+	}
+
+	// Deduplicate: skip if we've seen this UDN within the current interval.
+	if d.recentlySeen(udn) {
+		return false
+	}
+	d.markSeen(udn)
+
+	// Extract the IP from the device location URL.
+	ip := ""
+	if maybe.Location != nil {
+		ip = maybe.Location.Hostname()
+	}
+	if ip == "" {
+		return false
+	}
+
+	hostname := dev.FriendlyName
+	if hostname == "" {
+		hostname = dev.ModelName
+	}
+
+	device := &models.Device{
+		Hostname:        hostname,
+		IPAddresses:     []string{ip},
+		Status:          models.DeviceStatusOnline,
+		DiscoveryMethod: models.DiscoveryUPnP,
+		DeviceType:      inferDeviceTypeFromUPnP(dev.DeviceType),
+		Manufacturer:    dev.Manufacturer,
+	}
+
+	created, err := d.store.UpsertDevice(ctx, device)
+	if err != nil {
+		d.logger.Warn("UPnP device upsert failed",
+			zap.String("ip", ip),
+			zap.String("hostname", hostname),
+			zap.Error(err),
+		)
+		return false
+	}
+
+	topic := TopicDeviceUpdated
+	if created {
+		topic = TopicDeviceDiscovered
+	}
+	d.publishEvent(ctx, topic, DeviceEvent{
+		Device: device,
+	})
+
+	d.logger.Info("UPnP device discovered",
+		zap.String("ip", ip),
+		zap.String("hostname", hostname),
+		zap.String("udn", udn),
+		zap.String("manufacturer", dev.Manufacturer),
+		zap.String("model", dev.ModelName),
+		zap.Bool("new", created),
+	)
+
+	return true
+}
+
+// recentlySeen returns true if the UDN was seen within the current scan interval.
+func (d *UPNPDiscoverer) recentlySeen(udn string) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	lastSeen, ok := d.seen[udn]
+	if !ok {
+		return false
+	}
+	return time.Since(lastSeen) < d.interval
+}
+
+// markSeen records the UDN as recently seen.
+func (d *UPNPDiscoverer) markSeen(udn string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.seen[udn] = time.Now()
+}
+
+// cleanSeen removes entries older than 2x the scan interval.
+func (d *UPNPDiscoverer) cleanSeen() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	cutoff := time.Now().Add(-2 * d.interval)
+	for udn, t := range d.seen {
+		if t.Before(cutoff) {
+			delete(d.seen, udn)
+		}
+	}
+}
+
+// publishEvent publishes an event to the event bus.
+func (d *UPNPDiscoverer) publishEvent(ctx context.Context, topic string, payload any) {
+	if d.bus == nil {
+		return
+	}
+	d.bus.PublishAsync(ctx, plugin.Event{
+		Topic:     topic,
+		Source:    "recon",
+		Timestamp: time.Now(),
+		Payload:   payload,
+	})
+}
+
+// inferDeviceTypeFromUPnP guesses the SubNetree device type from the UPnP device type URN.
+func inferDeviceTypeFromUPnP(deviceType string) models.DeviceType {
+	dt := strings.ToLower(deviceType)
+
+	switch {
+	case strings.Contains(dt, "mediarenderer") ||
+		strings.Contains(dt, "mediaserver"):
+		return models.DeviceTypeNAS
+
+	case strings.Contains(dt, "printer"):
+		return models.DeviceTypePrinter
+
+	case strings.Contains(dt, "internetgateway") ||
+		strings.Contains(dt, "wandevice") ||
+		strings.Contains(dt, "wanconnectiondevice"):
+		return models.DeviceTypeRouter
+
+	case strings.Contains(dt, "wlanaccess"):
+		return models.DeviceTypeAccessPoint
+
+	case strings.Contains(dt, "digitalSecuritycamera") ||
+		strings.Contains(dt, "digitalsecuritycamera"):
+		return models.DeviceTypeCamera
+
+	case strings.Contains(dt, "lightingcontrols") ||
+		strings.Contains(dt, "binarylight") ||
+		strings.Contains(dt, "dimmablelight") ||
+		strings.Contains(dt, "hvac") ||
+		strings.Contains(dt, "sensormanagement"):
+		return models.DeviceTypeIoT
+
+	default:
+		return models.DeviceTypeUnknown
+	}
+}

--- a/internal/recon/upnp_test.go
+++ b/internal/recon/upnp_test.go
@@ -1,0 +1,191 @@
+package recon
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/HerbHall/subnetree/internal/store"
+	"go.uber.org/zap"
+)
+
+func TestNewUPNPDiscoverer(t *testing.T) {
+	db, err := store.New(":memory:")
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	ctx := context.Background()
+	if err := db.Migrate(ctx, "recon", migrations()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	s := NewReconStore(db.DB())
+	bus := &mockEventBus{}
+	logger := zap.NewNop()
+
+	disc := NewUPNPDiscoverer(s, bus, logger, 5*time.Minute)
+	if disc == nil {
+		t.Fatal("NewUPNPDiscoverer returned nil")
+	}
+	if disc.store != s {
+		t.Error("store not set")
+	}
+	if disc.bus != bus {
+		t.Error("bus not set")
+	}
+	if disc.interval != 5*time.Minute {
+		t.Errorf("interval = %v, want 5m", disc.interval)
+	}
+	if disc.seen == nil {
+		t.Error("seen map not initialized")
+	}
+}
+
+func TestUPNPDiscoverer_RunStopsOnCancel(t *testing.T) {
+	db, err := store.New(":memory:")
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	ctx := context.Background()
+	if err := db.Migrate(ctx, "recon", migrations()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	s := NewReconStore(db.DB())
+	bus := &mockEventBus{}
+	logger := zap.NewNop()
+
+	// Use a very long interval so we only test cancellation, not ticks.
+	disc := NewUPNPDiscoverer(s, bus, logger, 10*time.Minute)
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		disc.Run(runCtx)
+		close(done)
+	}()
+
+	// Cancel and verify the goroutine exits promptly.
+	cancel()
+
+	select {
+	case <-done:
+		// Run exited cleanly.
+	case <-time.After(10 * time.Second):
+		t.Fatal("UPNPDiscoverer.Run did not stop within 10 seconds after cancellation")
+	}
+}
+
+func TestUPNPDiscoverer_Deduplication(t *testing.T) {
+	db, err := store.New(":memory:")
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	ctx := context.Background()
+	if err := db.Migrate(ctx, "recon", migrations()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	s := NewReconStore(db.DB())
+	bus := &mockEventBus{}
+	logger := zap.NewNop()
+
+	disc := NewUPNPDiscoverer(s, bus, logger, 60*time.Second)
+
+	udn := "uuid:12345678-1234-1234-1234-123456789abc"
+
+	// First time: not recently seen.
+	if disc.recentlySeen(udn) {
+		t.Error("UDN should not be recently seen before marking")
+	}
+
+	// Mark and check.
+	disc.markSeen(udn)
+	if !disc.recentlySeen(udn) {
+		t.Error("UDN should be recently seen after marking")
+	}
+
+	// Second check: still recently seen.
+	if !disc.recentlySeen(udn) {
+		t.Error("UDN should still be recently seen")
+	}
+}
+
+func TestUPNPDiscoverer_CleanSeen(t *testing.T) {
+	db, err := store.New(":memory:")
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	ctx := context.Background()
+	if err := db.Migrate(ctx, "recon", migrations()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	s := NewReconStore(db.DB())
+	logger := zap.NewNop()
+
+	// Very short interval so entries expire quickly.
+	disc := NewUPNPDiscoverer(s, nil, logger, 10*time.Millisecond)
+
+	disc.markSeen("uuid:device-1")
+	disc.markSeen("uuid:device-2")
+
+	// Both should exist.
+	disc.mu.Lock()
+	if len(disc.seen) != 2 {
+		t.Errorf("seen map has %d entries, want 2", len(disc.seen))
+	}
+	disc.mu.Unlock()
+
+	// Wait for entries to expire (2x interval = 20ms).
+	time.Sleep(30 * time.Millisecond)
+
+	disc.cleanSeen()
+
+	disc.mu.Lock()
+	if len(disc.seen) != 0 {
+		t.Errorf("seen map has %d entries after clean, want 0", len(disc.seen))
+	}
+	disc.mu.Unlock()
+}
+
+func TestInferDeviceTypeFromUPnP(t *testing.T) {
+	tests := []struct {
+		deviceType string
+		want       string
+	}{
+		{"urn:schemas-upnp-org:device:MediaRenderer:1", "nas"},
+		{"urn:schemas-upnp-org:device:MediaServer:1", "nas"},
+		{"urn:schemas-upnp-org:device:Printer:1", "printer"},
+		{"urn:schemas-upnp-org:device:InternetGatewayDevice:1", "router"},
+		{"urn:schemas-upnp-org:device:WANDevice:1", "router"},
+		{"urn:schemas-upnp-org:device:WANConnectionDevice:1", "router"},
+		{"urn:schemas-upnp-org:device:WLANAccessPointDevice:1", "access_point"},
+		{"urn:schemas-upnp-org:device:DigitalSecurityCamera:1", "camera"},
+		{"urn:schemas-upnp-org:device:BinaryLight:1", "iot"},
+		{"urn:schemas-upnp-org:device:DimmableLight:1", "iot"},
+		{"urn:schemas-upnp-org:device:HVAC_System:1", "iot"},
+		{"urn:schemas-upnp-org:device:SensorManagement:1", "iot"},
+		{"urn:schemas-upnp-org:device:LightingControls:1", "iot"},
+		{"urn:schemas-upnp-org:device:Basic:1", "unknown"},
+		{"", "unknown"},
+		{"some-custom-device-type", "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.deviceType, func(t *testing.T) {
+			got := string(inferDeviceTypeFromUPnP(tt.deviceType))
+			if got != tt.want {
+				t.Errorf("inferDeviceTypeFromUPnP(%q) = %q, want %q", tt.deviceType, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add UPnP/SSDP passive device discovery to the Recon module using `github.com/huin/goupnp`
- Follow the same pattern as the existing mDNS listener: periodic discovery sweeps, deduplication by UDN, device type inference, and event bus integration
- Map UPnP device type URNs to SubNetree device types (router, printer, NAS, camera, IoT, access point)
- UPnP is HTTP-based and works on all platforms including Windows -- no build-tag stubs needed

## Changes

| File | Change |
|------|--------|
| `internal/recon/upnp.go` | New `UPNPDiscoverer` with `Run` loop, dedup, `cleanSeen`, and `inferDeviceTypeFromUPnP` |
| `internal/recon/upnp_test.go` | Table-driven tests for type inference, deduplication, lifecycle, and constructor |
| `internal/recon/config.go` | Add `UPNPEnabled` (default: true) and `UPNPInterval` (default: 5min) config fields |
| `internal/recon/recon.go` | Wire UPnP discoverer into `Init`, `Start`, and `Health` |
| `go.mod` / `go.sum` | Add `github.com/huin/goupnp v1.3.0` dependency |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/recon/...` -- all tests pass
- [x] `golangci-lint run ./internal/recon/...` -- clean
- [ ] CI passes

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)