### PR TITLE
feat: maintenance windows for scheduled alert suppression

### DIFF
--- a/internal/pulse/maint_window.go
+++ b/internal/pulse/maint_window.go
@@ -1,0 +1,226 @@
+package pulse
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// MaintWindow represents a scheduled maintenance window during which
+// monitoring alerts for specified devices are suppressed.
+type MaintWindow struct {
+	ID          string    `json:"id"`
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+	StartTime   time.Time `json:"start_time"`
+	EndTime     time.Time `json:"end_time"`
+	Recurrence  string    `json:"recurrence"` // "once", "daily", "weekly", "monthly"
+	DeviceIDs   []string  `json:"device_ids"`
+	Enabled     bool      `json:"enabled"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+var validRecurrence = map[string]bool{
+	"once":    true,
+	"daily":   true,
+	"weekly":  true,
+	"monthly": true,
+}
+
+// -- Maintenance Window CRUD --
+
+// InsertMaintWindow inserts a new maintenance window.
+func (s *PulseStore) InsertMaintWindow(ctx context.Context, mw *MaintWindow) error {
+	enabled := 0
+	if mw.Enabled {
+		enabled = 1
+	}
+	deviceJSON, err := json.Marshal(mw.DeviceIDs)
+	if err != nil {
+		return fmt.Errorf("marshal device_ids: %w", err)
+	}
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO pulse_maint_windows (
+			id, name, description, start_time, end_time, recurrence,
+			device_ids, enabled, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		mw.ID, mw.Name, mw.Description, mw.StartTime, mw.EndTime,
+		mw.Recurrence, string(deviceJSON), enabled, mw.CreatedAt, mw.UpdatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("insert maint window: %w", err)
+	}
+	return nil
+}
+
+// GetMaintWindow returns a maintenance window by ID. Returns nil, nil if not found.
+func (s *PulseStore) GetMaintWindow(ctx context.Context, id string) (*MaintWindow, error) {
+	var mw MaintWindow
+	var enabledInt int
+	var deviceJSON string
+	err := s.db.QueryRowContext(ctx, `
+		SELECT id, name, description, start_time, end_time, recurrence,
+			device_ids, enabled, created_at, updated_at
+		FROM pulse_maint_windows WHERE id = ?`,
+		id,
+	).Scan(
+		&mw.ID, &mw.Name, &mw.Description, &mw.StartTime, &mw.EndTime,
+		&mw.Recurrence, &deviceJSON, &enabledInt, &mw.CreatedAt, &mw.UpdatedAt,
+	)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get maint window: %w", err)
+	}
+	mw.Enabled = enabledInt != 0
+	if err := json.Unmarshal([]byte(deviceJSON), &mw.DeviceIDs); err != nil {
+		return nil, fmt.Errorf("unmarshal device_ids: %w", err)
+	}
+	return &mw, nil
+}
+
+// ListMaintWindows returns all maintenance windows.
+func (s *PulseStore) ListMaintWindows(ctx context.Context) ([]MaintWindow, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, name, description, start_time, end_time, recurrence,
+			device_ids, enabled, created_at, updated_at
+		FROM pulse_maint_windows ORDER BY start_time DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("list maint windows: %w", err)
+	}
+	defer rows.Close()
+
+	var windows []MaintWindow
+	for rows.Next() {
+		var mw MaintWindow
+		var enabledInt int
+		var deviceJSON string
+		if err := rows.Scan(
+			&mw.ID, &mw.Name, &mw.Description, &mw.StartTime, &mw.EndTime,
+			&mw.Recurrence, &deviceJSON, &enabledInt, &mw.CreatedAt, &mw.UpdatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan maint window: %w", err)
+		}
+		mw.Enabled = enabledInt != 0
+		if err := json.Unmarshal([]byte(deviceJSON), &mw.DeviceIDs); err != nil {
+			return nil, fmt.Errorf("unmarshal device_ids: %w", err)
+		}
+		windows = append(windows, mw)
+	}
+	return windows, rows.Err()
+}
+
+// UpdateMaintWindow updates an existing maintenance window.
+func (s *PulseStore) UpdateMaintWindow(ctx context.Context, mw *MaintWindow) error {
+	enabled := 0
+	if mw.Enabled {
+		enabled = 1
+	}
+	deviceJSON, err := json.Marshal(mw.DeviceIDs)
+	if err != nil {
+		return fmt.Errorf("marshal device_ids: %w", err)
+	}
+	_, err = s.db.ExecContext(ctx, `
+		UPDATE pulse_maint_windows SET
+			name = ?, description = ?, start_time = ?, end_time = ?,
+			recurrence = ?, device_ids = ?, enabled = ?, updated_at = ?
+		WHERE id = ?`,
+		mw.Name, mw.Description, mw.StartTime, mw.EndTime,
+		mw.Recurrence, string(deviceJSON), enabled, mw.UpdatedAt, mw.ID,
+	)
+	if err != nil {
+		return fmt.Errorf("update maint window: %w", err)
+	}
+	return nil
+}
+
+// DeleteMaintWindow removes a maintenance window by ID.
+func (s *PulseStore) DeleteMaintWindow(ctx context.Context, id string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM pulse_maint_windows WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("delete maint window: %w", err)
+	}
+	return nil
+}
+
+// IsDeviceInMaintenanceWindow checks whether the given device is currently
+// inside any enabled maintenance window, accounting for recurrence.
+func (s *PulseStore) IsDeviceInMaintenanceWindow(ctx context.Context, deviceID string) (bool, error) {
+	windows, err := s.ListMaintWindows(ctx)
+	if err != nil {
+		return false, err
+	}
+	now := time.Now().UTC()
+	for i := range windows {
+		if !windows[i].Enabled {
+			continue
+		}
+		// Check if device is in this window's device list.
+		found := false
+		for _, did := range windows[i].DeviceIDs {
+			if did == deviceID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			continue
+		}
+		if isTimeInWindow(now, windows[i].StartTime, windows[i].EndTime, windows[i].Recurrence) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// isTimeInWindow returns true if t falls within the maintenance window
+// defined by start/end with the given recurrence type.
+func isTimeInWindow(t, start, end time.Time, recurrence string) bool {
+	switch recurrence {
+	case "once":
+		return !t.Before(start) && !t.After(end)
+
+	case "daily":
+		return isTimeOfDayInRange(t, start, end)
+
+	case "weekly":
+		if t.Weekday() != start.Weekday() {
+			return false
+		}
+		return isTimeOfDayInRange(t, start, end)
+
+	case "monthly":
+		if t.Day() != start.Day() {
+			return false
+		}
+		return isTimeOfDayInRange(t, start, end)
+
+	default:
+		return false
+	}
+}
+
+// isTimeOfDayInRange checks whether the time-of-day of t falls within
+// the time-of-day range defined by start and end. Supports midnight
+// crossing (e.g., 22:00-02:00).
+func isTimeOfDayInRange(t, start, end time.Time) bool {
+	tSec := timeOfDaySeconds(t)
+	startSec := timeOfDaySeconds(start)
+	endSec := timeOfDaySeconds(end)
+
+	if startSec <= endSec {
+		// Normal range (e.g., 02:00-06:00).
+		return tSec >= startSec && tSec <= endSec
+	}
+	// Midnight-crossing range (e.g., 22:00-02:00).
+	return tSec >= startSec || tSec <= endSec
+}
+
+// timeOfDaySeconds returns the number of seconds elapsed since midnight.
+func timeOfDaySeconds(t time.Time) int {
+	return t.Hour()*3600 + t.Minute()*60 + t.Second()
+}

--- a/internal/pulse/maint_window_test.go
+++ b/internal/pulse/maint_window_test.go
@@ -1,0 +1,363 @@
+package pulse
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// isTimeInWindow – table-driven
+// ---------------------------------------------------------------------------
+
+func TestIsTimeInWindow(t *testing.T) {
+	base := time.Date(2025, 6, 15, 0, 0, 0, 0, time.UTC) // Sunday
+
+	tests := []struct {
+		name       string
+		now        time.Time
+		start      time.Time
+		end        time.Time
+		recurrence string
+		want       bool
+	}{
+		{
+			name:       "once: within range",
+			now:        base.Add(3 * time.Hour),
+			start:      base.Add(2 * time.Hour),
+			end:        base.Add(4 * time.Hour),
+			recurrence: "once",
+			want:       true,
+		},
+		{
+			name:       "once: before range",
+			now:        base.Add(1 * time.Hour),
+			start:      base.Add(2 * time.Hour),
+			end:        base.Add(4 * time.Hour),
+			recurrence: "once",
+			want:       false,
+		},
+		{
+			name:       "once: after range",
+			now:        base.Add(5 * time.Hour),
+			start:      base.Add(2 * time.Hour),
+			end:        base.Add(4 * time.Hour),
+			recurrence: "once",
+			want:       false,
+		},
+		{
+			name:       "daily: within time of day",
+			now:        time.Date(2025, 7, 10, 3, 0, 0, 0, time.UTC),
+			start:      base.Add(2 * time.Hour), // 02:00
+			end:        base.Add(4 * time.Hour), // 04:00
+			recurrence: "daily",
+			want:       true,
+		},
+		{
+			name:       "daily: outside time of day",
+			now:        time.Date(2025, 7, 10, 5, 0, 0, 0, time.UTC),
+			start:      base.Add(2 * time.Hour), // 02:00
+			end:        base.Add(4 * time.Hour), // 04:00
+			recurrence: "daily",
+			want:       false,
+		},
+		{
+			name:       "daily: midnight crossing within",
+			now:        time.Date(2025, 7, 10, 23, 30, 0, 0, time.UTC),
+			start:      base.Add(22 * time.Hour), // 22:00
+			end:        base.Add(2 * time.Hour),   // 02:00 next day
+			recurrence: "daily",
+			want:       true,
+		},
+		{
+			name:       "daily: midnight crossing within (after midnight)",
+			now:        time.Date(2025, 7, 11, 1, 30, 0, 0, time.UTC),
+			start:      base.Add(22 * time.Hour), // 22:00
+			end:        base.Add(2 * time.Hour),   // 02:00
+			recurrence: "daily",
+			want:       true,
+		},
+		{
+			name:       "weekly: correct weekday within time",
+			now:        time.Date(2025, 6, 22, 3, 0, 0, 0, time.UTC), // Sunday
+			start:      base.Add(2 * time.Hour),                       // Sunday 02:00
+			end:        base.Add(4 * time.Hour),                       // Sunday 04:00
+			recurrence: "weekly",
+			want:       true,
+		},
+		{
+			name:       "weekly: wrong weekday",
+			now:        time.Date(2025, 6, 23, 3, 0, 0, 0, time.UTC), // Monday
+			start:      base.Add(2 * time.Hour),                       // Sunday 02:00
+			end:        base.Add(4 * time.Hour),                       // Sunday 04:00
+			recurrence: "weekly",
+			want:       false,
+		},
+		{
+			name:       "monthly: correct day within time",
+			now:        time.Date(2025, 7, 15, 3, 0, 0, 0, time.UTC), // 15th
+			start:      base.Add(2 * time.Hour),                       // 15th 02:00
+			end:        base.Add(4 * time.Hour),                       // 15th 04:00
+			recurrence: "monthly",
+			want:       true,
+		},
+		{
+			name:       "monthly: wrong day",
+			now:        time.Date(2025, 7, 16, 3, 0, 0, 0, time.UTC), // 16th
+			start:      base.Add(2 * time.Hour),                       // 15th 02:00
+			end:        base.Add(4 * time.Hour),                       // 15th 04:00
+			recurrence: "monthly",
+			want:       false,
+		},
+		{
+			name:       "unknown recurrence",
+			now:        base.Add(3 * time.Hour),
+			start:      base.Add(2 * time.Hour),
+			end:        base.Add(4 * time.Hour),
+			recurrence: "yearly",
+			want:       false,
+		},
+		{
+			name:       "once: exact start boundary",
+			now:        base.Add(2 * time.Hour),
+			start:      base.Add(2 * time.Hour),
+			end:        base.Add(4 * time.Hour),
+			recurrence: "once",
+			want:       true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isTimeInWindow(tt.now, tt.start, tt.end, tt.recurrence)
+			if got != tt.want {
+				t.Errorf("isTimeInWindow() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Store CRUD
+// ---------------------------------------------------------------------------
+
+func TestMaintWindow_CRUD(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	mw := &MaintWindow{
+		ID:          "mw-1",
+		Name:        "Weekly Patch Window",
+		Description: "Server patching",
+		StartTime:   time.Date(2025, 6, 15, 2, 0, 0, 0, time.UTC),
+		EndTime:     time.Date(2025, 6, 15, 4, 0, 0, 0, time.UTC),
+		Recurrence:  "weekly",
+		DeviceIDs:   []string{"dev-a", "dev-b"},
+		Enabled:     true,
+		CreatedAt:   time.Now().UTC(),
+		UpdatedAt:   time.Now().UTC(),
+	}
+
+	// Insert.
+	if err := s.InsertMaintWindow(ctx, mw); err != nil {
+		t.Fatalf("InsertMaintWindow: %v", err)
+	}
+
+	// Get.
+	got, err := s.GetMaintWindow(ctx, "mw-1")
+	if err != nil {
+		t.Fatalf("GetMaintWindow: %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetMaintWindow returned nil")
+	}
+	if got.Name != "Weekly Patch Window" {
+		t.Errorf("Name = %q, want %q", got.Name, "Weekly Patch Window")
+	}
+	if len(got.DeviceIDs) != 2 {
+		t.Errorf("DeviceIDs len = %d, want 2", len(got.DeviceIDs))
+	}
+	if !got.Enabled {
+		t.Error("Enabled = false, want true")
+	}
+
+	// List.
+	all, err := s.ListMaintWindows(ctx)
+	if err != nil {
+		t.Fatalf("ListMaintWindows: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("ListMaintWindows len = %d, want 1", len(all))
+	}
+
+	// Update.
+	mw.Name = "Updated Window"
+	mw.Enabled = false
+	mw.UpdatedAt = time.Now().UTC()
+	if err := s.UpdateMaintWindow(ctx, mw); err != nil {
+		t.Fatalf("UpdateMaintWindow: %v", err)
+	}
+	got, err = s.GetMaintWindow(ctx, "mw-1")
+	if err != nil {
+		t.Fatalf("GetMaintWindow after update: %v", err)
+	}
+	if got.Name != "Updated Window" {
+		t.Errorf("Name after update = %q, want %q", got.Name, "Updated Window")
+	}
+	if got.Enabled {
+		t.Error("Enabled after update = true, want false")
+	}
+
+	// Delete.
+	if err := s.DeleteMaintWindow(ctx, "mw-1"); err != nil {
+		t.Fatalf("DeleteMaintWindow: %v", err)
+	}
+	got, err = s.GetMaintWindow(ctx, "mw-1")
+	if err != nil {
+		t.Fatalf("GetMaintWindow after delete: %v", err)
+	}
+	if got != nil {
+		t.Error("expected nil after delete")
+	}
+}
+
+func TestGetMaintWindow_NotFound(t *testing.T) {
+	s := testStore(t)
+	got, err := s.GetMaintWindow(context.Background(), "nonexistent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Error("expected nil for non-existent window")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// IsDeviceInMaintenanceWindow
+// ---------------------------------------------------------------------------
+
+func TestIsDeviceInMaintenanceWindow_Active(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	mw := &MaintWindow{
+		ID:         "mw-active",
+		Name:       "Active Window",
+		StartTime:  now.Add(-1 * time.Hour),
+		EndTime:    now.Add(1 * time.Hour),
+		Recurrence: "once",
+		DeviceIDs:  []string{"dev-1", "dev-2"},
+		Enabled:    true,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	if err := s.InsertMaintWindow(ctx, mw); err != nil {
+		t.Fatalf("InsertMaintWindow: %v", err)
+	}
+
+	inMaint, err := s.IsDeviceInMaintenanceWindow(ctx, "dev-1")
+	if err != nil {
+		t.Fatalf("IsDeviceInMaintenanceWindow: %v", err)
+	}
+	if !inMaint {
+		t.Error("expected device to be in maintenance window")
+	}
+}
+
+func TestIsDeviceInMaintenanceWindow_Disabled(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	mw := &MaintWindow{
+		ID:         "mw-disabled",
+		Name:       "Disabled Window",
+		StartTime:  now.Add(-1 * time.Hour),
+		EndTime:    now.Add(1 * time.Hour),
+		Recurrence: "once",
+		DeviceIDs:  []string{"dev-1"},
+		Enabled:    false,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	if err := s.InsertMaintWindow(ctx, mw); err != nil {
+		t.Fatalf("InsertMaintWindow: %v", err)
+	}
+
+	inMaint, err := s.IsDeviceInMaintenanceWindow(ctx, "dev-1")
+	if err != nil {
+		t.Fatalf("IsDeviceInMaintenanceWindow: %v", err)
+	}
+	if inMaint {
+		t.Error("expected device NOT to be in maintenance window (disabled)")
+	}
+}
+
+func TestIsDeviceInMaintenanceWindow_Expired(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	mw := &MaintWindow{
+		ID:         "mw-expired",
+		Name:       "Expired Window",
+		StartTime:  now.Add(-3 * time.Hour),
+		EndTime:    now.Add(-1 * time.Hour),
+		Recurrence: "once",
+		DeviceIDs:  []string{"dev-1"},
+		Enabled:    true,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	if err := s.InsertMaintWindow(ctx, mw); err != nil {
+		t.Fatalf("InsertMaintWindow: %v", err)
+	}
+
+	inMaint, err := s.IsDeviceInMaintenanceWindow(ctx, "dev-1")
+	if err != nil {
+		t.Fatalf("IsDeviceInMaintenanceWindow: %v", err)
+	}
+	if inMaint {
+		t.Error("expected device NOT to be in maintenance window (expired)")
+	}
+}
+
+func TestIsDeviceInMaintenanceWindow_NoWindows(t *testing.T) {
+	s := testStore(t)
+	inMaint, err := s.IsDeviceInMaintenanceWindow(context.Background(), "dev-1")
+	if err != nil {
+		t.Fatalf("IsDeviceInMaintenanceWindow: %v", err)
+	}
+	if inMaint {
+		t.Error("expected device NOT to be in maintenance window (no windows)")
+	}
+}
+
+func TestIsDeviceInMaintenanceWindow_DeviceNotInList(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	mw := &MaintWindow{
+		ID:         "mw-other",
+		Name:       "Other Devices",
+		StartTime:  now.Add(-1 * time.Hour),
+		EndTime:    now.Add(1 * time.Hour),
+		Recurrence: "once",
+		DeviceIDs:  []string{"dev-a", "dev-b"},
+		Enabled:    true,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	if err := s.InsertMaintWindow(ctx, mw); err != nil {
+		t.Fatalf("InsertMaintWindow: %v", err)
+	}
+
+	inMaint, err := s.IsDeviceInMaintenanceWindow(ctx, "dev-1")
+	if err != nil {
+		t.Fatalf("IsDeviceInMaintenanceWindow: %v", err)
+	}
+	if inMaint {
+		t.Error("expected device NOT to be in maintenance window (not in list)")
+	}
+}

--- a/internal/pulse/migrations.go
+++ b/internal/pulse/migrations.go
@@ -105,5 +105,24 @@ func migrations() []plugin.Migration {
 				return nil
 			},
 		},
+		{
+			Version:     5,
+			Description: "create maintenance windows table",
+			Up: func(tx *sql.Tx) error {
+				_, err := tx.Exec(`CREATE TABLE IF NOT EXISTS pulse_maint_windows (
+					id TEXT PRIMARY KEY,
+					name TEXT NOT NULL,
+					description TEXT NOT NULL DEFAULT '',
+					start_time DATETIME NOT NULL,
+					end_time DATETIME NOT NULL,
+					recurrence TEXT NOT NULL DEFAULT 'once',
+					device_ids TEXT NOT NULL DEFAULT '[]',
+					enabled INTEGER NOT NULL DEFAULT 1,
+					created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+					updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+				)`)
+				return err
+			},
+		},
 	}
 }

--- a/web/src/api/pulse-maintenance.ts
+++ b/web/src/api/pulse-maintenance.ts
@@ -1,0 +1,54 @@
+import { api } from './client'
+
+// MaintWindow represents a scheduled maintenance window.
+export interface MaintWindow {
+  id: string
+  name: string
+  description: string
+  start_time: string
+  end_time: string
+  recurrence: 'once' | 'daily' | 'weekly' | 'monthly'
+  device_ids: string[]
+  enabled: boolean
+  created_at: string
+  updated_at: string
+}
+
+export interface CreateMaintWindowRequest {
+  name: string
+  description: string
+  start_time: string
+  end_time: string
+  recurrence: string
+  device_ids: string[]
+}
+
+export interface UpdateMaintWindowRequest {
+  name?: string
+  description?: string
+  start_time?: string
+  end_time?: string
+  recurrence?: string
+  device_ids?: string[]
+  enabled?: boolean
+}
+
+export async function listMaintWindows(): Promise<MaintWindow[]> {
+  return api.get<MaintWindow[]>('/pulse/maintenance-windows')
+}
+
+export async function createMaintWindow(req: CreateMaintWindowRequest): Promise<MaintWindow> {
+  return api.post<MaintWindow>('/pulse/maintenance-windows', req)
+}
+
+export async function getMaintWindow(id: string): Promise<MaintWindow> {
+  return api.get<MaintWindow>(`/pulse/maintenance-windows/${id}`)
+}
+
+export async function updateMaintWindow(id: string, req: UpdateMaintWindowRequest): Promise<MaintWindow> {
+  return api.put<MaintWindow>(`/pulse/maintenance-windows/${id}`, req)
+}
+
+export async function deleteMaintWindow(id: string): Promise<void> {
+  return api.delete(`/pulse/maintenance-windows/${id}`)
+}

--- a/web/src/components/pulse/maintenance-windows.tsx
+++ b/web/src/components/pulse/maintenance-windows.tsx
@@ -1,0 +1,330 @@
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  Plus,
+  Pencil,
+  Trash2,
+  X,
+  Calendar,
+  Clock,
+  Power,
+} from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
+import {
+  listMaintWindows,
+  createMaintWindow,
+  updateMaintWindow,
+  deleteMaintWindow,
+} from '@/api/pulse-maintenance'
+import type { MaintWindow, CreateMaintWindowRequest, UpdateMaintWindowRequest } from '@/api/pulse-maintenance'
+
+// ---------------------------------------------------------------------------
+// Status badges
+// ---------------------------------------------------------------------------
+
+function StatusBadge({ window }: { window: MaintWindow }) {
+  const now = new Date()
+  const start = new Date(window.start_time)
+  const end = new Date(window.end_time)
+
+  if (!window.enabled) {
+    return <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">Disabled</span>
+  }
+  if (window.recurrence !== 'once') {
+    return <span className="inline-flex items-center rounded-full bg-blue-100 dark:bg-blue-900/30 px-2 py-0.5 text-xs text-blue-700 dark:text-blue-300">Recurring</span>
+  }
+  if (now >= start && now <= end) {
+    return <span className="inline-flex items-center rounded-full bg-green-100 dark:bg-green-900/30 px-2 py-0.5 text-xs text-green-700 dark:text-green-300">Active</span>
+  }
+  if (now < start) {
+    return <span className="inline-flex items-center rounded-full bg-yellow-100 dark:bg-yellow-900/30 px-2 py-0.5 text-xs text-yellow-700 dark:text-yellow-300">Upcoming</span>
+  }
+  return <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">Expired</span>
+}
+
+function RecurrenceBadge({ recurrence }: { recurrence: string }) {
+  const labels: Record<string, string> = {
+    once: 'Once',
+    daily: 'Daily',
+    weekly: 'Weekly',
+    monthly: 'Monthly',
+  }
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+      <Clock className="h-3 w-3" />
+      {labels[recurrence] ?? recurrence}
+    </span>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Form
+// ---------------------------------------------------------------------------
+
+interface MaintWindowFormProps {
+  initial?: MaintWindow
+  onSubmit: (data: CreateMaintWindowRequest | UpdateMaintWindowRequest) => void
+  onCancel: () => void
+  isLoading: boolean
+}
+
+function MaintWindowForm({ initial, onSubmit, onCancel, isLoading }: MaintWindowFormProps) {
+  const [name, setName] = useState(initial?.name ?? '')
+  const [description, setDescription] = useState(initial?.description ?? '')
+  const [startTime, setStartTime] = useState(initial?.start_time ? initial.start_time.slice(0, 16) : '')
+  const [endTime, setEndTime] = useState(initial?.end_time ? initial.end_time.slice(0, 16) : '')
+  const [recurrence, setRecurrence] = useState<string>(initial?.recurrence ?? 'once')
+  const [deviceIds, setDeviceIds] = useState(initial?.device_ids?.join(', ') ?? '')
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    const ids = deviceIds.split(',').map((s) => s.trim()).filter(Boolean)
+    const data: CreateMaintWindowRequest = {
+      name,
+      description,
+      start_time: new Date(startTime).toISOString(),
+      end_time: new Date(endTime).toISOString(),
+      recurrence,
+      device_ids: ids,
+    }
+    onSubmit(data)
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm font-medium mb-1">Name</label>
+          <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Weekly patch window" required />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Recurrence</label>
+          <select
+            value={recurrence}
+            onChange={(e) => setRecurrence(e.target.value)}
+            className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          >
+            <option value="once">Once</option>
+            <option value="daily">Daily</option>
+            <option value="weekly">Weekly</option>
+            <option value="monthly">Monthly</option>
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Start Time</label>
+          <Input type="datetime-local" value={startTime} onChange={(e) => setStartTime(e.target.value)} required />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">End Time</label>
+          <Input type="datetime-local" value={endTime} onChange={(e) => setEndTime(e.target.value)} required />
+        </div>
+      </div>
+      <div>
+        <label className="block text-sm font-medium mb-1">Description</label>
+        <Input value={description} onChange={(e) => setDescription(e.target.value)} placeholder="Optional description" />
+      </div>
+      <div>
+        <label className="block text-sm font-medium mb-1">Device IDs (comma-separated)</label>
+        <Input value={deviceIds} onChange={(e) => setDeviceIds(e.target.value)} placeholder="dev-1, dev-2, dev-3" required />
+      </div>
+      <div className="flex gap-2 justify-end">
+        <Button type="button" variant="ghost" onClick={onCancel} disabled={isLoading}>
+          Cancel
+        </Button>
+        <Button type="submit" disabled={isLoading}>
+          {initial ? 'Update' : 'Create'}
+        </Button>
+      </div>
+    </form>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Main panel
+// ---------------------------------------------------------------------------
+
+export function MaintenanceWindowsPanel() {
+  const queryClient = useQueryClient()
+  const [showForm, setShowForm] = useState(false)
+  const [editing, setEditing] = useState<MaintWindow | null>(null)
+
+  const { data: windows = [], isLoading } = useQuery({
+    queryKey: ['pulse', 'maintenance-windows'],
+    queryFn: listMaintWindows,
+  })
+
+  const createMut = useMutation({
+    mutationFn: (req: CreateMaintWindowRequest) => createMaintWindow(req),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['pulse', 'maintenance-windows'] })
+      setShowForm(false)
+      toast.success('Maintenance window created')
+    },
+    onError: () => toast.error('Failed to create maintenance window'),
+  })
+
+  const updateMut = useMutation({
+    mutationFn: ({ id, req }: { id: string; req: UpdateMaintWindowRequest }) => updateMaintWindow(id, req),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['pulse', 'maintenance-windows'] })
+      setEditing(null)
+      toast.success('Maintenance window updated')
+    },
+    onError: () => toast.error('Failed to update maintenance window'),
+  })
+
+  const deleteMut = useMutation({
+    mutationFn: (id: string) => deleteMaintWindow(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['pulse', 'maintenance-windows'] })
+      toast.success('Maintenance window deleted')
+    },
+    onError: () => toast.error('Failed to delete maintenance window'),
+  })
+
+  const toggleMut = useMutation({
+    mutationFn: ({ id, enabled }: { id: string; enabled: boolean }) =>
+      updateMaintWindow(id, { enabled }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['pulse', 'maintenance-windows'] })
+    },
+    onError: () => toast.error('Failed to toggle maintenance window'),
+  })
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardContent className="p-6">
+          <div className="animate-pulse space-y-3">
+            <div className="h-4 bg-muted rounded w-1/3" />
+            <div className="h-4 bg-muted rounded w-1/2" />
+            <div className="h-4 bg-muted rounded w-2/5" />
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-medium">Maintenance Windows</h3>
+        {!showForm && !editing && (
+          <Button size="sm" onClick={() => setShowForm(true)}>
+            <Plus className="h-4 w-4 mr-1" />
+            Add Window
+          </Button>
+        )}
+      </div>
+
+      {showForm && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">New Maintenance Window</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <MaintWindowForm
+              onSubmit={(data) => createMut.mutate(data as CreateMaintWindowRequest)}
+              onCancel={() => setShowForm(false)}
+              isLoading={createMut.isPending}
+            />
+          </CardContent>
+        </Card>
+      )}
+
+      {editing && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base flex items-center justify-between">
+              Edit Maintenance Window
+              <Button size="icon" variant="ghost" onClick={() => setEditing(null)}>
+                <X className="h-4 w-4" />
+              </Button>
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <MaintWindowForm
+              initial={editing}
+              onSubmit={(data) => updateMut.mutate({ id: editing.id, req: data as UpdateMaintWindowRequest })}
+              onCancel={() => setEditing(null)}
+              isLoading={updateMut.isPending}
+            />
+          </CardContent>
+        </Card>
+      )}
+
+      {windows.length === 0 && !showForm ? (
+        <Card>
+          <CardContent className="p-6 text-center text-muted-foreground">
+            <Calendar className="h-8 w-8 mx-auto mb-2 opacity-50" />
+            <p>No maintenance windows configured.</p>
+            <p className="text-xs mt-1">
+              Create maintenance windows to suppress alerts during scheduled downtime.
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-2">
+          {windows.map((mw) => (
+            <Card key={mw.id} className={cn(!mw.enabled && 'opacity-60')}>
+              <CardContent className="p-4">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="font-medium">{mw.name}</span>
+                      <StatusBadge window={mw} />
+                      <RecurrenceBadge recurrence={mw.recurrence} />
+                    </div>
+                    {mw.description && (
+                      <p className="text-sm text-muted-foreground mt-1">{mw.description}</p>
+                    )}
+                    <div className="text-xs text-muted-foreground mt-2 flex flex-wrap gap-x-4 gap-y-1">
+                      <span>
+                        Start: {new Date(mw.start_time).toLocaleString()}
+                      </span>
+                      <span>
+                        End: {new Date(mw.end_time).toLocaleString()}
+                      </span>
+                      <span>
+                        Devices: {mw.device_ids.length}
+                      </span>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-1 shrink-0">
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      title={mw.enabled ? 'Disable' : 'Enable'}
+                      onClick={() => toggleMut.mutate({ id: mw.id, enabled: !mw.enabled })}
+                    >
+                      <Power className={cn('h-4 w-4', mw.enabled ? 'text-green-600' : 'text-muted-foreground')} />
+                    </Button>
+                    <Button size="icon" variant="ghost" onClick={() => { setEditing(mw); setShowForm(false) }}>
+                      <Pencil className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      className="text-destructive hover:text-destructive"
+                      onClick={() => {
+                        if (confirm(`Delete maintenance window "${mw.name}"?`)) {
+                          deleteMut.mutate(mw.id)
+                        }
+                      }}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/pages/monitoring/index.tsx
+++ b/web/src/pages/monitoring/index.tsx
@@ -14,6 +14,7 @@ import {
   Power,
   Eye,
   Filter,
+  Wrench,
 } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
@@ -37,6 +38,7 @@ import {
   getDeviceMetrics,
 } from '@/api/pulse'
 import { SparklineChart } from '@/components/sparkline-chart'
+import { MaintenanceWindowsPanel } from '@/components/pulse/maintenance-windows'
 import type {
   Check,
   Alert,
@@ -45,12 +47,13 @@ import type {
   CreateNotificationRequest,
 } from '@/api/types'
 
-type TabId = 'checks' | 'alerts' | 'notifications'
+type TabId = 'checks' | 'alerts' | 'notifications' | 'maintenance'
 
 const tabs: { id: TabId; label: string; icon: React.ElementType }[] = [
   { id: 'checks', label: 'Checks', icon: HeartPulse },
   { id: 'alerts', label: 'Alerts', icon: AlertTriangle },
   { id: 'notifications', label: 'Notifications', icon: Bell },
+  { id: 'maintenance', label: 'Maintenance', icon: Wrench },
 ]
 
 export function MonitoringPage() {
@@ -92,6 +95,7 @@ export function MonitoringPage() {
       {activeTab === 'checks' && <ChecksTab />}
       {activeTab === 'alerts' && <AlertsTab />}
       {activeTab === 'notifications' && <NotificationsTab />}
+      {activeTab === 'maintenance' && <MaintenanceWindowsPanel />}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Adds scheduled maintenance windows to the Pulse monitoring module that suppress alerts during planned downtime
- Supports four recurrence types: once, daily, weekly, and monthly (with midnight-crossing support)
- Full CRUD REST API (5 endpoints) + React management panel with create/edit/toggle/delete
- Scheduler automatically skips checks for devices in active maintenance windows
- 13 table-driven tests for time window matching logic plus store CRUD and integration tests

## Changes

### Backend (Go)
- **`internal/pulse/maint_window.go`** -- `MaintWindow` model, store CRUD (Insert/Get/List/Update/Delete), `IsDeviceInMaintenanceWindow`, `isTimeInWindow` with recurrence-aware matching
- **`internal/pulse/maint_window_test.go`** -- Table-driven tests for `isTimeInWindow` (13 cases), store CRUD, and `IsDeviceInMaintenanceWindow` (active/disabled/expired/no-windows/not-in-list)
- **`internal/pulse/migrations.go`** -- Migration v5: `pulse_maint_windows` table with JSON device_ids column
- **`internal/pulse/handlers.go`** -- 5 maintenance window routes + handler methods using `uuid.New()` for ID generation
- **`internal/pulse/scheduler.go`** -- Filter checks in `tick()` to skip devices in active maintenance windows

### Frontend (React/TypeScript)
- **`web/src/api/pulse-maintenance.ts`** -- API client with typed interfaces
- **`web/src/components/pulse/maintenance-windows.tsx`** -- Full CRUD panel with status/recurrence badges, TanStack Query mutations
- **`web/src/pages/monitoring/index.tsx`** -- Added Maintenance tab with Wrench icon

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/pulse/...` -- new tests pass (pre-existing `TestHTTPChecker_Non2xx` failure unrelated)
- [x] `golangci-lint run ./internal/pulse/...` passes clean
- [x] `pnpm run lint` passes
- [x] `pnpm run build` passes

Closes #279

Generated with [Claude Code](https://claude.com/claude-code)