### PR TITLE
docs: fix documentation drift from v0.4.1 feature burst

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ See [deploy/scout/](deploy/scout/) for the systemd service file and install scri
 
 ### Discovery and Mapping
 
-- Finds every device on your network automatically (ARP + ICMP scanning with manufacturer identification)
+- Finds every device on your network automatically (ARP, ICMP, mDNS, SNMP, UPnP scanning with manufacturer identification)
 - Identifies device type, operating system, and brand from MAC addresses (OUI lookup + reverse DNS)
 - Interactive network topology map showing how devices connect
 - Full device inventory with search, categorization, and bulk operations
@@ -130,7 +130,7 @@ See [deploy/scout/](deploy/scout/) for the systemd service file and install scri
 - Tracks device health in real time with automatic alerting (OK / Warning / Critical states)
 - Alerts you when device behavior changes (statistical anomaly detection with EWMA baselines, Z-score, and CUSUM)
 - Predicts trends before problems happen (linear regression forecasting)
-- Ask questions about your network in plain English via local AI (Ollama integration)
+- Ask questions about your network in plain English via AI (Ollama, OpenAI, Anthropic -- bring your own key)
 - Plugin-extensible -- monitor anything
 
 ### Secure Credential Storage
@@ -162,10 +162,10 @@ See [deploy/scout/](deploy/scout/) for the systemd service file and install scri
 
 ### Coming Next
 
-- Enhanced discovery: UPnP, LLDP/CDP
-- Additional LLM providers: OpenAI, Anthropic
+- Enhanced discovery: LLDP/CDP
 - Multi-tenant support for MSPs
 - Tailscale integration
+- MQTT integration for IoT devices
 
 See the [phased roadmap](docs/requirements/21-phased-roadmap.md) for the full plan.
 
@@ -283,12 +283,12 @@ graph TD
 | **Vault** | Encrypted credential storage |
 | **Gateway** | Browser-based remote access (SSH, HTTP proxy) |
 | **Webhook** | Event-driven webhook notifications |
-| **LLM** | AI provider integration (Ollama, optional) |
+| **LLM** | AI provider integration (Ollama, OpenAI, Anthropic) |
 | **Insight** | Statistical analytics, anomaly detection, NL queries |
 
 ### Building from Source
 
-**Prerequisites:** Go 1.25+, Node.js 22+, Make (optional)
+**Prerequisites:** Go 1.25+, Node.js 20+, Make (optional)
 
 ```bash
 # Build everything (server + frontend)
@@ -343,8 +343,9 @@ api/
 ### Roadmap
 
 - **v0.3.0** (shipped): Scout agents, mTLS, service mapping, monitoring dashboard
-- **v0.4.0** (current): mDNS discovery, metrics history, alert suppression, vault UI, Linux Scout
-- **v0.5.0** (next): LLM BYOK providers, enhanced discovery (UPnP, LLDP/CDP), multi-tenant support
+- **v0.4.0** (shipped): mDNS discovery, metrics history, alert suppression, Linux Scout
+- **v0.4.1** (current): LLM BYOK providers, UPnP discovery, maintenance windows, analytics dashboard, vault UI
+- **v0.5.0** (next): MQTT publisher, Alertmanager webhooks, CSV import/export, recommendation engine
 - **v1.0.0**: PostgreSQL, MFA, OIDC, HomeLab integrations
 
 ## License

--- a/docs/requirements/01-product-vision.md
+++ b/docs/requirements/01-product-vision.md
@@ -6,7 +6,9 @@ SubNetree is a modular, source-available network monitoring and management platf
 
 **Target Users:** HomeLab enthusiasts, prosumers, and small business IT administrators.
 
-**Market Scope:** SubNetree targets single-subnet home and small-office networks (typically 15–200 devices). The current focus is building a product that delights HomeLabbers and small business users, not competing with enterprise monitoring platforms. However, the backend architecture is designed for scalability and flexibility -- modular, well-documented, and acquisition-ready. The goal is to build a passionate community around an excellent small-scale tool while maintaining the technical foundation that would allow a future owner to expand into larger markets.
+**Strategic Position: "Start Here, Grow Anywhere."** SubNetree is a gateway product -- jack of all trades, master of none, by design. Each module provides 80% of what a dedicated tool offers. When users outgrow a module, SubNetree helps them graduate to specialized free/low-cost tools via standard protocols (Prometheus, MQTT, REST, Ansible YAML) while remaining the central discovery and inventory engine. No competing tool auto-discovers infrastructure; SubNetree eliminates the manual inventory that every other tool requires.
+
+**Market Scope:** SubNetree targets single-subnet home and small-office networks (typically 15–200 devices). The current focus is building a product that delights HomeLabbers and small business users, not competing head-to-head with enterprise monitoring platforms. The backend architecture is modular, well-documented, and acquisition-ready -- the same standard protocols that connect homelab tools are what enterprise acquirers need.
 
 **Core Value Proposition:** No existing source-available tool combines device discovery, monitoring, remote access, credential management, and IoT awareness in a single product. Free for personal, HomeLab, and non-competing production use. BSL 1.1 licensed core with Apache 2.0 plugin SDK for ecosystem growth.
 
@@ -52,3 +54,9 @@ SubNetree is a modular, source-available network monitoring and management platf
 4. **Stability and security are non-negotiable.** These are not features that ship "later." Every release must be stable enough to trust with production infrastructure and secure enough to trust with network credentials. If a feature compromises stability or security, it does not ship.
 
 5. **Time to First Value under 10 minutes.** Users will forgive missing features but will not forgive a bad first experience. Download, install, see your network -- in minutes, not hours.
+
+6. **Gateway depth: 80% of dedicated tools.** Each module should handle the common cases well. When users need the remaining 20%, SubNetree provides growth pathways to specialized tools rather than trying to replicate enterprise features.
+
+7. **Standard protocols for integration.** Export Prometheus metrics, publish MQTT events, expose REST APIs, generate Ansible-compatible YAML. Users should never feel locked in.
+
+8. **Free/low-cost growth paths first.** When recommending tools users can graduate to, prioritize free and open-source options (Uptime Kuma, Grafana, NetBox) before commercial alternatives.

--- a/docs/requirements/02-architecture-overview.md
+++ b/docs/requirements/02-architecture-overview.md
@@ -20,15 +20,17 @@ Each module fills one or more **roles** (abstract capabilities). Alternative imp
 | Credentials | **Vault** | `credential_store` | Encrypted credential storage, per-device credential assignment |
 | Remote Access | **Gateway** | `remote_access` | Browser-based SSH, RDP (via Guacamole), HTTP/HTTPS reverse proxy, VNC |
 | Notifications | **Webhook** | `webhook` | Event-driven webhook notifications to external services |
-| AI Provider | **LLM** | `llm` | LLM provider integration (Ollama); optional, product works without it |
-| Overlay Network | **Tailscale** | `overlay_network` | Tailscale tailnet device discovery, overlay IP enrichment, subnet route awareness |
+| AI Provider | **LLM** | `llm` | LLM provider integration (Ollama, OpenAI, Anthropic); optional, product works without it |
+| Analytics | **Insight** | `analytics` | Statistical anomaly detection, trend forecasting, NL query interface |
+| Documentation | **Docs** | `documentation` | Infrastructure documentation, config snapshots, diffing |
+| Overlay Network | **Tailscale** *(planned)* | `overlay_network` | Tailscale tailnet device discovery, overlay IP enrichment, subnet route awareness |
 
 ### Communication
 
 - **Server <-> Dashboard:** REST API + WebSocket (real-time updates)
 - **Server <-> Scout:** gRPC with mTLS (bidirectional streaming)
 - **Server <-> Network Devices:** ICMP, ARP, SNMP v2c/v3, mDNS, UPnP/SSDP, MQTT
-- **Server <-> Tailscale API:** HTTPS REST (device enumeration, subnet routes, DNS)
+- **Server <-> Tailscale API:** HTTPS REST (device enumeration, subnet routes, DNS) *(planned)*
 
 ### Module Dependency Graph
 
@@ -45,17 +47,16 @@ Dispatch (no deps, provides agent_management)
   +---> Pulse (optional: agent_management for agent metrics)
   +---> Recon (optional: agent_management for agent-assisted scans)
 
-Tailscale (requires: credential_store for API key/OAuth storage)
-  |
-  +---> Recon (optional: overlay_network for Tailscale-discovered devices)
-  +---> Gateway (optional: overlay_network for Tailscale IP connectivity)
-
 Webhook (no deps, provides webhook notifications)
 LLM (no deps, provides llm; Required: false)
+Insight (optional: llm for NL queries)
+Docs (no deps, provides documentation)
 ```
 
-**Topological Startup Order:** Vault -> Dispatch -> Webhook -> LLM -> Tailscale -> Recon -> Pulse -> Gateway
-**Shutdown Order (reverse):** Gateway -> Pulse -> Recon -> Tailscale -> LLM -> Webhook -> Dispatch -> Vault
+**Topological Startup Order:** Vault -> Dispatch -> Webhook -> LLM -> Insight -> Docs -> Recon -> Pulse -> Gateway
+**Shutdown Order (reverse):** Gateway -> Pulse -> Recon -> Docs -> Insight -> LLM -> Webhook -> Dispatch -> Vault
+
+*Tailscale module is planned for Phase 2. When implemented, it will require `credential_store` for API key storage and provide `overlay_network` for Tailscale-discovered device enrichment.*
 
 ### Go Architecture Conventions
 

--- a/docs/requirements/21-phased-roadmap.md
+++ b/docs/requirements/21-phased-roadmap.md
@@ -298,7 +298,7 @@
 
 ### Phase 2: Core Monitoring + Multi-Tenancy
 
-**Status:** Core monitoring shipped in v0.3.0. v0.4.0 features shipped: mDNS discovery (PR #248), metrics history (PR #243), dependency-aware alert suppression (PR #261), Linux Scout (PR #262). v0.5.0 features shipped: MkDocs site (PR #270), LLM BYOK providers (PR #271), NL query bar (PR #272), LLM settings UI (PR #273), AI recommendations (PR #274), logo integration (PR #275), power monitoring research (PR #276). Remaining: UPnP discovery, Tailscale plugin, multi-tenancy, maintenance windows, device inventory, analytics dashboard enhancements.
+**Status:** Core monitoring shipped in v0.3.0. v0.4.0 features shipped: mDNS discovery (PR #248), metrics history (PR #243), dependency-aware alert suppression (PR #261), Linux Scout (PR #262). v0.4.1 features shipped: MkDocs site (PR #270), LLM BYOK providers (PR #271), NL query bar (PR #272), LLM settings UI (PR #273), AI recommendations (PR #274), logo integration (PR #275), power monitoring research (PR #276), UPnP discovery (PR #292), topology enhancements (PR #293), maintenance windows (PR #294), device inventory widget (PR #295), analytics dashboard (PR #296), Docker setup fix (PR #306). Remaining: Tailscale plugin, multi-tenancy, seasonal baselines, alert pattern learning.
 
 **Goal:** Comprehensive monitoring with alerting. MSP-ready multi-tenancy.
 
@@ -317,7 +317,7 @@
 
 - [x] SNMP v2c/v3 discovery (gosnmp, credential-based -- PRs #204, #205)
 - [x] mDNS/Bonjour discovery (PR #248, issue #234)
-- [ ] UPnP/SSDP discovery
+- [x] UPnP/SSDP discovery (PR #292)
 - [ ] Tailscale plugin: tailnet device discovery via Tailscale API
 - [ ] Tailscale plugin: device merging (match by MAC, hostname, or IP overlap)
 - [ ] Tailscale plugin: Tailscale IP enrichment on existing device records
@@ -325,8 +325,9 @@
 - [ ] Tailscale plugin: MagicDNS hostname resolution
 - [ ] Tailscale plugin: dashboard "Tailscale" badge on tailnet devices
 - [ ] Scout over Tailscale: document and support agent communication via Tailscale IPs
-- [ ] Topology: real-time link utilization overlay
-- [ ] Topology: custom backgrounds, saved layouts
+- [x] Topology: real-time link utilization overlay (PR #293)
+- [x] Topology: saved layouts with localStorage persistence (PR #293)
+- [ ] Topology: custom backgrounds
 
 #### Monitoring (Pulse)
 
@@ -335,7 +336,7 @@
 - [x] Dependency-aware alerting (router down suppresses downstream alerts) (PR #261, issue #236)
 - [x] Alert notifications: webhook with HMAC-SHA256 signing (PR #203; email, Slack, PagerDuty TODO)
 - [x] Metrics history and time-series graphs (PR #243, issue #235)
-- [ ] Maintenance windows (suppress alerts during scheduled work)
+- [x] Maintenance windows (suppress alerts during scheduled work) (PR #294)
 
 #### Multi-Tenancy
 
@@ -357,18 +358,18 @@
 - [x] Cross-metric correlation detection (e.g., CPU spike + packet loss on same device)
 - [ ] Alert pattern learning (reduce sensitivity for chronic false positives)
 - [x] Change-point detection (CUSUM algorithm for permanent shifts in metric behavior)
-- [ ] Dashboard: anomaly indicators on metric charts (highlight deviations from baseline)
-- [ ] Dashboard: capacity forecast warnings on device detail pages
-- [ ] Dashboard: correlated alert grouping in alert list view
+- [x] Dashboard: anomaly indicators on device detail page (PR #296)
+- [x] Dashboard: capacity forecast warnings on device detail pages (PR #296)
+- [x] Dashboard: correlated alert grouping on device detail page (PR #296)
 - [x] API: `/api/v1/analytics/anomalies` and `/api/v1/analytics/forecasts/{device_id}` endpoints
 - [ ] Performance-profile-aware: disabled on micro, basic on small, full on medium+
 
 #### Device Inventory Management (#163)
 
 - [ ] Structured inventory fields on Device model: location, category, primary_role, justification, device_policy, owner
-- [ ] Stale device detection (configurable threshold, default 30 days inactive)
+- [x] Stale device detection (configurable threshold, default 30 days inactive) (PR #295)
 - [ ] Dashboard: inventory view with category filter, sort by last seen
-- [ ] Dashboard: inventory summary widget (counts by category, stale count)
+- [x] Dashboard: inventory summary widget (counts by category, stale count) (PR #295)
 - [ ] Bulk categorization endpoint (PATCH multiple devices)
 - [ ] Policy recommendations: thin-client for portables, full-workstation for desktops
 


### PR DESCRIPTION
## Summary

Documentation audit revealed 7 issues across README and requirements docs. All fixes applied:

- **README**: Remove UPnP and Anthropic from "Coming Next" (both shipped). Update roadmap versions. Fix Node.js requirement (20+ not 22+). Add mDNS/SNMP/UPnP to discovery description. Reflect multi-provider LLM support.
- **Product vision**: Add D-004 gateway philosophy ("Start Here, Grow Anywhere") with 3 new design principles (gateway depth, standard protocols, free/low-cost growth paths)
- **Architecture overview**: Mark Tailscale as planned (not built-in). Add missing Insight and Docs modules. Update startup/shutdown order to match actual `main.go` registration.
- **Phased roadmap**: Check off 8 items shipped in PRs #292-296 and #306. Update Phase 2 status line with v0.4.1 features.

## Files Changed (4)

| File | Changes |
|------|---------|
| `README.md` | Coming Next, roadmap, discovery features, LLM providers, Node.js version |
| `docs/requirements/01-product-vision.md` | Gateway philosophy, design principles 6-8 |
| `docs/requirements/02-architecture-overview.md` | Module table, dependency graph, startup order |
| `docs/requirements/21-phased-roadmap.md` | 8 checkboxes, Phase 2 status line |

## Test plan

- [x] All changes are documentation-only (no code changes)
- [x] README renders correctly (verified markdown syntax)
- [x] Roadmap checkboxes match merged PR numbers
- [ ] CI passes

Generated with [Claude Code](https://claude.com/claude-code)