### PR TITLE
feat: device inventory dashboard widget and stale badges

### DIFF
--- a/web/src/components/dashboard/inventory-summary.tsx
+++ b/web/src/components/dashboard/inventory-summary.tsx
@@ -1,0 +1,138 @@
+import { Link } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
+import { Monitor, AlertTriangle, ArrowRight } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+import { getInventorySummary } from '@/api/devices'
+import { cn } from '@/lib/utils'
+
+const DEVICE_TYPE_LABELS: Record<string, string> = {
+  server: 'Server',
+  desktop: 'Desktop',
+  laptop: 'Laptop',
+  mobile: 'Mobile',
+  router: 'Router',
+  switch: 'Switch',
+  access_point: 'AP',
+  firewall: 'Firewall',
+  printer: 'Printer',
+  nas: 'NAS',
+  iot: 'IoT',
+  phone: 'Phone',
+  tablet: 'Tablet',
+  camera: 'Camera',
+  unknown: 'Unknown',
+}
+
+export function InventorySummaryWidget() {
+  const { data: summary, isLoading } = useQuery({
+    queryKey: ['inventorySummary'],
+    queryFn: () => getInventorySummary(),
+    refetchInterval: 30 * 1000,
+  })
+
+  return (
+    <Card>
+      <CardHeader className="pb-3 flex flex-row items-center justify-between">
+        <CardTitle className="text-sm font-medium flex items-center gap-2">
+          <Monitor className="h-4 w-4 text-muted-foreground" />
+          Device Inventory
+        </CardTitle>
+        <Button variant="ghost" size="sm" asChild className="gap-1 text-xs">
+          <Link to="/devices">
+            View All
+            <ArrowRight className="h-3 w-3" />
+          </Link>
+        </Button>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="space-y-3">
+            <div className="grid grid-cols-3 gap-4">
+              {[...Array(3)].map((_, i) => (
+                <div key={i} className="text-center">
+                  <Skeleton className="h-8 w-12 mx-auto" />
+                  <Skeleton className="h-3 w-16 mx-auto mt-1" />
+                </div>
+              ))}
+            </div>
+            <Skeleton className="h-4 w-full" />
+          </div>
+        ) : !summary || summary.total_devices === 0 ? (
+          <div className="flex items-center justify-between">
+            <p className="text-sm text-muted-foreground">
+              No devices discovered yet. Run a network scan to get started.
+            </p>
+            <Button variant="outline" size="sm" asChild className="gap-2 shrink-0">
+              <Link to="/devices">
+                <Monitor className="h-3.5 w-3.5" />
+                Devices
+              </Link>
+            </Button>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {/* Counts */}
+            <div className="grid grid-cols-3 gap-4">
+              <div className="text-center">
+                <p className="text-2xl font-bold">{summary.total_devices}</p>
+                <p className="text-xs text-muted-foreground">Total</p>
+              </div>
+              <div className="text-center">
+                <p className="text-2xl font-bold text-green-600 dark:text-green-400">
+                  {summary.online_count}
+                </p>
+                <p className="text-xs text-muted-foreground">Online</p>
+              </div>
+              <div className="text-center">
+                <p className={cn(
+                  'text-2xl font-bold',
+                  summary.stale_count > 0
+                    ? 'text-amber-600 dark:text-amber-400'
+                    : 'text-muted-foreground'
+                )}>
+                  {summary.stale_count}
+                </p>
+                <p className="text-xs text-muted-foreground flex items-center justify-center gap-1">
+                  {summary.stale_count > 0 && (
+                    <AlertTriangle className="h-3 w-3 text-amber-500" />
+                  )}
+                  Stale
+                </p>
+              </div>
+            </div>
+
+            {/* Category breakdown as badges */}
+            {Object.keys(summary.by_type).length > 0 && (
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="text-xs text-muted-foreground">Types:</span>
+                {Object.entries(summary.by_type)
+                  .sort(([, a], [, b]) => b - a)
+                  .map(([type, count]) => (
+                    <span
+                      key={type}
+                      className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-muted text-muted-foreground"
+                    >
+                      {DEVICE_TYPE_LABELS[type] || type}: {count}
+                    </span>
+                  ))}
+              </div>
+            )}
+
+            {/* Stale warning link */}
+            {summary.stale_count > 0 && (
+              <Link
+                to="/devices?status=stale"
+                className="flex items-center gap-2 text-xs text-amber-600 dark:text-amber-400 hover:underline"
+              >
+                <AlertTriangle className="h-3.5 w-3.5" />
+                {summary.stale_count} device{summary.stale_count !== 1 ? 's' : ''} not seen in 30+ days
+              </Link>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/web/src/pages/dashboard.tsx
+++ b/web/src/pages/dashboard.tsx
@@ -39,6 +39,7 @@ import { cn } from '@/lib/utils'
 import { useKeyboardShortcuts } from '@/hooks/use-keyboard-shortcuts'
 import { NLQueryBar } from '@/components/nl-query-bar'
 import { RecommendationsWidget } from '@/components/insight/recommendations'
+import { InventorySummaryWidget } from '@/components/dashboard/inventory-summary'
 
 const REFRESH_OPTIONS = [
   { label: '15s', value: 15 * 1000 },
@@ -550,6 +551,9 @@ export function DashboardPage() {
 
       {/* AI Recommendations */}
       <RecommendationsWidget />
+
+      {/* Device Inventory Summary */}
+      <InventorySummaryWidget />
 
       {/* Main Content Grid */}
       <div className="grid gap-6 lg:grid-cols-3">


### PR DESCRIPTION
## Summary

- Add **InventorySummaryWidget** to dashboard page showing total/online/stale device counts and device type breakdown badges
- Add per-device **Stale badge** (amber) in the devices table when `last_seen` exceeds 7 days
- Add **Stale filter pill** to the devices page status filter row with client-side filtering

## Details

### Dashboard Widget (`web/src/components/dashboard/inventory-summary.tsx`)
- Uses existing `getInventorySummary` API from `@/api/devices`
- TanStack Query with `['inventorySummary']` key and 30s auto-refresh
- Shows total, online, and stale counts with amber warning color when stale > 0
- Device type breakdown as compact badges
- Link to `/devices?status=stale` when stale devices exist
- Follows existing card pattern (Card, CardHeader, CardTitle, CardContent)

### Stale Badge in Devices Table (`web/src/pages/devices/index.tsx`)
- `isDeviceStale()` helper checks if `last_seen` > 7 days
- Amber "Stale" badge with AlertTriangle icon shown next to StatusBadge
- New StatusPill for "Stale" filter in the status filter row
- Client-side filtering (stale is not a server-side status value)
- Extended `statusFilter` type to include `'stale'`

### Dashboard Integration (`web/src/pages/dashboard.tsx`)
- Widget placed after RecommendationsWidget, before the main content grid

Closes #281

## Test plan

- [ ] Dashboard shows InventorySummaryWidget with correct counts
- [ ] Widget handles loading, empty, and populated states
- [ ] Stale warning link navigates to `/devices?status=stale`
- [ ] Devices table shows amber "Stale" badge for devices with last_seen > 7 days
- [ ] Stale filter pill filters to only stale devices
- [ ] TypeScript compilation passes (`npx tsc -b --noEmit`)
- [ ] ESLint passes (`npx eslint .`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)