### PR TITLE
feat: tier-aware default configuration

### DIFF
--- a/cmd/subnetree/main.go
+++ b/cmd/subnetree/main.go
@@ -40,6 +40,7 @@ import (
 	"github.com/HerbHall/subnetree/internal/settings"
 	"github.com/HerbHall/subnetree/internal/store"
 	"github.com/HerbHall/subnetree/internal/svcmap"
+	"github.com/HerbHall/subnetree/internal/tier"
 	"github.com/HerbHall/subnetree/internal/vault"
 	"github.com/HerbHall/subnetree/internal/version"
 	"github.com/HerbHall/subnetree/internal/webhook"
@@ -82,6 +83,10 @@ func main() {
 	}
 	cfg := config.New(viperCfg)
 
+	// Detect hardware tier and apply tier-specific defaults.
+	detectedTier := tier.DetectTier()
+	tier.ApplyDefaults(viperCfg, detectedTier)
+
 	// Initialize logger from configuration.
 	logger, err := config.NewLogger(viperCfg)
 	if err != nil {
@@ -91,6 +96,11 @@ func main() {
 	defer func() { _ = logger.Sync() }()
 
 	logger.Info("SubNetree server starting", zap.String("version", version.Short()))
+
+	logger.Info("hardware tier detected",
+		zap.Int("tier", int(detectedTier)),
+		zap.String("tier_name", tier.Name(detectedTier)),
+	)
 
 	if f := viperCfg.ConfigFileUsed(); f != "" {
 		logger.Info("configuration loaded",

--- a/internal/tier/defaults.go
+++ b/internal/tier/defaults.go
@@ -1,0 +1,50 @@
+package tier
+
+import (
+	"github.com/HerbHall/subnetree/pkg/catalog"
+	"github.com/spf13/viper"
+)
+
+// TierDefaults maps hardware tiers to configuration overrides.
+// These are applied ONLY for keys not already set by user config.
+var TierDefaults = map[catalog.HardwareTier]map[string]any{
+	catalog.TierSBC: {
+		"plugins.pulse.check_interval": "5m",
+		"plugins.pulse.max_workers":    2,
+		"plugins.recon.scan_interval":  "5m",
+		"data_retention_days":          7,
+		"plugins.insight.enabled":      false,
+		"plugins.llm.enabled":          false,
+	},
+	catalog.TierMiniPC: {
+		"plugins.pulse.check_interval": "2m",
+		"plugins.pulse.max_workers":    5,
+		"plugins.recon.scan_interval":  "2m",
+		"data_retention_days":          30,
+	},
+	catalog.TierCluster: {
+		"plugins.pulse.check_interval": "1m",
+		"plugins.pulse.max_workers":    10,
+		"plugins.recon.scan_interval":  "1m",
+		"data_retention_days":          90,
+	},
+	catalog.TierSMB: {
+		"plugins.pulse.check_interval": "1m",
+		"plugins.pulse.max_workers":    10,
+		"plugins.recon.scan_interval":  "1m",
+		"data_retention_days":          180,
+	},
+}
+
+// ApplyDefaults sets tier-specific defaults for keys not already configured by the user.
+func ApplyDefaults(v *viper.Viper, t catalog.HardwareTier) {
+	defaults, ok := TierDefaults[t]
+	if !ok {
+		return
+	}
+	for key, val := range defaults {
+		if !v.IsSet(key) {
+			v.SetDefault(key, val)
+		}
+	}
+}

--- a/internal/tier/detector.go
+++ b/internal/tier/detector.go
@@ -1,0 +1,56 @@
+package tier
+
+import (
+	"runtime"
+
+	"github.com/HerbHall/subnetree/pkg/catalog"
+)
+
+const (
+	gb = 1024 * 1024 * 1024 // bytes in a gigabyte
+)
+
+// DetectTier determines the hardware tier based on system resources.
+func DetectTier() catalog.HardwareTier {
+	totalRAM := getSystemRAMBytes()
+	arch := runtime.GOARCH
+	cores := runtime.NumCPU()
+
+	return DetectTierWithRAM(totalRAM, arch, cores)
+}
+
+// Name returns a human-readable name for a hardware tier.
+func Name(t catalog.HardwareTier) string {
+	switch t {
+	case catalog.TierSBC:
+		return "SBC"
+	case catalog.TierMiniPC:
+		return "Mini PC"
+	case catalog.TierNAS:
+		return "NAS"
+	case catalog.TierCluster:
+		return "Cluster"
+	case catalog.TierSMB:
+		return "SMB Server"
+	default:
+		return "Unknown"
+	}
+}
+
+// DetectTierWithRAM is exported for testing -- allows injecting RAM value.
+func DetectTierWithRAM(ramBytes uint64, arch string, cores int) catalog.HardwareTier {
+	isARM := arch == "arm" || arch == "arm64"
+
+	switch {
+	case isARM && ramBytes < 8*gb:
+		return catalog.TierSBC
+	case ramBytes < 8*gb:
+		return catalog.TierSBC
+	case ramBytes <= 32*gb:
+		return catalog.TierMiniPC
+	case ramBytes <= 64*gb && cores <= 16:
+		return catalog.TierCluster
+	default:
+		return catalog.TierSMB
+	}
+}

--- a/internal/tier/detector_linux.go
+++ b/internal/tier/detector_linux.go
@@ -1,0 +1,36 @@
+//go:build linux
+
+package tier
+
+import (
+	"bufio"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func getSystemRAMBytes() uint64 {
+	f, err := os.Open("/proc/meminfo")
+	if err != nil {
+		return 0
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "MemTotal:") {
+			fields := strings.Fields(line)
+			if len(fields) < 2 {
+				return 0
+			}
+			kb, parseErr := strconv.ParseUint(fields[1], 10, 64)
+			if parseErr != nil {
+				return 0
+			}
+			return kb * 1024 // Convert kB to bytes
+		}
+	}
+
+	return 0
+}

--- a/internal/tier/detector_other.go
+++ b/internal/tier/detector_other.go
@@ -1,0 +1,7 @@
+//go:build !linux && !windows
+
+package tier
+
+func getSystemRAMBytes() uint64 {
+	return 0 // Unknown platform; defaults to TierSBC (conservative)
+}

--- a/internal/tier/detector_test.go
+++ b/internal/tier/detector_test.go
@@ -1,0 +1,137 @@
+package tier
+
+import (
+	"testing"
+
+	"github.com/HerbHall/subnetree/pkg/catalog"
+	"github.com/spf13/viper"
+)
+
+func TestDetectTierWithRAM(t *testing.T) {
+	tests := []struct {
+		name     string
+		ramBytes uint64
+		arch     string
+		cores    int
+		want     catalog.HardwareTier
+	}{
+		{
+			name:     "ARM 2GB -> TierSBC",
+			ramBytes: 2 * gb,
+			arch:     "arm64",
+			cores:    4,
+			want:     catalog.TierSBC,
+		},
+		{
+			name:     "x86 4GB -> TierSBC",
+			ramBytes: 4 * gb,
+			arch:     "amd64",
+			cores:    4,
+			want:     catalog.TierSBC,
+		},
+		{
+			name:     "x86 16GB -> TierMiniPC",
+			ramBytes: 16 * gb,
+			arch:     "amd64",
+			cores:    4,
+			want:     catalog.TierMiniPC,
+		},
+		{
+			name:     "x86 64GB 8 cores -> TierCluster",
+			ramBytes: 64 * gb,
+			arch:     "amd64",
+			cores:    8,
+			want:     catalog.TierCluster,
+		},
+		{
+			name:     "x86 128GB -> TierSMB",
+			ramBytes: 128 * gb,
+			arch:     "amd64",
+			cores:    32,
+			want:     catalog.TierSMB,
+		},
+		{
+			name:     "zero RAM -> TierSBC",
+			ramBytes: 0,
+			arch:     "amd64",
+			cores:    4,
+			want:     catalog.TierSBC,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DetectTierWithRAM(tt.ramBytes, tt.arch, tt.cores)
+			if got != tt.want {
+				t.Errorf("DetectTierWithRAM(%d, %q, %d) = %d, want %d", tt.ramBytes, tt.arch, tt.cores, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestName(t *testing.T) {
+	tests := []struct {
+		tier catalog.HardwareTier
+		want string
+	}{
+		{catalog.TierSBC, "SBC"},
+		{catalog.TierMiniPC, "Mini PC"},
+		{catalog.TierNAS, "NAS"},
+		{catalog.TierCluster, "Cluster"},
+		{catalog.TierSMB, "SMB Server"},
+		{catalog.HardwareTier(99), "Unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := Name(tt.tier); got != tt.want {
+				t.Errorf("Name(%d) = %q, want %q", tt.tier, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyDefaults_DoesNotOverrideUserConfig(t *testing.T) {
+	v := viper.New()
+	// User explicitly set a value.
+	v.Set("plugins.pulse.check_interval", "10s")
+	v.Set("plugins.pulse.max_workers", 20)
+
+	ApplyDefaults(v, catalog.TierSBC)
+
+	// User values must be preserved.
+	if got := v.GetString("plugins.pulse.check_interval"); got != "10s" {
+		t.Errorf("check_interval = %q, want %q (user override should be preserved)", got, "10s")
+	}
+	if got := v.GetInt("plugins.pulse.max_workers"); got != 20 {
+		t.Errorf("max_workers = %d, want %d (user override should be preserved)", got, 20)
+	}
+
+	// Tier defaults applied for unset keys.
+	if got := v.GetInt("data_retention_days"); got != 7 {
+		t.Errorf("data_retention_days = %d, want %d (tier default should apply)", got, 7)
+	}
+}
+
+func TestApplyDefaults_SetsDefaultsForUnsetKeys(t *testing.T) {
+	v := viper.New()
+	ApplyDefaults(v, catalog.TierMiniPC)
+
+	if got := v.GetString("plugins.pulse.check_interval"); got != "2m" {
+		t.Errorf("check_interval = %q, want %q", got, "2m")
+	}
+	if got := v.GetInt("plugins.pulse.max_workers"); got != 5 {
+		t.Errorf("max_workers = %d, want %d", got, 5)
+	}
+	if got := v.GetInt("data_retention_days"); got != 30 {
+		t.Errorf("data_retention_days = %d, want %d", got, 30)
+	}
+}
+
+func TestApplyDefaults_UnknownTierIsNoOp(t *testing.T) {
+	v := viper.New()
+	ApplyDefaults(v, catalog.TierNAS) // NAS has no defaults
+
+	if v.IsSet("plugins.pulse.check_interval") {
+		t.Error("expected no defaults set for TierNAS")
+	}
+}

--- a/internal/tier/detector_windows.go
+++ b/internal/tier/detector_windows.go
@@ -1,0 +1,35 @@
+//go:build windows
+
+package tier
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+type memoryStatusEx struct {
+	Length               uint32
+	MemoryLoad           uint32
+	TotalPhys            uint64
+	AvailPhys            uint64
+	TotalPageFile        uint64
+	AvailPageFile        uint64
+	TotalVirtual         uint64
+	AvailVirtual         uint64
+	AvailExtendedVirtual uint64
+}
+
+func getSystemRAMBytes() uint64 {
+	kernel32 := syscall.NewLazyDLL("kernel32.dll")
+	globalMemoryStatusEx := kernel32.NewProc("GlobalMemoryStatusEx")
+
+	var ms memoryStatusEx
+	ms.Length = uint32(unsafe.Sizeof(ms)) //nolint:gosec // G103: unsafe needed for Windows syscall
+
+	ret, _, _ := globalMemoryStatusEx.Call(uintptr(unsafe.Pointer(&ms))) //nolint:gosec // G103: unsafe needed for Windows syscall
+	if ret == 0 {
+		return 0 // fallback
+	}
+
+	return ms.TotalPhys
+}


### PR DESCRIPTION
## Summary

- New `internal/tier/` package that auto-detects hardware tier at startup using RAM, CPU cores, and architecture
- Platform-specific RAM detection: Windows (kernel32 GlobalMemoryStatusEx), Linux (/proc/meminfo), fallback for other platforms
- Five-tier classification: SBC (Tier 0), Mini PC (Tier 1), NAS (Tier 2, Scout-only), Cluster (Tier 3), SMB (Tier 4)
- Applies tier-specific defaults for check intervals, worker counts, data retention, and module enablement
- User configuration always takes precedence over tier defaults (uses `viper.SetDefault`)
- Integrates with the recommendation engine catalog types from `pkg/catalog`

## Test plan

- [x] `go build ./...` compiles
- [x] `go test -race ./internal/tier/...` passes
- [x] `golangci-lint run ./internal/tier/...` clean
- [x] `go vet ./...` clean
- [ ] CI passes

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)