### PR TITLE
feat: topology visualization enhancements

### DIFF
--- a/web/src/components/__tests__/topology.test.tsx
+++ b/web/src/components/__tests__/topology.test.tsx
@@ -40,6 +40,7 @@ vi.mock('@xyflow/react', () => ({
   useNodesState: (init: unknown[]) => [init, vi.fn(), vi.fn()],
   useEdgesState: (init: unknown[]) => [init, vi.fn(), vi.fn()],
   getSmoothStepPath: () => ['M0,0 L100,100', 50, 50],
+  getBezierPath: () => ['M0,0 C50,0 50,100 100,100', 50, 50],
 }))
 
 // Mock html-to-image
@@ -591,6 +592,12 @@ describe('TopologyToolbar', () => {
     showMinimap: false,
     onMinimapToggle: vi.fn(),
     flowRef: { current: document.createElement('div') },
+    showUtilization: false,
+    onUtilizationToggle: vi.fn(),
+    savedLayouts: [] as import('@/components/topology/layout-storage').SavedLayout[],
+    onSaveLayout: vi.fn(),
+    onLoadLayout: vi.fn(),
+    onDeleteLayout: vi.fn(),
   }
 
   beforeEach(() => {

--- a/web/src/components/topology/layout-storage.ts
+++ b/web/src/components/topology/layout-storage.ts
@@ -1,0 +1,83 @@
+import type { Node } from '@xyflow/react'
+
+export interface SavedLayout {
+  id: string
+  name: string
+  nodes: Array<{ id: string; position: { x: number; y: number } }>
+  createdAt: string
+}
+
+const STORAGE_KEY = 'subnetree-topology-layouts'
+
+/** Read all saved layouts from localStorage. */
+function readLayouts(): SavedLayout[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return []
+    return JSON.parse(raw) as SavedLayout[]
+  } catch {
+    return []
+  }
+}
+
+/** Write layouts array to localStorage. */
+function writeLayouts(layouts: SavedLayout[]): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(layouts))
+}
+
+/** Save the current node positions as a named layout. */
+export function saveLayout(
+  name: string,
+  nodes: Array<{ id: string; position: { x: number; y: number } }>
+): SavedLayout {
+  const layouts = readLayouts()
+  const layout: SavedLayout = {
+    id: crypto.randomUUID(),
+    name,
+    nodes: nodes.map((n) => ({ id: n.id, position: { ...n.position } })),
+    createdAt: new Date().toISOString(),
+  }
+  layouts.push(layout)
+  writeLayouts(layouts)
+  return layout
+}
+
+/** Load a single saved layout by ID. */
+export function loadLayout(id: string): SavedLayout | null {
+  const layouts = readLayouts()
+  return layouts.find((l) => l.id === id) ?? null
+}
+
+/** List all saved layouts, most recent first. */
+export function listLayouts(): SavedLayout[] {
+  return readLayouts().sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  )
+}
+
+/** Delete a saved layout by ID. */
+export function deleteLayout(id: string): void {
+  const layouts = readLayouts().filter((l) => l.id !== id)
+  writeLayouts(layouts)
+}
+
+/**
+ * Apply a saved layout to the current set of nodes.
+ * Nodes present in the saved layout get their positions updated;
+ * nodes not in the saved layout keep their current positions.
+ */
+export function applyLayout<T extends Node>(
+  currentNodes: T[],
+  saved: SavedLayout
+): T[] {
+  const positionMap = new Map(
+    saved.nodes.map((n) => [n.id, n.position])
+  )
+  return currentNodes.map((node) => {
+    const savedPos = positionMap.get(node.id)
+    if (savedPos) {
+      return { ...node, position: { ...savedPos } }
+    }
+    return node
+  })
+}

--- a/web/src/components/topology/topology-toolbar.tsx
+++ b/web/src/components/topology/topology-toolbar.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, type RefObject } from 'react'
+import { memo, useState, useRef, useEffect, type RefObject } from 'react'
 import { useReactFlow } from '@xyflow/react'
 import { toPng } from 'html-to-image'
 import { toast } from 'sonner'
@@ -11,7 +11,12 @@ import {
   GitBranch,
   LayoutGrid,
   Download,
+  Activity,
+  Save,
+  FolderOpen,
+  Trash2,
 } from 'lucide-react'
+import type { SavedLayout } from './layout-storage'
 
 export type LayoutAlgorithm = 'circular' | 'hierarchical' | 'grid'
 
@@ -21,6 +26,12 @@ interface TopologyToolbarProps {
   showMinimap: boolean
   onMinimapToggle: () => void
   flowRef: RefObject<HTMLDivElement | null>
+  showUtilization: boolean
+  onUtilizationToggle: () => void
+  savedLayouts: SavedLayout[]
+  onSaveLayout: (name: string) => void
+  onLoadLayout: (id: string) => void
+  onDeleteLayout: (id: string) => void
 }
 
 const layoutOptions: { value: LayoutAlgorithm; label: string; Icon: typeof CircleDot }[] = [
@@ -29,15 +40,46 @@ const layoutOptions: { value: LayoutAlgorithm; label: string; Icon: typeof Circl
   { value: 'grid', label: 'Grid', Icon: LayoutGrid },
 ]
 
+/** Toolbar separator element. */
+function Separator() {
+  return (
+    <div
+      className="h-5 w-px mx-1"
+      style={{ backgroundColor: 'var(--nv-border-default)' }}
+    />
+  )
+}
+
 export const TopologyToolbar = memo(function TopologyToolbar({
   layout,
   onLayoutChange,
   showMinimap,
   onMinimapToggle,
   flowRef,
+  showUtilization,
+  onUtilizationToggle,
+  savedLayouts,
+  onSaveLayout,
+  onLoadLayout,
+  onDeleteLayout,
 }: TopologyToolbarProps) {
   const { zoomIn, zoomOut, fitView } = useReactFlow()
   const [exporting, setExporting] = useState(false)
+  const [layoutsOpen, setLayoutsOpen] = useState(false)
+  const [saveName, setSaveName] = useState('')
+  const layoutsRef = useRef<HTMLDivElement>(null)
+
+  // Close layouts dropdown when clicking outside
+  useEffect(() => {
+    if (!layoutsOpen) return
+    function handleClickOutside(e: MouseEvent) {
+      if (layoutsRef.current && !layoutsRef.current.contains(e.target as globalThis.Node)) {
+        setLayoutsOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [layoutsOpen])
 
   const handleExport = async () => {
     const element = flowRef.current
@@ -61,6 +103,19 @@ export const TopologyToolbar = memo(function TopologyToolbar({
     } finally {
       setExporting(false)
     }
+  }
+
+  const handleSave = () => {
+    const name = saveName.trim()
+    if (!name) return
+    onSaveLayout(name)
+    setSaveName('')
+    toast.success(`Layout "${name}" saved`)
+  }
+
+  const handleDelete = (id: string, name: string) => {
+    onDeleteLayout(id)
+    toast.success(`Layout "${name}" deleted`)
   }
 
   return (
@@ -89,11 +144,7 @@ export const TopologyToolbar = memo(function TopologyToolbar({
         </button>
       ))}
 
-      {/* Separator */}
-      <div
-        className="h-5 w-px mx-1"
-        style={{ backgroundColor: 'var(--nv-border-default)' }}
-      />
+      <Separator />
 
       {/* Zoom controls */}
       <button
@@ -121,11 +172,19 @@ export const TopologyToolbar = memo(function TopologyToolbar({
         <Maximize className="h-4 w-4" />
       </button>
 
-      {/* Separator */}
-      <div
-        className="h-5 w-px mx-1"
-        style={{ backgroundColor: 'var(--nv-border-default)' }}
-      />
+      <Separator />
+
+      {/* Utilization toggle */}
+      <button
+        onClick={onUtilizationToggle}
+        title={showUtilization ? 'Hide utilization overlay' : 'Show utilization overlay'}
+        className="rounded-md p-1.5 transition-colors hover:bg-[var(--nv-bg-hover)]"
+        style={{
+          color: showUtilization ? 'var(--nv-text-accent)' : 'var(--nv-text-secondary)',
+        }}
+      >
+        <Activity className="h-4 w-4" />
+      </button>
 
       {/* Minimap toggle */}
       <button
@@ -139,11 +198,102 @@ export const TopologyToolbar = memo(function TopologyToolbar({
         <Map className="h-4 w-4" />
       </button>
 
-      {/* Separator */}
-      <div
-        className="h-5 w-px mx-1"
-        style={{ backgroundColor: 'var(--nv-border-default)' }}
-      />
+      <Separator />
+
+      {/* Saved layouts dropdown */}
+      <div ref={layoutsRef} className="relative">
+        <button
+          onClick={() => setLayoutsOpen((prev) => !prev)}
+          title="Saved layouts"
+          className="rounded-md p-1.5 transition-colors hover:bg-[var(--nv-bg-hover)]"
+          style={{
+            color: layoutsOpen ? 'var(--nv-text-accent)' : 'var(--nv-text-secondary)',
+          }}
+        >
+          <FolderOpen className="h-4 w-4" />
+        </button>
+        {layoutsOpen && (
+          <div
+            className="absolute top-full right-0 mt-2 w-64 rounded-lg p-3 shadow-lg z-50"
+            style={{
+              backgroundColor: 'var(--nv-bg-card)',
+              border: '1px solid var(--nv-border-default)',
+            }}
+          >
+            {/* Save current layout */}
+            <div className="flex gap-1.5 mb-2">
+              <input
+                type="text"
+                value={saveName}
+                onChange={(e) => setSaveName(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && handleSave()}
+                placeholder="Layout name..."
+                className="flex-1 rounded-md px-2 py-1 text-xs"
+                style={{
+                  backgroundColor: 'var(--nv-bg-surface)',
+                  border: '1px solid var(--nv-border-subtle)',
+                  color: 'var(--nv-text-primary)',
+                }}
+              />
+              <button
+                onClick={handleSave}
+                disabled={!saveName.trim()}
+                title="Save layout"
+                className="rounded-md p-1.5 transition-colors hover:bg-[var(--nv-bg-hover)] disabled:opacity-40"
+                style={{ color: 'var(--nv-text-secondary)' }}
+              >
+                <Save className="h-3.5 w-3.5" />
+              </button>
+            </div>
+
+            {/* List of saved layouts */}
+            {savedLayouts.length === 0 ? (
+              <p
+                className="text-[10px] text-center py-2"
+                style={{ color: 'var(--nv-text-secondary)' }}
+              >
+                No saved layouts
+              </p>
+            ) : (
+              <ul className="space-y-1 max-h-48 overflow-y-auto">
+                {savedLayouts.map((sl) => (
+                  <li
+                    key={sl.id}
+                    className="flex items-center gap-1 rounded-md px-2 py-1 text-xs group"
+                    style={{ color: 'var(--nv-text-primary)' }}
+                  >
+                    <button
+                      onClick={() => {
+                        onLoadLayout(sl.id)
+                        setLayoutsOpen(false)
+                        toast.success(`Layout "${sl.name}" applied`)
+                      }}
+                      className="flex-1 text-left truncate hover:underline"
+                      title={`Load "${sl.name}"`}
+                    >
+                      {sl.name}
+                    </button>
+                    <span
+                      className="text-[10px] flex-shrink-0"
+                      style={{ color: 'var(--nv-text-secondary)' }}
+                    >
+                      {new Date(sl.createdAt).toLocaleDateString()}
+                    </span>
+                    <button
+                      onClick={() => handleDelete(sl.id, sl.name)}
+                      title={`Delete "${sl.name}"`}
+                      className="opacity-0 group-hover:opacity-100 rounded p-0.5 transition-opacity hover:bg-[var(--nv-bg-hover)]"
+                      style={{ color: 'var(--nv-text-secondary)' }}
+                    >
+                      <Trash2 className="h-3 w-3" />
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+      </div>
 
       {/* Export PNG */}
       <button

--- a/web/src/components/topology/utilization-edge.tsx
+++ b/web/src/components/topology/utilization-edge.tsx
@@ -1,0 +1,110 @@
+import { memo, useState } from 'react'
+import {
+  BaseEdge,
+  EdgeLabelRenderer,
+  getBezierPath,
+  type EdgeProps,
+  type Edge,
+} from '@xyflow/react'
+
+export interface UtilizationEdgeData {
+  utilization?: number // 0-100
+  speed?: number
+  linkType?: string
+  [key: string]: unknown
+}
+
+export type UtilizationEdgeType = Edge<UtilizationEdgeData, 'utilization'>
+
+/** Map utilization percentage to a color: green (<50%), yellow (50-80%), red (>80%). */
+function getUtilizationColor(utilization: number | undefined): string {
+  if (utilization === undefined) return 'var(--nv-topo-link-default)'
+  if (utilization < 50) return '#22c55e' // green-500
+  if (utilization <= 80) return '#eab308' // yellow-500
+  return '#ef4444' // red-500
+}
+
+/** Scale stroke width from 1px (0%) to 4px (100%). */
+function getStrokeWidth(utilization: number | undefined): number {
+  if (utilization === undefined) return 1.5
+  return 1 + (utilization / 100) * 3
+}
+
+export const UtilizationEdge = memo(function UtilizationEdge(
+  props: EdgeProps<UtilizationEdgeType>
+) {
+  const {
+    id,
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    sourcePosition,
+    targetPosition,
+    data,
+    selected,
+  } = props
+
+  const [hovered, setHovered] = useState(false)
+
+  const [edgePath, labelX, labelY] = getBezierPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+  })
+
+  const utilization = data?.utilization
+  const color = getUtilizationColor(utilization)
+  const strokeWidth = getStrokeWidth(utilization)
+
+  return (
+    <>
+      {/* Invisible wider path for easier hover interaction */}
+      <path
+        d={edgePath}
+        fill="none"
+        stroke="transparent"
+        strokeWidth={20}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+      />
+      <BaseEdge
+        id={id}
+        path={edgePath}
+        style={{
+          stroke: selected || hovered ? 'var(--nv-topo-link-active)' : color,
+          strokeWidth: selected || hovered ? strokeWidth + 1 : strokeWidth,
+          transition: 'stroke 0.2s, stroke-width 0.2s',
+        }}
+      />
+      {/* Utilization tooltip on hover */}
+      {hovered && (
+        <EdgeLabelRenderer>
+          <div
+            className="nodrag nopan pointer-events-none rounded px-2 py-1 text-[10px] font-mono"
+            style={{
+              position: 'absolute',
+              transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
+              backgroundColor: 'var(--nv-bg-elevated)',
+              color: 'var(--nv-text-secondary)',
+              border: '1px solid var(--nv-border-default)',
+            }}
+          >
+            {utilization !== undefined ? (
+              <span>
+                <span style={{ color, fontWeight: 600 }}>{utilization}%</span>
+                {' utilization'}
+                {data?.linkType && ` \u00b7 ${data.linkType}`}
+              </span>
+            ) : (
+              <span>{data?.linkType || 'No data'}</span>
+            )}
+          </div>
+        </EdgeLabelRenderer>
+      )}
+    </>
+  )
+})


### PR DESCRIPTION
## Summary

- Add **link utilization overlay** with color-coded edges (green <50%, yellow 50-80%, red >80%) and dynamic stroke width scaling
- Add **saved layout persistence** via localStorage for saving, loading, and deleting custom node position layouts
- Extend topology toolbar with utilization toggle button, saved layouts dropdown panel with save/load/delete controls
- Update test file with new toolbar props and `getBezierPath` mock

## New Files

- `web/src/components/topology/utilization-edge.tsx` -- Custom React Flow edge component with hover tooltips showing utilization percentage and link type
- `web/src/components/topology/layout-storage.ts` -- localStorage CRUD module for saved topology layouts with `applyLayout` helper

## Modified Files

- `web/src/components/topology/topology-toolbar.tsx` -- Added utilization toggle, saved layouts dropdown, Separator component, 6 new props
- `web/src/pages/topology.tsx` -- Integrated utilization edge types, layout storage handlers, dynamic edge type switching
- `web/src/components/__tests__/topology.test.tsx` -- Updated defaultProps and added `getBezierPath` mock

## Test plan

- [x] TypeScript build passes (`pnpm run build`)
- [x] ESLint passes with zero warnings (`pnpm run lint`)
- [ ] Frontend tests pass (`pnpm test`)
- [ ] Visual verification of utilization overlay toggle
- [ ] Visual verification of saved layouts save/load/delete

Closes #283

Generated with [Claude Code](https://claude.com/claude-code)