### PR TITLE
fix: prevent browser autofill from overwriting email in setup wizard

### DIFF
--- a/web/src/pages/setup.tsx
+++ b/web/src/pages/setup.tsx
@@ -294,12 +294,12 @@ export function SetupPage() {
               <Label htmlFor="username">Username</Label>
               <Input
                 id="username"
-                name="new-username"
+                name="username"
                 value={formData.username}
                 onChange={(e) => updateField('username', e.target.value)}
                 placeholder="admin"
                 autoFocus
-                autoComplete="off"
+                autoComplete="username"
               />
               {errors.username && (
                 <p className="text-sm text-red-400">{errors.username}</p>
@@ -310,6 +310,7 @@ export function SetupPage() {
               <Label htmlFor="email">Email</Label>
               <Input
                 id="email"
+                name="email"
                 type="email"
                 value={formData.email}
                 onChange={(e) => updateField('email', e.target.value)}
@@ -326,6 +327,7 @@ export function SetupPage() {
               <div className="relative">
                 <Input
                   id="password"
+                  name="new-password"
                   type={showPassword ? 'text' : 'password'}
                   value={formData.password}
                   onChange={(e) => updateField('password', e.target.value)}
@@ -371,6 +373,7 @@ export function SetupPage() {
               <div className="relative">
                 <Input
                   id="confirmPassword"
+                  name="confirm-password"
                   type={showPassword ? 'text' : 'password'}
                   value={formData.confirmPassword}
                   onChange={(e) => updateField('confirmPassword', e.target.value)}


### PR DESCRIPTION
## Summary

- Fix browser password autofill overwriting the email field with a saved username during setup wizard account creation
- Root cause: `name="new-username"` and `autocomplete="off"` on the username field. Chrome ignores `autocomplete="off"` (since Chrome 34) and doesn't recognize non-standard `name` values, so when a saved password is picked, the browser maps the email field as the username companion and overwrites it
- Fix: use standard `name` and `autocomplete` attributes on all four form fields so browsers correctly identify each field's role

## Changes

| Field | Before | After |
|-------|--------|-------|
| Username | `name="new-username"`, `autocomplete="off"` | `name="username"`, `autocomplete="username"` |
| Email | no `name` attribute | `name="email"` |
| Password | no `name` attribute | `name="new-password"` |
| Confirm | no `name` attribute | `name="confirm-password"` |

## Test plan

- [x] TypeScript check passes
- [x] All 23 setup page tests pass
- [ ] CI passes
- [ ] Manual: open setup wizard in Chrome with saved passwords, verify autofill doesn't overwrite email

Generated with [Claude Code](https://claude.com/claude-code)