### PR TITLE
feat: embedded tool recommendation catalog

### DIFF
--- a/api/swagger/docs.go
+++ b/api/swagger/docs.go
@@ -228,6 +228,95 @@ const docTemplate = `{
                 }
             }
         },
+        "/catalog/entries": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the full tool catalog for client-side filtering.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "catalog"
+                ],
+                "summary": "List all catalog entries",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_catalog.CatalogEntry"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/catalog/recommendations": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns recommended homelab tools filtered by hardware tier and optional category, sorted by memory requirements ascending.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "catalog"
+                ],
+                "summary": "Get tool recommendations",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "default": 1,
+                        "description": "Hardware tier (0=SBC, 1=Mini PC, 2=NAS, 3=Cluster, 4=SMB)",
+                        "name": "tier",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by category (monitoring, infrastructure, dns, etc.)",
+                        "name": "category",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_catalog.RecommendationResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/dispatch/agents": {
             "get": {
                 "security": [
@@ -3973,6 +4062,132 @@ const docTemplate = `{
                 }
             }
         },
+        "github_com_HerbHall_subnetree_pkg_catalog.CatalogEntry": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_catalog.Category"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "docker_image": {
+                    "type": "string"
+                },
+                "github_url": {
+                    "type": "string"
+                },
+                "integration_notes": {
+                    "type": "string"
+                },
+                "integration_status": {
+                    "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_catalog.IntegrationStatus"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "license": {
+                    "type": "string"
+                },
+                "min_ram_mb": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "protocols": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "stars": {
+                    "type": "integer"
+                },
+                "supported_tiers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_catalog.HardwareTier"
+                    }
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "website": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_HerbHall_subnetree_pkg_catalog.Category": {
+            "type": "string",
+            "enum": [
+                "monitoring",
+                "infrastructure",
+                "dns",
+                "home-automation",
+                "notifications",
+                "dashboard",
+                "cmdb",
+                "documentation",
+                "network"
+            ],
+            "x-enum-varnames": [
+                "CategoryMonitoring",
+                "CategoryInfrastructure",
+                "CategoryDNS",
+                "CategoryHomeAutomation",
+                "CategoryNotifications",
+                "CategoryDashboard",
+                "CategoryCMDB",
+                "CategoryDocumentation",
+                "CategoryNetwork"
+            ]
+        },
+        "github_com_HerbHall_subnetree_pkg_catalog.HardwareTier": {
+            "type": "integer",
+            "enum": [
+                0,
+                1,
+                2,
+                3,
+                4
+            ],
+            "x-enum-comments": {
+                "TierCluster": "Proxmox cluster",
+                "TierMiniPC": "Intel N100 (8-32 GB)",
+                "TierNAS": "Synology/QNAP (Scout only)",
+                "TierSBC": "Pi, SBC (1 GB)",
+                "TierSMB": "Small business server"
+            },
+            "x-enum-varnames": [
+                "TierSBC",
+                "TierMiniPC",
+                "TierNAS",
+                "TierCluster",
+                "TierSMB"
+            ]
+        },
+        "github_com_HerbHall_subnetree_pkg_catalog.IntegrationStatus": {
+            "type": "string",
+            "enum": [
+                "shipped",
+                "planned",
+                "possible"
+            ],
+            "x-enum-comments": {
+                "IntegrationPlanned": "On roadmap",
+                "IntegrationPossible": "Feasible, not scheduled",
+                "IntegrationShipped": "Already works"
+            },
+            "x-enum-varnames": [
+                "IntegrationShipped",
+                "IntegrationPlanned",
+                "IntegrationPossible"
+            ]
+        },
         "github_com_HerbHall_subnetree_pkg_models.APIProblem": {
             "type": "object",
             "properties": {
@@ -4604,6 +4819,23 @@ const docTemplate = `{
                 "username": {
                     "type": "string",
                     "example": "admin"
+                }
+            }
+        },
+        "internal_catalog.RecommendationResponse": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "entries": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_catalog.CatalogEntry"
+                    }
+                },
+                "tier": {
+                    "type": "integer"
                 }
             }
         },

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -221,6 +221,95 @@
                 }
             }
         },
+        "/catalog/entries": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the full tool catalog for client-side filtering.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "catalog"
+                ],
+                "summary": "List all catalog entries",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_catalog.CatalogEntry"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/catalog/recommendations": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns recommended homelab tools filtered by hardware tier and optional category, sorted by memory requirements ascending.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "catalog"
+                ],
+                "summary": "Get tool recommendations",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "default": 1,
+                        "description": "Hardware tier (0=SBC, 1=Mini PC, 2=NAS, 3=Cluster, 4=SMB)",
+                        "name": "tier",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by category (monitoring, infrastructure, dns, etc.)",
+                        "name": "category",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_catalog.RecommendationResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/dispatch/agents": {
             "get": {
                 "security": [
@@ -3966,6 +4055,132 @@
                 }
             }
         },
+        "github_com_HerbHall_subnetree_pkg_catalog.CatalogEntry": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_catalog.Category"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "docker_image": {
+                    "type": "string"
+                },
+                "github_url": {
+                    "type": "string"
+                },
+                "integration_notes": {
+                    "type": "string"
+                },
+                "integration_status": {
+                    "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_catalog.IntegrationStatus"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "license": {
+                    "type": "string"
+                },
+                "min_ram_mb": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "protocols": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "stars": {
+                    "type": "integer"
+                },
+                "supported_tiers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_catalog.HardwareTier"
+                    }
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "website": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_HerbHall_subnetree_pkg_catalog.Category": {
+            "type": "string",
+            "enum": [
+                "monitoring",
+                "infrastructure",
+                "dns",
+                "home-automation",
+                "notifications",
+                "dashboard",
+                "cmdb",
+                "documentation",
+                "network"
+            ],
+            "x-enum-varnames": [
+                "CategoryMonitoring",
+                "CategoryInfrastructure",
+                "CategoryDNS",
+                "CategoryHomeAutomation",
+                "CategoryNotifications",
+                "CategoryDashboard",
+                "CategoryCMDB",
+                "CategoryDocumentation",
+                "CategoryNetwork"
+            ]
+        },
+        "github_com_HerbHall_subnetree_pkg_catalog.HardwareTier": {
+            "type": "integer",
+            "enum": [
+                0,
+                1,
+                2,
+                3,
+                4
+            ],
+            "x-enum-comments": {
+                "TierCluster": "Proxmox cluster",
+                "TierMiniPC": "Intel N100 (8-32 GB)",
+                "TierNAS": "Synology/QNAP (Scout only)",
+                "TierSBC": "Pi, SBC (1 GB)",
+                "TierSMB": "Small business server"
+            },
+            "x-enum-varnames": [
+                "TierSBC",
+                "TierMiniPC",
+                "TierNAS",
+                "TierCluster",
+                "TierSMB"
+            ]
+        },
+        "github_com_HerbHall_subnetree_pkg_catalog.IntegrationStatus": {
+            "type": "string",
+            "enum": [
+                "shipped",
+                "planned",
+                "possible"
+            ],
+            "x-enum-comments": {
+                "IntegrationPlanned": "On roadmap",
+                "IntegrationPossible": "Feasible, not scheduled",
+                "IntegrationShipped": "Already works"
+            },
+            "x-enum-varnames": [
+                "IntegrationShipped",
+                "IntegrationPlanned",
+                "IntegrationPossible"
+            ]
+        },
         "github_com_HerbHall_subnetree_pkg_models.APIProblem": {
             "type": "object",
             "properties": {
@@ -4597,6 +4812,23 @@
                 "username": {
                     "type": "string",
                     "example": "admin"
+                }
+            }
+        },
+        "internal_catalog.RecommendationResponse": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "entries": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_catalog.CatalogEntry"
+                    }
+                },
+                "tier": {
+                    "type": "integer"
                 }
             }
         },

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -151,6 +151,101 @@ definitions:
         description: '"cpu", "memory", "disk"'
         type: string
     type: object
+  github_com_HerbHall_subnetree_pkg_catalog.CatalogEntry:
+    properties:
+      category:
+        $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_catalog.Category'
+      description:
+        type: string
+      docker_image:
+        type: string
+      github_url:
+        type: string
+      integration_notes:
+        type: string
+      integration_status:
+        $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_catalog.IntegrationStatus'
+      language:
+        type: string
+      license:
+        type: string
+      min_ram_mb:
+        type: integer
+      name:
+        type: string
+      protocols:
+        items:
+          type: string
+        type: array
+      stars:
+        type: integer
+      supported_tiers:
+        items:
+          $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_catalog.HardwareTier'
+        type: array
+      tags:
+        items:
+          type: string
+        type: array
+      website:
+        type: string
+    type: object
+  github_com_HerbHall_subnetree_pkg_catalog.Category:
+    enum:
+    - monitoring
+    - infrastructure
+    - dns
+    - home-automation
+    - notifications
+    - dashboard
+    - cmdb
+    - documentation
+    - network
+    type: string
+    x-enum-varnames:
+    - CategoryMonitoring
+    - CategoryInfrastructure
+    - CategoryDNS
+    - CategoryHomeAutomation
+    - CategoryNotifications
+    - CategoryDashboard
+    - CategoryCMDB
+    - CategoryDocumentation
+    - CategoryNetwork
+  github_com_HerbHall_subnetree_pkg_catalog.HardwareTier:
+    enum:
+    - 0
+    - 1
+    - 2
+    - 3
+    - 4
+    type: integer
+    x-enum-comments:
+      TierCluster: Proxmox cluster
+      TierMiniPC: Intel N100 (8-32 GB)
+      TierNAS: Synology/QNAP (Scout only)
+      TierSBC: Pi, SBC (1 GB)
+      TierSMB: Small business server
+    x-enum-varnames:
+    - TierSBC
+    - TierMiniPC
+    - TierNAS
+    - TierCluster
+    - TierSMB
+  github_com_HerbHall_subnetree_pkg_catalog.IntegrationStatus:
+    enum:
+    - shipped
+    - planned
+    - possible
+    type: string
+    x-enum-comments:
+      IntegrationPlanned: On roadmap
+      IntegrationPossible: Feasible, not scheduled
+      IntegrationShipped: Already works
+    x-enum-varnames:
+    - IntegrationShipped
+    - IntegrationPlanned
+    - IntegrationPossible
   github_com_HerbHall_subnetree_pkg_models.APIProblem:
     properties:
       detail:
@@ -606,6 +701,17 @@ definitions:
       username:
         example: admin
         type: string
+    type: object
+  internal_catalog.RecommendationResponse:
+    properties:
+      count:
+        type: integer
+      entries:
+        items:
+          $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_catalog.CatalogEntry'
+        type: array
+      tier:
+        type: integer
     type: object
   internal_dispatch.enrollTokenRequest:
     properties:
@@ -1344,6 +1450,64 @@ paths:
       summary: Check setup status
       tags:
       - auth
+  /catalog/entries:
+    get:
+      description: Returns the full tool catalog for client-side filtering.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_catalog.CatalogEntry'
+            type: array
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - BearerAuth: []
+      summary: List all catalog entries
+      tags:
+      - catalog
+  /catalog/recommendations:
+    get:
+      description: Returns recommended homelab tools filtered by hardware tier and
+        optional category, sorted by memory requirements ascending.
+      parameters:
+      - default: 1
+        description: Hardware tier (0=SBC, 1=Mini PC, 2=NAS, 3=Cluster, 4=SMB)
+        in: query
+        name: tier
+        type: integer
+      - description: Filter by category (monitoring, infrastructure, dns, etc.)
+        in: query
+        name: category
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/internal_catalog.RecommendationResponse'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Get tool recommendations
+      tags:
+      - catalog
   /dispatch/agents:
     get:
       description: Returns all registered Scout agents.

--- a/cmd/subnetree/main.go
+++ b/cmd/subnetree/main.go
@@ -22,6 +22,7 @@ import (
 
 	_ "github.com/HerbHall/subnetree/api/swagger"
 	"github.com/HerbHall/subnetree/internal/auth"
+	"github.com/HerbHall/subnetree/internal/catalog"
 	"github.com/HerbHall/subnetree/internal/config"
 	"github.com/HerbHall/subnetree/internal/dashboard"
 	"github.com/HerbHall/subnetree/internal/dispatch"
@@ -42,6 +43,7 @@ import (
 	"github.com/HerbHall/subnetree/internal/version"
 	"github.com/HerbHall/subnetree/internal/webhook"
 	"github.com/HerbHall/subnetree/internal/ws"
+	pkgcatalog "github.com/HerbHall/subnetree/pkg/catalog"
 	"github.com/HerbHall/subnetree/pkg/plugin"
 	"go.uber.org/zap"
 )
@@ -298,7 +300,13 @@ func main() {
 		return db.DB().PingContext(ctx)
 	})
 	dashboardHandler := dashboard.Handler()
-	extraRoutes := []server.SimpleRouteRegistrar{settingsHandler, wsHandler, svcmapHandler}
+
+	// Create catalog recommendation handler.
+	cat := pkgcatalog.NewCatalog()
+	catalogEngine := catalog.NewEngine(cat)
+	catalogHandler := catalog.NewHandler(catalogEngine, logger.Named("catalog"))
+
+	extraRoutes := []server.SimpleRouteRegistrar{settingsHandler, wsHandler, svcmapHandler, catalogHandler}
 	if sshHandler != nil {
 		extraRoutes = append(extraRoutes, sshHandler)
 	}

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	golang.org/x/time v0.14.0
 	google.golang.org/grpc v1.79.1
 	google.golang.org/protobuf v1.36.11
+	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.44.3
 )
 
@@ -66,7 +67,6 @@ require (
 	golang.org/x/tools v0.40.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.67.6 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/internal/catalog/engine.go
+++ b/internal/catalog/engine.go
@@ -1,0 +1,69 @@
+// Package catalog provides the recommendation engine that filters the embedded
+// tool catalog by hardware tier and category.
+package catalog
+
+import (
+	"sort"
+
+	pkgcatalog "github.com/HerbHall/subnetree/pkg/catalog"
+)
+
+// Engine filters catalog entries by hardware tier and category.
+type Engine struct {
+	cat *pkgcatalog.Catalog
+}
+
+// NewEngine creates a new recommendation engine backed by the given catalog.
+func NewEngine(cat *pkgcatalog.Catalog) *Engine {
+	return &Engine{cat: cat}
+}
+
+// Recommend returns catalog entries compatible with the given hardware tier,
+// sorted by MinRAMMB ascending (lightest first).
+func (e *Engine) Recommend(tier pkgcatalog.HardwareTier) ([]pkgcatalog.CatalogEntry, error) {
+	entries, err := e.cat.Entries()
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]pkgcatalog.CatalogEntry, 0, len(entries))
+	for i := range entries {
+		if tierSupported(entries[i].SupportedTiers, tier) {
+			result = append(result, entries[i])
+		}
+	}
+
+	sort.Slice(result, func(a, b int) bool {
+		return result[a].MinRAMMB < result[b].MinRAMMB
+	})
+
+	return result, nil
+}
+
+// RecommendByCategory returns catalog entries compatible with the given tier
+// and matching the specified category, sorted by MinRAMMB ascending.
+func (e *Engine) RecommendByCategory(tier pkgcatalog.HardwareTier, cat pkgcatalog.Category) ([]pkgcatalog.CatalogEntry, error) {
+	entries, err := e.Recommend(tier)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]pkgcatalog.CatalogEntry, 0, len(entries))
+	for i := range entries {
+		if entries[i].Category == cat {
+			result = append(result, entries[i])
+		}
+	}
+
+	return result, nil
+}
+
+// tierSupported checks whether target is present in the tiers slice.
+func tierSupported(tiers []pkgcatalog.HardwareTier, target pkgcatalog.HardwareTier) bool {
+	for i := range tiers {
+		if tiers[i] == target {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/catalog/engine_test.go
+++ b/internal/catalog/engine_test.go
@@ -1,0 +1,139 @@
+package catalog
+
+import (
+	"testing"
+
+	pkgcatalog "github.com/HerbHall/subnetree/pkg/catalog"
+)
+
+func TestEngine_Recommend_Tier0(t *testing.T) {
+	engine := NewEngine(pkgcatalog.NewCatalog())
+	entries, err := engine.Recommend(pkgcatalog.TierSBC)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Tier 0 should exclude tools that only support higher tiers
+	// (Grafana, Prometheus, NetBox all require Tier 1+).
+	for i := range entries {
+		if entries[i].Name == "Grafana" || entries[i].Name == "Prometheus" || entries[i].Name == "NetBox" {
+			t.Errorf("tier 0 should not include %s", entries[i].Name)
+		}
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected at least one entry for tier 0")
+	}
+}
+
+func TestEngine_Recommend_Tier1_IncludesAll(t *testing.T) {
+	engine := NewEngine(pkgcatalog.NewCatalog())
+	entries, err := engine.Recommend(pkgcatalog.TierMiniPC)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Tier 1 (Mini PC) supports most tools. Only NAS-only tools excluded.
+	// All 15 entries support tier 1 except none (NAS tier 2 tools also support 1).
+	// Check we get a substantial set.
+	if len(entries) < 12 {
+		t.Errorf("expected at least 12 entries for tier 1, got %d", len(entries))
+	}
+}
+
+func TestEngine_Recommend_SortedByRAM(t *testing.T) {
+	engine := NewEngine(pkgcatalog.NewCatalog())
+	entries, err := engine.Recommend(pkgcatalog.TierMiniPC)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for i := 1; i < len(entries); i++ {
+		if entries[i].MinRAMMB < entries[i-1].MinRAMMB {
+			t.Errorf("entries not sorted by RAM: %s (%d MB) before %s (%d MB)",
+				entries[i-1].Name, entries[i-1].MinRAMMB,
+				entries[i].Name, entries[i].MinRAMMB)
+		}
+	}
+}
+
+func TestEngine_RecommendByCategory(t *testing.T) {
+	engine := NewEngine(pkgcatalog.NewCatalog())
+	entries, err := engine.RecommendByCategory(pkgcatalog.TierMiniPC, pkgcatalog.CategoryMonitoring)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(entries) == 0 {
+		t.Fatal("expected monitoring entries for tier 1")
+	}
+	for i := range entries {
+		if entries[i].Category != pkgcatalog.CategoryMonitoring {
+			t.Errorf("expected category monitoring, got %s for %s", entries[i].Category, entries[i].Name)
+		}
+	}
+}
+
+func TestEngine_Recommend_NAS_OnlyLightweight(t *testing.T) {
+	engine := NewEngine(pkgcatalog.NewCatalog())
+	entries, err := engine.Recommend(pkgcatalog.TierNAS)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// NAS tier should only include tools that explicitly support tier 2.
+	for i := range entries {
+		if !tierSupported(entries[i].SupportedTiers, pkgcatalog.TierNAS) {
+			t.Errorf("tier NAS should not include %s", entries[i].Name)
+		}
+	}
+
+	// Should be a smaller subset than tier 1.
+	tier1Entries, _ := engine.Recommend(pkgcatalog.TierMiniPC)
+	if len(entries) >= len(tier1Entries) {
+		t.Errorf("NAS tier (%d entries) should be smaller than Mini PC tier (%d entries)",
+			len(entries), len(tier1Entries))
+	}
+}
+
+func TestTierSupported(t *testing.T) {
+	tests := []struct {
+		name   string
+		tiers  []pkgcatalog.HardwareTier
+		target pkgcatalog.HardwareTier
+		want   bool
+	}{
+		{
+			name:   "present",
+			tiers:  []pkgcatalog.HardwareTier{0, 1, 3, 4},
+			target: 1,
+			want:   true,
+		},
+		{
+			name:   "absent",
+			tiers:  []pkgcatalog.HardwareTier{0, 1, 3, 4},
+			target: 2,
+			want:   false,
+		},
+		{
+			name:   "empty",
+			tiers:  []pkgcatalog.HardwareTier{},
+			target: 0,
+			want:   false,
+		},
+		{
+			name:   "all tiers",
+			tiers:  []pkgcatalog.HardwareTier{0, 1, 2, 3, 4},
+			target: 3,
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tierSupported(tt.tiers, tt.target)
+			if got != tt.want {
+				t.Errorf("tierSupported(%v, %d) = %v, want %v", tt.tiers, tt.target, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/catalog/handler.go
+++ b/internal/catalog/handler.go
@@ -1,0 +1,134 @@
+package catalog
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	pkgcatalog "github.com/HerbHall/subnetree/pkg/catalog"
+	"go.uber.org/zap"
+)
+
+// RecommendationResponse is the response for GET /api/v1/catalog/recommendations.
+type RecommendationResponse struct {
+	Tier    int                       `json:"tier"`
+	Count   int                       `json:"count"`
+	Entries []pkgcatalog.CatalogEntry `json:"entries"`
+}
+
+// Handler serves the catalog recommendation API.
+type Handler struct {
+	engine *Engine
+	logger *zap.Logger
+}
+
+// NewHandler creates a new catalog API handler.
+func NewHandler(engine *Engine, logger *zap.Logger) *Handler {
+	return &Handler{engine: engine, logger: logger}
+}
+
+// RegisterRoutes implements server.SimpleRouteRegistrar.
+func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/v1/catalog/recommendations", h.handleRecommendations)
+	mux.HandleFunc("GET /api/v1/catalog/entries", h.handleListEntries)
+}
+
+// handleRecommendations returns recommended tools for a hardware tier.
+//
+//	@Summary		Get tool recommendations
+//	@Description	Returns recommended homelab tools filtered by hardware tier and optional category, sorted by memory requirements ascending.
+//	@Tags			catalog
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			tier query int false "Hardware tier (0=SBC, 1=Mini PC, 2=NAS, 3=Cluster, 4=SMB)" default(1)
+//	@Param			category query string false "Filter by category (monitoring, infrastructure, dns, etc.)"
+//	@Success		200 {object} RecommendationResponse
+//	@Failure		400 {object} map[string]any
+//	@Failure		500 {object} map[string]any
+//	@Router			/catalog/recommendations [get]
+func (h *Handler) handleRecommendations(w http.ResponseWriter, r *http.Request) {
+	tierStr := r.URL.Query().Get("tier")
+	tier := 1 // default: Mini PC
+	if tierStr != "" {
+		parsed, err := strconv.Atoi(tierStr)
+		if err != nil || parsed < 0 || parsed > 4 {
+			writeError(w, http.StatusBadRequest, "tier must be an integer between 0 and 4")
+			return
+		}
+		tier = parsed
+	}
+
+	category := r.URL.Query().Get("category")
+
+	var entries []pkgcatalog.CatalogEntry
+	var err error
+
+	if category != "" {
+		entries, err = h.engine.RecommendByCategory(
+			pkgcatalog.HardwareTier(tier),
+			pkgcatalog.Category(category),
+		)
+	} else {
+		entries, err = h.engine.Recommend(pkgcatalog.HardwareTier(tier))
+	}
+
+	if err != nil {
+		h.logger.Error("failed to get recommendations", zap.Error(err))
+		writeError(w, http.StatusInternalServerError, "failed to load catalog")
+		return
+	}
+
+	if entries == nil {
+		entries = []pkgcatalog.CatalogEntry{}
+	}
+
+	writeJSON(w, http.StatusOK, RecommendationResponse{
+		Tier:    tier,
+		Count:   len(entries),
+		Entries: entries,
+	})
+}
+
+// handleListEntries returns all catalog entries.
+//
+//	@Summary		List all catalog entries
+//	@Description	Returns the full tool catalog for client-side filtering.
+//	@Tags			catalog
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Success		200 {array} pkgcatalog.CatalogEntry
+//	@Failure		500 {object} map[string]any
+//	@Router			/catalog/entries [get]
+func (h *Handler) handleListEntries(w http.ResponseWriter, r *http.Request) {
+	entries, err := h.engine.cat.Entries()
+	if err != nil {
+		h.logger.Error("failed to load catalog", zap.Error(err))
+		writeError(w, http.StatusInternalServerError, "failed to load catalog")
+		return
+	}
+
+	if entries == nil {
+		entries = []pkgcatalog.CatalogEntry{}
+	}
+
+	writeJSON(w, http.StatusOK, entries)
+}
+
+// -- helpers --
+
+func writeJSON(w http.ResponseWriter, status int, data any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(data)
+}
+
+func writeError(w http.ResponseWriter, status int, detail string) {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"type":   "https://subnetree.com/problems/" + http.StatusText(status),
+		"title":  http.StatusText(status),
+		"status": status,
+		"detail": detail,
+	})
+}

--- a/internal/catalog/handler_test.go
+++ b/internal/catalog/handler_test.go
@@ -1,0 +1,155 @@
+package catalog
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	pkgcatalog "github.com/HerbHall/subnetree/pkg/catalog"
+	"go.uber.org/zap"
+)
+
+func newTestHandler(t *testing.T) *Handler {
+	t.Helper()
+	cat := pkgcatalog.NewCatalog()
+	engine := NewEngine(cat)
+	return NewHandler(engine, zap.NewNop())
+}
+
+func TestHandleRecommendations_DefaultTier(t *testing.T) {
+	h := newTestHandler(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/catalog/recommendations", http.NoBody)
+	rec := httptest.NewRecorder()
+
+	h.handleRecommendations(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+
+	var resp RecommendationResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.Tier != 1 {
+		t.Errorf("expected default tier 1, got %d", resp.Tier)
+	}
+	if resp.Count == 0 {
+		t.Error("expected non-zero count for default tier")
+	}
+	if resp.Count != len(resp.Entries) {
+		t.Errorf("count (%d) does not match entries length (%d)", resp.Count, len(resp.Entries))
+	}
+}
+
+func TestHandleRecommendations_SpecificTier(t *testing.T) {
+	h := newTestHandler(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/catalog/recommendations?tier=0", http.NoBody)
+	rec := httptest.NewRecorder()
+
+	h.handleRecommendations(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+
+	var resp RecommendationResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.Tier != 0 {
+		t.Errorf("expected tier 0, got %d", resp.Tier)
+	}
+
+	// Tier 0 should have fewer entries than tier 1 (some tools excluded).
+	h2 := newTestHandler(t)
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/catalog/recommendations?tier=1", http.NoBody)
+	rec2 := httptest.NewRecorder()
+	h2.handleRecommendations(rec2, req2)
+
+	var resp2 RecommendationResponse
+	if err := json.NewDecoder(rec2.Body).Decode(&resp2); err != nil {
+		t.Fatalf("failed to decode tier 1 response: %v", err)
+	}
+
+	if resp.Count >= resp2.Count {
+		t.Errorf("tier 0 (%d entries) should have fewer entries than tier 1 (%d entries)",
+			resp.Count, resp2.Count)
+	}
+}
+
+func TestHandleRecommendations_InvalidTier(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{name: "negative", query: "?tier=-1"},
+		{name: "too high", query: "?tier=5"},
+		{name: "non-numeric", query: "?tier=abc"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newTestHandler(t)
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/catalog/recommendations"+tt.query, http.NoBody)
+			rec := httptest.NewRecorder()
+
+			h.handleRecommendations(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("expected status 400, got %d", rec.Code)
+			}
+		})
+	}
+}
+
+func TestHandleRecommendations_CategoryFilter(t *testing.T) {
+	h := newTestHandler(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/catalog/recommendations?tier=1&category=monitoring", http.NoBody)
+	rec := httptest.NewRecorder()
+
+	h.handleRecommendations(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+
+	var resp RecommendationResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.Count == 0 {
+		t.Fatal("expected monitoring entries for tier 1")
+	}
+	for i := range resp.Entries {
+		if resp.Entries[i].Category != pkgcatalog.CategoryMonitoring {
+			t.Errorf("entry %s has category %s, expected monitoring",
+				resp.Entries[i].Name, resp.Entries[i].Category)
+		}
+	}
+}
+
+func TestHandleListEntries(t *testing.T) {
+	h := newTestHandler(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/catalog/entries", http.NoBody)
+	rec := httptest.NewRecorder()
+
+	h.handleListEntries(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+
+	var entries []pkgcatalog.CatalogEntry
+	if err := json.NewDecoder(rec.Body).Decode(&entries); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(entries) != 15 {
+		t.Errorf("expected 15 entries, got %d", len(entries))
+	}
+}

--- a/pkg/catalog/catalog.yaml
+++ b/pkg/catalog/catalog.yaml
@@ -1,0 +1,240 @@
+entries:
+  - name: "Home Assistant"
+    description: "Open-source home automation platform with thousands of integrations for smart devices."
+    category: "home-automation"
+    github_url: "https://github.com/home-assistant/core"
+    website: "https://www.home-assistant.io"
+    docker_image: "ghcr.io/home-assistant/home-assistant"
+    stars: 84825
+    license: "Apache-2.0"
+    language: "Python"
+    min_ram_mb: 200
+    supported_tiers: [0, 1, 3, 4]
+    protocols: ["REST", "MQTT", "webhooks"]
+    integration_status: "planned"
+    integration_notes: "MQTT publisher planned for v0.5.0 (#298)"
+    tags: ["iot", "smart-home", "automation"]
+
+  - name: "Uptime Kuma"
+    description: "Self-hosted monitoring tool with beautiful status pages and notification integrations."
+    category: "monitoring"
+    github_url: "https://github.com/louislam/uptime-kuma"
+    website: "https://uptime.kuma.pet"
+    docker_image: "louislam/uptime-kuma"
+    stars: 82832
+    license: "MIT"
+    language: "JavaScript"
+    min_ram_mb: 50
+    supported_tiers: [0, 1, 2, 3, 4]
+    protocols: ["REST", "webhooks"]
+    integration_status: "possible"
+    integration_notes: "Webhook bridge for bidirectional status sync"
+    tags: ["uptime", "status-page", "alerts"]
+
+  - name: "Grafana"
+    description: "Observability platform for metrics visualization with dashboards and alerting."
+    category: "monitoring"
+    github_url: "https://github.com/grafana/grafana"
+    website: "https://grafana.com"
+    docker_image: "grafana/grafana"
+    stars: 72139
+    license: "AGPL-3.0"
+    language: "TypeScript"
+    min_ram_mb: 50
+    supported_tiers: [1, 3, 4]
+    protocols: ["Prometheus", "REST"]
+    integration_status: "planned"
+    integration_notes: "Dashboard provisioning bundle planned for Phase 3"
+    tags: ["visualization", "dashboards", "alerting"]
+
+  - name: "Prometheus"
+    description: "Time-series monitoring system with powerful query language and alerting rules."
+    category: "monitoring"
+    github_url: "https://github.com/prometheus/prometheus"
+    website: "https://prometheus.io"
+    docker_image: "prom/prometheus"
+    stars: 62705
+    license: "Apache-2.0"
+    language: "Go"
+    min_ram_mb: 100
+    supported_tiers: [1, 3, 4]
+    protocols: ["Prometheus", "REST"]
+    integration_status: "shipped"
+    integration_notes: "SubNetree ships /metrics endpoint compatible with Prometheus scraping"
+    tags: ["metrics", "time-series", "alerting"]
+
+  - name: "Traefik"
+    description: "Cloud-native reverse proxy and load balancer with automatic service discovery."
+    category: "infrastructure"
+    github_url: "https://github.com/traefik/traefik"
+    website: "https://traefik.io"
+    docker_image: "traefik/traefik"
+    stars: 61650
+    license: "MIT"
+    language: "Go"
+    min_ram_mb: 30
+    supported_tiers: [0, 1, 3, 4]
+    protocols: ["REST"]
+    integration_status: "possible"
+    integration_notes: "Auto-discovery of Traefik-managed services via API"
+    tags: ["reverse-proxy", "load-balancer", "ingress"]
+
+  - name: "Pi-hole"
+    description: "Network-wide ad blocker and DNS sinkhole for your entire network."
+    category: "dns"
+    github_url: "https://github.com/pi-hole/pi-hole"
+    website: "https://pi-hole.net"
+    docker_image: "pihole/pihole"
+    stars: 55705
+    license: "EUPL-1.2"
+    language: "Shell"
+    min_ram_mb: 50
+    supported_tiers: [0, 1, 2, 3, 4]
+    protocols: ["REST"]
+    integration_status: "possible"
+    integration_notes: "DNS query stats and client discovery via Pi-hole API"
+    tags: ["dns", "ad-blocking", "privacy"]
+
+  - name: "Portainer"
+    description: "Container management platform with a web UI for Docker and Kubernetes."
+    category: "infrastructure"
+    github_url: "https://github.com/portainer/portainer"
+    website: "https://www.portainer.io"
+    docker_image: "portainer/portainer-ce"
+    stars: 36569
+    license: "Zlib"
+    language: "TypeScript"
+    min_ram_mb: 50
+    supported_tiers: [0, 1, 3, 4]
+    protocols: ["REST"]
+    integration_status: "possible"
+    integration_notes: "Container inventory correlation via Portainer API"
+    tags: ["containers", "docker", "kubernetes"]
+
+  - name: "AdGuard Home"
+    description: "Network-wide ad and tracker blocking DNS server with parental controls."
+    category: "dns"
+    github_url: "https://github.com/AdguardTeam/AdGuardHome"
+    website: "https://adguard.com/adguard-home.html"
+    docker_image: "adguard/adguardhome"
+    stars: 32582
+    license: "GPL-3.0"
+    language: "Go"
+    min_ram_mb: 30
+    supported_tiers: [0, 1, 2, 3, 4]
+    protocols: ["REST"]
+    integration_status: "possible"
+    integration_notes: "DNS client discovery and query analytics via AdGuard API"
+    tags: ["dns", "ad-blocking", "privacy"]
+
+  - name: "Nginx Proxy Manager"
+    description: "Easy-to-use reverse proxy with free SSL certificates and a web-based management UI."
+    category: "infrastructure"
+    github_url: "https://github.com/NginxProxyManager/nginx-proxy-manager"
+    website: "https://nginxproxymanager.com"
+    docker_image: "jc21/nginx-proxy-manager"
+    stars: 31673
+    license: "MIT"
+    language: "TypeScript"
+    min_ram_mb: 50
+    supported_tiers: [0, 1, 3, 4]
+    protocols: ["REST"]
+    integration_status: "possible"
+    integration_notes: "Proxy host discovery via NPM API"
+    tags: ["reverse-proxy", "ssl", "nginx"]
+
+  - name: "ntfy"
+    description: "Simple HTTP-based pub-sub notification service for sending push notifications."
+    category: "notifications"
+    github_url: "https://github.com/binwiederhier/ntfy"
+    website: "https://ntfy.sh"
+    docker_image: "binwiederhier/ntfy"
+    stars: 28763
+    license: "Apache-2.0"
+    language: "Go"
+    min_ram_mb: 10
+    supported_tiers: [0, 1, 2, 3, 4]
+    protocols: ["REST", "webhooks"]
+    integration_status: "planned"
+    integration_notes: "Alert forwarding planned for v0.5.0"
+    tags: ["notifications", "push", "alerts"]
+
+  - name: "Homepage"
+    description: "Highly customizable application dashboard with service health monitoring widgets."
+    category: "dashboard"
+    github_url: "https://github.com/gethomepage/homepage"
+    website: "https://gethomepage.dev"
+    docker_image: "ghcr.io/gethomepage/homepage"
+    stars: 28412
+    license: "GPL-3.0"
+    language: "JavaScript"
+    min_ram_mb: 50
+    supported_tiers: [0, 1, 3, 4]
+    protocols: ["REST"]
+    integration_status: "possible"
+    integration_notes: "SubNetree widget for Homepage via REST API"
+    tags: ["dashboard", "startpage", "widgets"]
+
+  - name: "NetBox"
+    description: "Infrastructure resource modeling application for IP address management and DCIM."
+    category: "cmdb"
+    github_url: "https://github.com/netbox-community/netbox"
+    website: "https://netbox.dev"
+    docker_image: "netboxcommunity/netbox"
+    stars: 19800
+    license: "Apache-2.0"
+    language: "Python"
+    min_ram_mb: 500
+    supported_tiers: [1, 3, 4]
+    protocols: ["REST", "webhooks"]
+    integration_status: "planned"
+    integration_notes: "Device export planned for Phase 3"
+    tags: ["ipam", "dcim", "inventory"]
+
+  - name: "Beszel"
+    description: "Lightweight server monitoring hub with Docker stats and automatic alerts."
+    category: "monitoring"
+    github_url: "https://github.com/henrygd/beszel"
+    website: "https://beszel.dev"
+    docker_image: "henrygd/beszel"
+    stars: 19358
+    license: "MIT"
+    language: "Go"
+    min_ram_mb: 23
+    supported_tiers: [0, 1, 2, 3, 4]
+    protocols: ["REST"]
+    integration_status: "possible"
+    integration_notes: "Metric correlation via Beszel API"
+    tags: ["monitoring", "docker", "lightweight"]
+
+  - name: "BookStack"
+    description: "Simple wiki and documentation platform organized into books, chapters, and pages."
+    category: "documentation"
+    github_url: "https://github.com/BookStackApp/BookStack"
+    website: "https://www.bookstackapp.com"
+    docker_image: "lscr.io/linuxserver/bookstack"
+    stars: 18256
+    license: "MIT"
+    language: "PHP"
+    min_ram_mb: 100
+    supported_tiers: [0, 1, 3, 4]
+    protocols: ["REST"]
+    integration_status: "planned"
+    integration_notes: "Documentation generation planned for Phase 3"
+    tags: ["wiki", "documentation", "knowledge-base"]
+
+  - name: "NetAlertX"
+    description: "Network presence and intruder detection scanner with device tracking and alerts."
+    category: "network"
+    github_url: "https://github.com/jokob-sk/NetAlertX"
+    website: "https://netalertx.com"
+    docker_image: "jokobsk/netalertx"
+    stars: 5787
+    license: "GPL-3.0"
+    language: "Python"
+    min_ram_mb: 100
+    supported_tiers: [0, 1, 3, 4]
+    protocols: ["REST", "webhooks"]
+    integration_status: "possible"
+    integration_notes: "Device discovery data sharing via REST APIs"
+    tags: ["network", "scanner", "intrusion-detection"]

--- a/pkg/catalog/loader.go
+++ b/pkg/catalog/loader.go
@@ -1,0 +1,50 @@
+package catalog
+
+import (
+	_ "embed"
+	"fmt"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed catalog.yaml
+var catalogRawData []byte
+
+// catalogFile is the top-level structure of the embedded YAML.
+type catalogFile struct {
+	Entries []CatalogEntry `yaml:"entries"`
+}
+
+// Catalog provides lazy-loaded access to the embedded tool catalog.
+type Catalog struct {
+	once    sync.Once
+	entries []CatalogEntry
+	err     error
+}
+
+// NewCatalog creates a new Catalog that will parse the embedded YAML on first access.
+func NewCatalog() *Catalog {
+	return &Catalog{}
+}
+
+// Entries returns a copy of all catalog entries.
+func (c *Catalog) Entries() ([]CatalogEntry, error) {
+	c.once.Do(c.load)
+	if c.err != nil {
+		return nil, c.err
+	}
+	cp := make([]CatalogEntry, len(c.entries))
+	copy(cp, c.entries)
+	return cp, nil
+}
+
+// load parses the embedded YAML catalog data.
+func (c *Catalog) load() {
+	var f catalogFile
+	if err := yaml.Unmarshal(catalogRawData, &f); err != nil {
+		c.err = fmt.Errorf("catalog: parse yaml: %w", err)
+		return
+	}
+	c.entries = f.Entries
+}

--- a/pkg/catalog/loader_test.go
+++ b/pkg/catalog/loader_test.go
@@ -1,0 +1,111 @@
+package catalog
+
+import (
+	"testing"
+)
+
+func TestCatalog_LoadsSuccessfully(t *testing.T) {
+	cat := NewCatalog()
+	entries, err := cat.Entries()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 15 {
+		t.Fatalf("expected 15 entries, got %d", len(entries))
+	}
+}
+
+func TestCatalog_AllEntriesHaveRequiredFields(t *testing.T) {
+	cat := NewCatalog()
+	entries, err := cat.Entries()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for i := range entries {
+		e := &entries[i]
+		if e.Name == "" {
+			t.Errorf("entry %d: missing name", i)
+		}
+		if e.Description == "" {
+			t.Errorf("entry %d (%s): missing description", i, e.Name)
+		}
+		if e.Category == "" {
+			t.Errorf("entry %d (%s): missing category", i, e.Name)
+		}
+		if e.GitHubURL == "" {
+			t.Errorf("entry %d (%s): missing github_url", i, e.Name)
+		}
+		if e.DockerImage == "" {
+			t.Errorf("entry %d (%s): missing docker_image", i, e.Name)
+		}
+		if e.Stars <= 0 {
+			t.Errorf("entry %d (%s): stars must be positive, got %d", i, e.Name, e.Stars)
+		}
+		if e.License == "" {
+			t.Errorf("entry %d (%s): missing license", i, e.Name)
+		}
+		if e.Language == "" {
+			t.Errorf("entry %d (%s): missing language", i, e.Name)
+		}
+		if e.MinRAMMB <= 0 {
+			t.Errorf("entry %d (%s): min_ram_mb must be positive, got %d", i, e.Name, e.MinRAMMB)
+		}
+		if len(e.SupportedTiers) == 0 {
+			t.Errorf("entry %d (%s): missing supported_tiers", i, e.Name)
+		}
+		if e.IntegrationStatus == "" {
+			t.Errorf("entry %d (%s): missing integration_status", i, e.Name)
+		}
+	}
+}
+
+func TestCatalog_TierRangesValid(t *testing.T) {
+	cat := NewCatalog()
+	entries, err := cat.Entries()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for i := range entries {
+		e := &entries[i]
+		for _, tier := range e.SupportedTiers {
+			if tier < 0 || tier > 4 {
+				t.Errorf("entry %d (%s): invalid tier %d (must be 0-4)", i, e.Name, tier)
+			}
+		}
+	}
+}
+
+func TestCatalog_NoDuplicateNames(t *testing.T) {
+	cat := NewCatalog()
+	entries, err := cat.Entries()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	seen := make(map[string]bool, len(entries))
+	for i := range entries {
+		name := entries[i].Name
+		if seen[name] {
+			t.Errorf("duplicate entry name: %s", name)
+		}
+		seen[name] = true
+	}
+}
+
+func TestCatalog_ReturnsCopy(t *testing.T) {
+	cat := NewCatalog()
+	entries1, err := cat.Entries()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	entries2, err := cat.Entries()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Mutate the first slice and verify the second is unaffected.
+	original := entries1[0].Name
+	entries1[0].Name = "MUTATED"
+	if entries2[0].Name != original {
+		t.Errorf("Entries() did not return a copy: mutation leaked")
+	}
+}

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -1,0 +1,57 @@
+// Package catalog provides a curated catalog of complementary homelab tools
+// with hardware-tier filtering for SubNetree's recommendation engine.
+package catalog
+
+// HardwareTier represents a target deployment environment.
+type HardwareTier int
+
+const (
+	TierSBC     HardwareTier = 0 // Pi, SBC (1 GB)
+	TierMiniPC  HardwareTier = 1 // Intel N100 (8-32 GB)
+	TierNAS     HardwareTier = 2 // Synology/QNAP (Scout only)
+	TierCluster HardwareTier = 3 // Proxmox cluster
+	TierSMB     HardwareTier = 4 // Small business server
+)
+
+// Category groups tools by their primary function.
+type Category string
+
+const (
+	CategoryMonitoring     Category = "monitoring"
+	CategoryInfrastructure Category = "infrastructure"
+	CategoryDNS            Category = "dns"
+	CategoryHomeAutomation Category = "home-automation"
+	CategoryNotifications  Category = "notifications"
+	CategoryDashboard      Category = "dashboard"
+	CategoryCMDB           Category = "cmdb"
+	CategoryDocumentation  Category = "documentation"
+	CategoryNetwork        Category = "network"
+)
+
+// IntegrationStatus describes how a tool integrates with SubNetree.
+type IntegrationStatus string
+
+const (
+	IntegrationShipped  IntegrationStatus = "shipped"  // Already works
+	IntegrationPlanned  IntegrationStatus = "planned"  // On roadmap
+	IntegrationPossible IntegrationStatus = "possible" // Feasible, not scheduled
+)
+
+// CatalogEntry represents a single tool in the recommendation catalog.
+type CatalogEntry struct {
+	Name              string            `yaml:"name" json:"name"`
+	Description       string            `yaml:"description" json:"description"`
+	Category          Category          `yaml:"category" json:"category"`
+	GitHubURL         string            `yaml:"github_url" json:"github_url"`
+	Website           string            `yaml:"website" json:"website"`
+	DockerImage       string            `yaml:"docker_image" json:"docker_image"`
+	Stars             int               `yaml:"stars" json:"stars"`
+	License           string            `yaml:"license" json:"license"`
+	Language          string            `yaml:"language" json:"language"`
+	MinRAMMB          int               `yaml:"min_ram_mb" json:"min_ram_mb"`
+	SupportedTiers    []HardwareTier    `yaml:"supported_tiers" json:"supported_tiers"`
+	Protocols         []string          `yaml:"protocols" json:"protocols"`
+	IntegrationStatus IntegrationStatus `yaml:"integration_status" json:"integration_status"`
+	IntegrationNotes  string            `yaml:"integration_notes" json:"integration_notes"`
+	Tags              []string          `yaml:"tags" json:"tags"`
+}


### PR DESCRIPTION
## Summary

- Adds a curated YAML catalog of 15 homelab tools embedded via `//go:embed` with `sync.Once` lazy loading
- Implements tier-aware recommendation engine that filters tools by hardware tier (0-4) and category
- Exposes two new API endpoints: `GET /api/v1/catalog/recommendations` and `GET /api/v1/catalog/entries`

### Architecture

- `pkg/catalog/` -- Public types, embedded YAML data, loader (Apache 2.0 compatible)
- `internal/catalog/` -- Private engine (filtering/sorting) and HTTP handler
- Wired as `SimpleRouteRegistrar` in main.go (3-line addition)

### The 15 Tools

Home Assistant, Uptime Kuma, Grafana, Prometheus, Traefik, Pi-hole, Portainer, AdGuard Home, Nginx Proxy Manager, ntfy, Homepage, NetBox, Beszel, BookStack, NetAlertX

### API

- `GET /api/v1/catalog/recommendations?tier=N&category=X` -- filtered, sorted by RAM ascending
- `GET /api/v1/catalog/entries` -- full catalog for client-side filtering
- Default tier: 1 (Mini PC, 48.4% of market per hardware tier research)

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./pkg/catalog/... ./internal/catalog/... -race -v` -- 22 tests pass
- [x] `golangci-lint run` -- zero issues
- [x] Swagger spec regenerated with new catalog types
- [ ] CI passes (build, test, lint, swagger drift check)

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)