### PR TITLE
feat: elkjs auto-layout for topology visualization

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -44,6 +44,7 @@
     "@xyflow/react": "^12.10.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "elkjs": "^0.11.0",
     "html-to-image": "^1.11.13",
     "jwt-decode": "^4.0.0",
     "lucide-react": "^0.563.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      elkjs:
+        specifier: ^0.11.0
+        version: 0.11.0
       html-to-image:
         specifier: ^1.11.13
         version: 1.11.13
@@ -1346,6 +1349,9 @@ packages:
 
   electron-to-chromium@1.5.283:
     resolution: {integrity: sha512-3vifjt1HgrGW/h76UEeny+adYApveS9dH2h3p57JYzBSXJIKUJAvtmIytDKjcSCt9xHfrNCFJ7gts6vkhuq++w==}
+
+  elkjs@0.11.0:
+    resolution: {integrity: sha512-u4J8h9mwEDaYMqo0RYJpqNMFDoMK7f+pu4GjcV+N8jIC7TRdORgzkfSjTJemhqONFfH6fBI3wpysgWbhgVWIXw==}
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
@@ -3853,6 +3859,8 @@ snapshots:
       gopd: 1.2.0
 
   electron-to-chromium@1.5.283: {}
+
+  elkjs@0.11.0: {}
 
   emoji-regex@9.2.2: {}
 

--- a/web/src/components/__tests__/topology.test.tsx
+++ b/web/src/components/__tests__/topology.test.tsx
@@ -589,6 +589,8 @@ describe('TopologyToolbar', () => {
   const defaultProps = {
     layout: 'circular' as const,
     onLayoutChange: vi.fn(),
+    direction: 'DOWN' as const,
+    onDirectionChange: vi.fn(),
     showMinimap: false,
     onMinimapToggle: vi.fn(),
     flowRef: { current: document.createElement('div') },

--- a/web/src/components/topology/elk-layout.ts
+++ b/web/src/components/topology/elk-layout.ts
@@ -1,0 +1,55 @@
+import ELK, { type ElkNode } from 'elkjs/lib/elk.bundled.js'
+
+import type { DeviceNodeType } from './device-node'
+
+export type ElkDirection = 'DOWN' | 'RIGHT'
+
+const elk = new ELK()
+
+const NODE_WIDTH = 180
+const NODE_HEIGHT = 60
+
+/**
+ * Compute a layered layout for topology nodes using elkjs (Eclipse Layout Kernel).
+ * Returns a new array of nodes with updated positions.
+ */
+export async function elkLayout(
+  nodes: DeviceNodeType[],
+  edges: { id: string; source: string; target: string }[],
+  direction: ElkDirection = 'DOWN'
+): Promise<DeviceNodeType[]> {
+  if (nodes.length === 0) return []
+
+  const graph: ElkNode = {
+    id: 'root',
+    layoutOptions: {
+      'elk.algorithm': 'layered',
+      'elk.direction': direction,
+      'elk.spacing.nodeNode': '80',
+      'elk.layered.spacing.nodeNodeBetweenLayers': '150',
+      'elk.edgeRouting': 'ORTHOGONAL',
+    },
+    children: nodes.map((n) => ({
+      id: n.id,
+      width: NODE_WIDTH,
+      height: NODE_HEIGHT,
+    })),
+    edges: edges.map((e) => ({
+      id: e.id,
+      sources: [e.source],
+      targets: [e.target],
+    })),
+  }
+
+  const layout = await elk.layout(graph)
+
+  const positionMap = new Map<string, { x: number; y: number }>()
+  for (const child of layout.children ?? []) {
+    positionMap.set(child.id, { x: child.x ?? 0, y: child.y ?? 0 })
+  }
+
+  return nodes.map((node) => ({
+    ...node,
+    position: positionMap.get(node.id) ?? node.position,
+  }))
+}

--- a/web/src/components/topology/topology-toolbar.tsx
+++ b/web/src/components/topology/topology-toolbar.tsx
@@ -15,14 +15,19 @@ import {
   Save,
   FolderOpen,
   Trash2,
+  ArrowDown,
+  ArrowRight,
 } from 'lucide-react'
 import type { SavedLayout } from './layout-storage'
+import type { ElkDirection } from './elk-layout'
 
 export type LayoutAlgorithm = 'circular' | 'hierarchical' | 'grid'
 
 interface TopologyToolbarProps {
   layout: LayoutAlgorithm
   onLayoutChange: (layout: LayoutAlgorithm) => void
+  direction: ElkDirection
+  onDirectionChange: (direction: ElkDirection) => void
   showMinimap: boolean
   onMinimapToggle: () => void
   flowRef: RefObject<HTMLDivElement | null>
@@ -53,6 +58,8 @@ function Separator() {
 export const TopologyToolbar = memo(function TopologyToolbar({
   layout,
   onLayoutChange,
+  direction,
+  onDirectionChange,
   showMinimap,
   onMinimapToggle,
   flowRef,
@@ -143,6 +150,22 @@ export const TopologyToolbar = memo(function TopologyToolbar({
           <span className="hidden sm:inline">{label}</span>
         </button>
       ))}
+
+      {/* Direction toggle (only visible for hierarchical layout) */}
+      {layout === 'hierarchical' && (
+        <button
+          onClick={() => onDirectionChange(direction === 'DOWN' ? 'RIGHT' : 'DOWN')}
+          title={direction === 'DOWN' ? 'Switch to horizontal layout' : 'Switch to vertical layout'}
+          className="rounded-md p-1.5 transition-colors hover:bg-[var(--nv-bg-hover)]"
+          style={{ color: 'var(--nv-text-accent)' }}
+        >
+          {direction === 'DOWN' ? (
+            <ArrowDown className="h-3.5 w-3.5" />
+          ) : (
+            <ArrowRight className="h-3.5 w-3.5" />
+          )}
+        </button>
+      )}
 
       <Separator />
 


### PR DESCRIPTION
## Summary

- Replace custom BFS hierarchical layout with elkjs (Eclipse Layout Kernel) for Scanopy-quality topology diagrams
- Add layout direction toggle (top-down / left-right) visible when hierarchical layout is selected
- Keep circular and grid layouts as alternatives
- New `elk-layout.ts` module wraps elkjs with orthogonal edge routing and 80px/150px spacing
- Async layout computation with cancellation support (prevents stale updates)

## Test plan

- [ ] `cd web && pnpm build` passes
- [ ] `cd web && pnpm run lint` passes with 0 errors
- [ ] Topology page renders with elkjs hierarchical layout
- [ ] Direction toggle switches between top-down and left-right
- [ ] Circular and grid layouts still work unchanged

Closes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)