### PR TITLE
docs: Wave 0 research - WebSocket ADR, competitive tracking, issue 327 scoping

### DIFF
--- a/docs/adr/0007-scout-websocket-transport.md
+++ b/docs/adr/0007-scout-websocket-transport.md
@@ -1,0 +1,186 @@
+# ADR-0007: Scout WebSocket Transport for NAT Traversal
+
+## Status
+
+Proposed
+
+## Date
+
+2026-02-15
+
+## Context
+
+SubNetree's Scout agent communicates with the server via gRPC on a dedicated TCP port (`:9090`) with optional mTLS. The transport layer is implemented in two places:
+
+- **Agent side:** [`internal/scout/agent.go`](../../internal/scout/agent.go) -- `dialGRPC()` establishes a `grpc.ClientConn` to `config.ServerAddr` (default `localhost:9090`), with exponential backoff reconnection and TLS/mTLS certificate management.
+- **Server side:** [`internal/dispatch/dispatch.go`](../../internal/dispatch/dispatch.go) -- `Start()` opens a raw TCP listener on `GRPCAddr`, registers a `scoutServer` implementing the `ScoutService` protobuf service, and optionally configures mTLS with `VerifyClientCertIfGiven`.
+
+The protobuf contract ([`api/proto/v1/scout.proto`](../../api/proto/v1/scout.proto)) defines four RPCs: `CheckIn` (unary), `ReportMetrics` (client-streaming), `CommandStream` (bidirectional streaming), and `ReportProfile` (unary). Of these, `CheckIn` and `ReportProfile` are implemented; the two streaming RPCs are defined but not yet wired.
+
+This architecture works well for single-LAN homelab deployments (SubNetree's primary target: 10-75 devices on one network). However, it fails in three scenarios:
+
+1. **Agents behind NAT** -- A Scout at a remote site cannot initiate a connection to the server's gRPC port if the server is also behind NAT or if the user cannot configure port forwarding.
+2. **Restrictive firewalls** -- Corporate or ISP firewalls may block non-HTTP traffic on arbitrary ports. Port 9090 is not universally open.
+3. **Docker/container networks** -- Agents inside Docker bridge networks cannot reach the host's gRPC port without explicit port mapping.
+
+GitHub issue [#312](https://github.com/HerbHall/subnetree/issues/312) proposes WebSocket as an alternative transport to address these gaps. This ADR evaluates WebSocket against the current gRPC transport and against the planned Tailscale integration ([#278](https://github.com/HerbHall/subnetree/issues/278)).
+
+### Existing WebSocket Usage
+
+SubNetree already uses `coder/websocket` (v1.8.14, a direct dependency in `go.mod`) in two places:
+
+- [`internal/ws/handler.go`](../../internal/ws/handler.go) -- Real-time scan event streaming to the dashboard via `GET /api/v1/ws/scan` over the existing HTTP server (`:8080`).
+- [`internal/gateway/ssh.go`](../../internal/gateway/ssh.go) -- WebSocket-to-SSH bridge for browser-based terminal access via `GET /api/v1/ws/gateway/ssh/{device_id}`.
+
+Both use JWT-based authentication via query parameter (`?token=`) since the browser WebSocket API does not support custom headers. This pattern is proven and already deployed.
+
+## Decision
+
+**Defer** WebSocket as a Scout agent transport. Do not implement it now. Revisit when either (a) remote-site monitoring becomes a documented user need, or (b) the Tailscale integration (#278) proves insufficient for NAT traversal.
+
+### Rationale
+
+**1. The problem is rare for the target audience.**
+
+SubNetree targets homelab users with 10-75 devices, predominantly on a single LAN. In this deployment model, the server and all agents share a network segment. gRPC on `:9090` works without configuration. NAT traversal is needed only for multi-site monitoring, which is an advanced use case that no current user has requested.
+
+**2. gRPC streaming is architecturally superior for agent communication.**
+
+The `scout.proto` contract already defines `ReportMetrics` (client-streaming) and `CommandStream` (bidirectional streaming). These leverage gRPC's native streaming with automatic flow control, backpressure, and multiplexing over a single HTTP/2 connection. Reimplementing equivalent semantics over WebSocket would require:
+
+- Custom message framing (protobuf over WebSocket binary frames)
+- Manual flow control and backpressure
+- Reconnection state management (which stream offsets were acknowledged)
+- A second authentication path (JWT query params instead of mTLS client certificates)
+
+This is substantial engineering effort to replicate what gRPC provides natively.
+
+**3. Tailscale integration (#278) is a better NAT traversal solution.**
+
+Tailscale creates a flat overlay network where every device gets a stable IP address regardless of NAT topology. This solves the NAT problem at the network layer rather than the application layer:
+
+- No code changes to the Scout agent or Dispatch module
+- mTLS continues to work unchanged (Tailscale adds WireGuard encryption, mTLS adds identity verification)
+- Works for all protocols, not just agent check-ins (SSH bridge, future gRPC streams, SNMP polling)
+- Already documented in [`docs/guides/tailscale-deployment.md`](../../docs/guides/tailscale-deployment.md) and [`docs/guides/tailscale-funnel.md`](../../docs/guides/tailscale-funnel.md)
+- Tailscale is free for up to 100 devices (covers SubNetree's target range)
+
+**4. The implementation cost is disproportionate to the benefit.**
+
+Adding WebSocket transport would require:
+
+- A transport abstraction layer in the Scout agent (currently tightly coupled to `grpc.ClientConn` in [`agent.go:33-34`](../../internal/scout/agent.go#L33-L34))
+- A WebSocket-to-gRPC bridge or a parallel WebSocket handler in Dispatch
+- Dual authentication paths (mTLS for gRPC, JWT for WebSocket)
+- Configuration complexity (users choose between `grpc://`, `ws://`, `wss://` schemes)
+- Test matrix doubling (every agent behavior tested on both transports)
+
+For a problem that affects a small fraction of deployments, this cost is not justified.
+
+**5. A simpler escape hatch already exists.**
+
+Users needing NAT traversal today can use any of these approaches without code changes:
+
+- **Reverse SSH tunnel:** `ssh -R 9090:localhost:9090 remote-server`
+- **Tailscale/WireGuard VPN:** Flat network, no port forwarding needed
+- **Cloudflare Tunnel / ngrok:** Expose `:9090` via HTTPS tunnel
+- **Docker host networking:** `--network host` eliminates container NAT
+
+## Consequences
+
+### Positive
+
+- **No additional complexity** -- The agent transport remains a single code path (gRPC), reducing test surface and debugging scenarios.
+- **mTLS stays unified** -- Client certificate identity verification ([`grpc.go:65-76`](../../internal/dispatch/grpc.go#L65-L76)) does not need a parallel JWT-based identity path.
+- **Focus on higher-value work** -- Engineering effort stays on features that benefit all users (monitoring, analytics, vault), not edge-case transport issues.
+- **Tailscale path remains clean** -- When #278 ships, it solves NAT traversal universally without protocol-level workarounds.
+
+### Negative
+
+- **No built-in NAT traversal** -- Users with multi-site deployments must configure external tunneling (VPN, SSH tunnel, or Tailscale) to connect remote agents. This adds setup friction for that use case.
+- **Port 9090 dependency** -- Restrictive firewalls that only allow HTTP/HTTPS traffic will block gRPC. Users in those environments have no agent transport option without external tunneling.
+- **Perceived feature gap** -- Competitors that offer agent-initiated HTTP/WebSocket connections may appear more accessible for remote monitoring use cases.
+
+### Neutral
+
+- **WebSocket expertise is in-house** -- The existing `internal/ws/` and `internal/gateway/ssh.go` implementations demonstrate that the team can implement WebSocket transport if the need materializes. The decision to defer is based on prioritization, not capability.
+- **Proto contract is stable** -- The `scout.proto` RPCs are transport-agnostic at the message level. If WebSocket transport is needed later, the same protobuf messages can be serialized over WebSocket frames without changing the service contract.
+- **`gorilla/websocket` is also available** -- Present as an indirect dependency (via `paho.mqtt.golang`). If WebSocket transport is eventually built, either `coder/websocket` or `gorilla/websocket` could be used, though `coder/websocket` is preferred for consistency with existing code.
+
+## Alternatives Considered
+
+### Alternative 1: WebSocket Transport (Full Implementation)
+
+Add a WebSocket endpoint (e.g., `GET /api/v1/ws/scout`) to the HTTP server that accepts agent connections, authenticates via enrollment token or JWT, and bridges messages to the existing Dispatch store logic. The agent would gain a `--transport ws` flag.
+
+**Strengths:**
+
+- Works through any HTTP-capable proxy or firewall
+- Reuses the existing HTTP server port (`:8080`), eliminating the need for port `:9090`
+- Agent-initiated connections naturally traverse NAT (outbound TCP from agent to server)
+- `coder/websocket` already in the dependency tree
+
+**Rejected because:**
+
+- Duplicates gRPC functionality (streaming, reconnection, backpressure) in application code
+- Creates a second authentication path that must be kept in sync with mTLS
+- Doubles the transport test matrix
+- Solves a problem that affects a small minority of the target audience
+- Tailscale (#278) provides a cleaner network-layer solution
+
+### Alternative 2: gRPC-Web Proxy
+
+Run a gRPC-Web proxy (e.g., `improbable-eng/grpc-web` or Envoy) in front of the gRPC server. gRPC-Web encodes gRPC frames over HTTP/1.1 or HTTP/2, making them firewall-friendly.
+
+**Strengths:**
+
+- No agent code changes (gRPC-Web clients exist for Go)
+- Maintains protobuf contract and streaming semantics
+- Industry-standard approach for browser-to-gRPC communication
+
+**Rejected because:**
+
+- Adds an operational dependency (proxy sidecar) that conflicts with SubNetree's single-binary design philosophy
+- gRPC-Web Go client support is immature compared to browser (JavaScript) clients
+- Bidirectional streaming is not supported in gRPC-Web (only unary and server-streaming)
+- `CommandStream` RPC requires full bidirectional streaming
+
+### Alternative 3: Tailscale-Only (Issue #278)
+
+Rely entirely on Tailscale integration for NAT traversal. Agents and server join the same Tailnet; Tailscale handles routing, NAT traversal, and encryption.
+
+**Strengths:**
+
+- Zero application-layer changes
+- Adds WireGuard encryption on top of mTLS
+- Free for up to 100 devices
+- Already documented in deployment guides
+- Solves NAT traversal for all protocols (gRPC, SSH bridge, SNMP, HTTP API)
+
+**This is the recommended approach** when NAT traversal is needed. It is not "rejected" but rather the preferred path for users who need cross-network agent connectivity. The reason this ADR recommends deferring rather than adopting Alternative 3 right now is that Tailscale integration (#278) is its own separate implementation effort, and the current gRPC transport works for the primary LAN deployment scenario.
+
+### Alternative 4: QUIC Transport
+
+Replace gRPC-over-TCP with gRPC-over-QUIC (UDP-based, with built-in multiplexing and connection migration). QUIC handles NAT traversal via UDP hole punching and survives network changes (e.g., Wi-Fi to Ethernet) without reconnection.
+
+**Strengths:**
+
+- Connection migration eliminates reconnection churn
+- UDP hole punching provides some NAT traversal
+- Lower latency on lossy networks (no head-of-line blocking)
+
+**Rejected because:**
+
+- gRPC QUIC support in Go is experimental
+- UDP may be blocked by firewalls that allow TCP
+- Adds significant complexity to TLS configuration
+- Benefits are marginal for LAN deployments with stable connections
+
+## Revisit Triggers
+
+This decision should be revisited if any of the following occur:
+
+- **User demand:** Three or more users request remote-site agent connectivity without VPN
+- **Tailscale limitations:** The Tailscale integration (#278) ships but proves insufficient (e.g., users cannot or will not install Tailscale on monitored devices)
+- **Protocol consolidation:** A decision is made to eliminate the separate gRPC port (`:9090`) and run all communication through the HTTP server (`:8080`)
+- **Commercial deployment:** Enterprise customers require agent connectivity through corporate proxies that only allow HTTPS

--- a/docs/competitors/tracking.md
+++ b/docs/competitors/tracking.md
@@ -1,0 +1,269 @@
+# Competitive Tracking
+
+Lightweight competitor analysis for SubNetree. Updated monthly. Data sourced from GitHub API and prior research (see `D:/DevSpace/research/HomeLab/analysis/`).
+
+**Last updated**: 2026-02-15
+**Next review**: 2026-03-15
+
+---
+
+## Competitor Snapshots
+
+### NetAlertX
+
+| Attribute | Value |
+|-----------|-------|
+| GitHub | [netalertx/NetAlertX](https://github.com/netalertx/NetAlertX) |
+| Stars | 5,784 |
+| License | GPL-3.0 |
+| Language | Python |
+| Created | 2021-12-23 |
+| Activity | Active (regular releases) |
+
+**Positioning**: ARP/DHCP/Nmap network scanner with device change alerts and Home Assistant MQTT integration. Closest to SubNetree's Recon module scope.
+
+**Core capabilities**:
+
+- ARP, DHCP, ping/ICMP, Nmap scanning
+- Device change detection (IP, MAC, hostname, open ports)
+- 80+ notification channels via Apprise
+- Home Assistant MQTT integration (native)
+- Multi-VLAN/subnet support
+- Pi-hole / AdGuard Home / UNIFI controller import
+- SNMP device import (FortiGate)
+
+**Key weaknesses**:
+
+- No health monitoring or uptime checks
+- No agent-based collection
+- No credential vault or secrets management
+- No configuration documentation generation
+- No plugin architecture (monolithic codebase)
+- GPL-3.0 limits commercial adoption
+- Python runtime heavier than Go binary
+
+**Source**: RF-006, `community-validation-reddit-2026-02-14.md`
+
+---
+
+### Beszel
+
+| Attribute | Value |
+|-----------|-------|
+| GitHub | [henrygd/beszel](https://github.com/henrygd/beszel) |
+| Stars | 19,338 |
+| License | MIT |
+| Language | Go |
+| Created | 2024-07-07 |
+| Activity | Active (v0.18.3, rapid growth -- 0 to 19k stars in 18 months) |
+
+**Positioning**: Lightweight server monitoring hub. Positioned as "the perfect middle ground between Uptime Kuma and Grafana+Prometheus."
+
+**Core capabilities**:
+
+- Go-based agent with SSH+WebSocket dual transport (CBOR encoding)
+- CPU, RAM, disk, temperature, GPU monitoring
+- Docker container stats
+- S.M.A.R.T. disk health
+- Historical data with charts
+- Alerts and notifications
+- Auto-update mechanism (systemd, OpenRC, procd, FreeBSD)
+
+**Key weaknesses**:
+
+- No network discovery (manual agent install per host)
+- No credential vault
+- No configuration documentation
+- No topology visualization
+- No plugin architecture
+- SSH-based agent communication (vs SubNetree's gRPC + mTLS)
+- 210 open issues (growing backlog)
+- Manual enrollment (key/token copy)
+
+**Source**: RF-010, RF-006, `community-validation-reddit-2026-02-14.md`
+
+---
+
+### Scanopy
+
+| Attribute | Value |
+|-----------|-------|
+| GitHub | [scanopy/scanopy](https://github.com/scanopy/scanopy) |
+| Stars | 4,060 |
+| License | AGPL-3.0 / Commercial dual-license |
+| Language | Rust (backend), SvelteKit (frontend) |
+| Created | 2025-09-29 (as NetVisor, renamed Dec 2025) |
+| Activity | Active (aggressive release cadence, ~1 every 2 days, bus factor = 1) |
+
+**Positioning**: Network topology discovery and visualization. "Clean network diagrams. One-time setup, zero upkeep."
+
+**Core capabilities**:
+
+- ARP host discovery with dynamic concurrency
+- TCP/UDP port scanning (800ms timeout, batch=200)
+- 230+ service identification definitions
+- SNMP enrichment (v2c only -- system MIB, LLDP/CDP)
+- Docker container discovery
+- Interactive topology (elkjs auto-layout)
+- Multi-user RBAC (Owner/Admin/Member/Viewer)
+- OIDC/SSO support
+- Distributed scanning (multi-daemon)
+- REST API with OpenAPI docs
+
+**Key weaknesses**:
+
+- No change history (each scan overwrites state)
+- No alerting or notifications (webhooks marked "coming soon")
+- No configuration drift detection
+- No health monitoring
+- No agent-based profiling
+- No credential vault (users request `_FILE` env vars, issue #165)
+- Multi-NIC hosts appear as duplicates (issue #477, 10 comments)
+- Scanning can freeze host VMs (discussion #423)
+- Docker-only deployment (requires `privileged: true` + `network_mode: host`)
+- Bus factor = 1 (93%+ commits from sole maintainer)
+- AGPL-3.0 limits commercial ecosystem
+- Rust raises contributor barrier
+
+**Source**: RF-001, `scanopy-competitive-analysis.md`, `scanopy-gap-exploitation-2026-02-14.md`
+
+---
+
+### WatchYourLAN
+
+| Attribute | Value |
+|-----------|-------|
+| GitHub | [aceberg/WatchYourLAN](https://github.com/aceberg/WatchYourLAN) |
+| Stars | 6,763 |
+| License | MIT |
+| Language | Go |
+| Created | 2022-08-15 |
+| Activity | Maintained (slower cadence) |
+
+**Positioning**: Simple Go-based ARP LAN scanner with device history.
+
+**Core capabilities**:
+
+- ARP scanning with device history
+- Notifications via Shoutrrr
+- Grafana export
+- PostgreSQL support
+- Simple web UI
+
+**Key weaknesses**:
+
+- ARP-only scanning (no mDNS, SNMP, UPnP)
+- No health monitoring
+- No agent-based collection
+- No credential vault
+- No topology visualization
+- No VLAN awareness
+- No plugin architecture
+- No configuration documentation
+- Narrow scope (LAN inventory only)
+
+**Source**: RF-006, `community-validation-reddit-2026-02-14.md`
+
+---
+
+## Feature Comparison Matrix
+
+| Capability | SubNetree | NetAlertX | Beszel | Scanopy | WatchYourLAN |
+|------------|-----------|-----------|--------|---------|--------------|
+| **Discovery** | | | | | |
+| ARP scanning | Yes | Yes | -- | Yes | Yes |
+| mDNS discovery | Yes | -- | -- | -- | -- |
+| UPnP/SSDP discovery | Yes | -- | -- | -- | -- |
+| SNMP enrichment | Yes | Partial | -- | Yes (v2c) | -- |
+| Docker container discovery | -- | -- | Yes (stats) | Yes | -- |
+| **Inventory** | | | | | |
+| Device inventory | Yes | Yes | -- | Yes | Yes |
+| Hardware profiling | Yes (Scout) | -- | Yes (agent) | -- | -- |
+| Stale device detection | Yes | Yes | -- | -- | -- |
+| **Monitoring** | | | | | |
+| Health checks (ICMP/TCP/HTTP) | Yes | Partial (ping) | Yes | -- | -- |
+| Dependency-aware suppression | Yes | -- | -- | -- | -- |
+| Anomaly detection (EWMA) | Yes | -- | -- | -- | -- |
+| Metrics history | Yes (30d) | -- | Yes | -- | -- |
+| Docker container stats | Yes (Scout) | -- | Yes | -- | -- |
+| **Alerts** | | | | | |
+| Alert management | Yes | Yes | Yes | -- | Partial |
+| Webhook notifications | Yes | Yes | Yes | -- | -- |
+| Alertmanager-compatible | Yes | -- | -- | -- | -- |
+| Notification channels | Webhooks | 80+ (Apprise) | Built-in | -- | Shoutrrr |
+| **Visualization** | | | | | |
+| Topology visualization | Yes | -- | -- | Yes | -- |
+| Service mapping | Yes | -- | -- | Yes (230+) | -- |
+| **Security** | | | | | |
+| Credential vault | Yes | -- | -- | -- | -- |
+| mTLS agent communication | Yes | -- | -- | -- | -- |
+| **Agent** | | | | | |
+| Agent-based profiling | Yes (Scout) | -- | Yes | -- | -- |
+| Auto-update mechanism | Yes | -- | Yes | -- | -- |
+| Multi-platform agent | Yes (Win+Linux) | -- | Yes | -- | -- |
+| **Analytics** | | | | | |
+| AI/NL queries | Yes | -- | -- | -- | -- |
+| Recommendation engine | Yes (48 tools) | -- | -- | -- | -- |
+| **Integration** | | | | | |
+| MQTT / Home Assistant | Yes | Yes | Partial | -- | -- |
+| Prometheus /metrics | Yes | -- | -- | -- | Grafana export |
+| CSV import/export | Yes | -- | -- | -- | -- |
+| **Architecture** | | | | | |
+| Plugin architecture | Yes | -- | -- | -- | -- |
+| REST API | Yes | Partial | Yes (PocketBase) | Yes (OpenAPI) | -- |
+| Tier-aware defaults | Yes | -- | -- | -- | -- |
+
+**Legend**: Yes = shipped, Partial = limited implementation, -- = not available
+
+---
+
+## Monthly Check Template
+
+Use this checklist on the 15th of each month. Takes about 5 minutes with `gh` CLI.
+
+### Quick commands
+
+```bash
+# Star counts (run all four)
+gh api repos/netalertx/NetAlertX --jq '.stargazers_count'
+gh api repos/henrygd/beszel --jq '.stargazers_count'
+gh api repos/scanopy/scanopy --jq '.stargazers_count'
+gh api repos/aceberg/WatchYourLAN --jq '.stargazers_count'
+
+# Latest releases
+gh release list -R netalertx/NetAlertX --limit 3
+gh release list -R henrygd/beszel --limit 3
+gh release list -R scanopy/scanopy --limit 3
+gh release list -R aceberg/WatchYourLAN --limit 3
+
+# Open issue counts
+gh api repos/netalertx/NetAlertX --jq '.open_issues_count'
+gh api repos/henrygd/beszel --jq '.open_issues_count'
+gh api repos/scanopy/scanopy --jq '.open_issues_count'
+gh api repos/aceberg/WatchYourLAN --jq '.open_issues_count'
+```
+
+### Checklist
+
+- [ ] **Star counts**: Record in tracking log below. Look for sudden jumps (viral moment) or plateaus (stagnation).
+- [ ] **New releases**: Check changelogs for features that close gaps against SubNetree (alerting, state history, agent support, credential management, documentation).
+- [ ] **Open issue trends**: Growing backlog = maintainer burnout risk. Declining = healthy project or abandoned triage.
+- [ ] **New competitors**: Search GitHub for `homelab network discovery self-hosted` and `homelab infrastructure monitoring`. Check r/selfhosted and r/homelab mentions via blog aggregation.
+- [ ] **Community sentiment**: Skim recent issues/discussions on each repo for recurring complaints or feature requests that SubNetree already solves.
+- [ ] **Update this file**: Bump star counts, note new releases, flag any strategic changes.
+
+### Tracking log
+
+| Date | NetAlertX | Beszel | Scanopy | WatchYourLAN | Notes |
+|------|-----------|--------|---------|--------------|-------|
+| 2026-02-15 | 5,784 | 19,338 | 4,060 | 6,763 | Baseline. Beszel growing fastest. |
+| 2026-03-15 | | | | | |
+| 2026-04-15 | | | | | |
+| 2026-05-15 | | | | | |
+| 2026-06-15 | | | | | |
+
+---
+
+## Strategic Positioning Summary
+
+SubNetree's competitive moat is **breadth combined with depth in areas competitors ignore**. The homelab monitoring space has fragmented into single-purpose tools: NetAlertX for device scanning, Beszel for server metrics, Uptime Kuma for service uptime, Scanopy for topology visualization. Users run 3-5 tools and complain about "tool fatigue." SubNetree is the only platform that unifies discovery, monitoring, alerting, credential management, and agent-based profiling in a single binary. The gateway philosophy (D-004) -- providing 80% of each tool's core value in one integrated platform -- directly addresses the community's most vocal pain point. Three capabilities have zero competition: encrypted credential vault, AI-powered analytics, and plugin-extensible architecture. The planned auto-documentation engine (issue #299) targets the single largest unmet need identified across all community research: no tool automatically documents infrastructure changes. Competitors would need fundamental architectural changes to match these capabilities, and the solo-maintainer projects (Scanopy bus factor = 1, WatchYourLAN low velocity) are unlikely to make them.

--- a/docs/design/issue-327-scoping.md
+++ b/docs/design/issue-327-scoping.md
@@ -1,0 +1,210 @@
+# Issue #327 Scoping: Device Discovery and Monitoring
+
+Scoping analysis for [issue #327](https://github.com/HerbHall/subnetree/issues/327) -- "Device discovery and monitoring."
+
+## 1. Capability Audit
+
+The issue requests: ping, traceroute, reverse DNS, MAC address vendor lookup, device type classification, network hierarchy building, and additional device identification methods. The table below maps each request to current codebase status.
+
+| Feature | Requested | Status | File(s) | Notes |
+|---------|-----------|--------|---------|-------|
+| Ping (ICMP) | Yes | **Exists** | [icmp.go](../../internal/recon/icmp.go), [checker.go](../../internal/pulse/checker.go) | Recon uses `pro-bing` for subnet sweep; Pulse uses it for ongoing health checks. Both support configurable count, timeout, concurrency, and privileged mode on Windows. |
+| Reverse DNS lookup | Yes | **Exists** | [scanner.go:203-212](../../internal/recon/scanner.go#L203) | `resolveHostname()` calls `net.DefaultResolver.LookupAddr()` with 500ms timeout during every scan. Hostname is stored on the device record. |
+| MAC address discovery (ARP) | Yes | **Exists** | [arp.go](../../internal/recon/arp.go) | Cross-platform ARP table reader (Linux `/proc/net/arp`, Windows `arp -a`, macOS `arp -a`). Enabled by default. |
+| MAC vendor lookup (OUI) | Yes | **Exists** | [oui.go](../../internal/recon/oui.go) | Embedded 40k-entry OUI table. `Lookup(mac)` extracts first 3 octets and returns manufacturer name. Used during scan orchestration. |
+| SNMP discovery | Yes | **Exists** | [snmp_collector.go](../../internal/recon/snmp_collector.go), [snmp_oids.go](../../internal/recon/snmp_oids.go) | SNMPv2c and SNMPv3 with full auth. Queries sysDescr, sysObjectID, sysUpTime, sysContact, sysName, sysLocation. Walks IF-MIB for interface table. |
+| mDNS discovery | Implicit | **Exists** | [mdns.go](../../internal/recon/mdns.go) | Passive mDNS/Bonjour listener querying 14 service types. Infers device type from service name. Background goroutine with configurable interval. |
+| UPnP/SSDP discovery | Implicit | **Exists** | [upnp.go](../../internal/recon/upnp.go) | UPnP/SSDP device discovery via `goupnp`. Extracts manufacturer, model, device type from UPnP descriptors. Background goroutine. |
+| Device type classification | Yes | **Partial** | [snmp_collector.go:393-414](../../internal/recon/snmp_collector.go#L393), [mdns.go:250-263](../../internal/recon/mdns.go#L250), [upnp.go:220-253](../../internal/recon/upnp.go#L220), [device.go](../../pkg/models/device.go) | 15 device types defined. SNMP infers from sysDescr, mDNS from service name, UPnP from device type URN. ICMP-only scans always produce `unknown` type. |
+| Device categorization fields | Partial | **Exists** | [device.go:51-71](../../pkg/models/device.go#L51) | Device model has `Category`, `PrimaryRole`, `Owner`, `Location`, `Tags`, `CustomFields`. These are user-editable via API but not auto-populated. |
+| Topology / hierarchy tree | Yes | **Partial** | [scanner.go:214-253](../../internal/recon/scanner.go#L214), [store.go:412-460](../../internal/recon/store.go#L412) | `inferTopologyLinks()` creates edges between devices and subnet gateway (first usable IP). Only link type is `arp`. No switch port mapping, no multi-hop awareness. |
+| Traceroute | Yes | **Does NOT exist** | -- | No traceroute implementation anywhere in the codebase. |
+| Switch port mapping | Yes | **Does NOT exist** | -- | No SNMP bridge-MIB or forwarding database (FDB) table walking. Cannot determine which device is connected to which switch port. |
+| Device auto-classification from fingerprinting | Yes | **Does NOT exist** | -- | No multi-signal fingerprinting. Each discovery method infers type independently (sysDescr keywords, mDNS service, UPnP URN) but there is no combined heuristic engine. ICMP-only devices stay `unknown`. |
+| Network hierarchy (WAN -> router -> switch -> devices) | Yes | **Does NOT exist** | -- | Current topology is flat: devices connect to gateway via `arp` link type. No WAN edge detection, no router-switch-host layering, no per-port connectivity. |
+| TCP/HTTP health checks | Implicit | **Exists** | [tcp_checker.go](../../internal/pulse/tcp_checker.go), [http_checker.go](../../internal/pulse/http_checker.go) | TCP port connect and HTTP GET checkers with latency measurement. |
+| Service mapping | Implicit | **Exists** | [service.go](../../pkg/models/service.go) | Service model supports Docker containers, systemd services, Windows services, applications. Linked to devices. |
+
+### Summary
+
+- **Already fully implemented (6):** Ping/ICMP, reverse DNS, ARP scanning, MAC vendor lookup (OUI), SNMP discovery, mDNS/UPnP discovery
+- **Partially implemented (2):** Device type classification (works per-protocol but no combined engine), topology (flat gateway links only)
+- **Genuinely new (4):** Traceroute, switch port mapping, multi-signal device fingerprinting, hierarchical network topology
+
+## 2. Proposed Sub-Issues
+
+### Issue A: Traceroute utility endpoint
+
+**Title:** `feat(recon): add traceroute API endpoint for network path discovery`
+
+**Description:** Add a traceroute implementation that traces the network path from the SubNetree server to a target IP. Expose as `POST /api/v1/recon/traceroute` accepting a target IP and returning an ordered list of hops with RTT, hostname, and IP. Use raw ICMP with incrementing TTL (like `pro-bing`) to avoid requiring external `traceroute`/`tracert` binaries. Results should be stored temporarily for topology enrichment.
+
+**Estimated size:** M (medium)
+
+**Key files to modify:**
+
+- `internal/recon/traceroute.go` (new) -- core traceroute logic
+- `internal/recon/handlers.go` -- add `/traceroute` route and handler
+- `internal/recon/recon.go` -- register new route
+
+**Dependencies:** None. Standalone utility.
+
+---
+
+### Issue B: SNMP bridge-MIB switch port mapping
+
+**Title:** `feat(recon): SNMP bridge-MIB walk for switch port-to-MAC mapping`
+
+**Description:** Walk SNMP bridge-MIB (`.1.3.6.1.2.1.17`) and Q-BRIDGE-MIB (`.1.3.6.1.2.1.17.7`) on managed switches to build a port-to-MAC forwarding table. This reveals which devices are physically connected to which switch ports, enabling accurate Layer 2 topology instead of the current flat gateway-link model. Store results as enriched `TopologyLink` entries with `link_type: "bridge-fdb"` and port metadata.
+
+**Estimated size:** L (large)
+
+**Key files to modify:**
+
+- `internal/recon/snmp_oids.go` -- add bridge-MIB OID constants
+- `internal/recon/snmp_collector.go` -- add `GetForwardingTable()` method
+- `internal/recon/store.go` -- extend `TopologyLink` with port fields
+- `internal/recon/migrations.go` -- migration for new topology link columns
+- `internal/recon/handlers.go` -- add `/snmp/fdb/{device_id}` endpoint
+- `internal/recon/scanner.go` -- integrate FDB data into topology inference
+
+**Dependencies:** Requires SNMP credentials on managed switches (already supported via Vault). Benefits from Issue D for full hierarchy.
+
+---
+
+### Issue C: Multi-signal device fingerprinting engine
+
+**Title:** `feat(recon): multi-signal device type fingerprinting engine`
+
+**Description:** Create a device fingerprinting engine that combines signals from multiple discovery methods to classify devices more accurately. Inputs include: OUI manufacturer (existing), SNMP sysDescr and sysObjectID (existing), mDNS service types (existing), UPnP device type URN (existing), open TCP ports (new scan), and HTTP server headers (new probe). Implement as a scoring/weighted system where each signal contributes evidence toward a device type. Run automatically after scan completion to upgrade `unknown` devices. Expose classification confidence as a field on the device model.
+
+**Estimated size:** L (large)
+
+**Key files to modify:**
+
+- `internal/recon/fingerprint.go` (new) -- fingerprinting engine with signal aggregation
+- `internal/recon/fingerprint_rules.go` (new) -- rule definitions mapping signals to device types
+- `internal/recon/scanner.go` -- invoke fingerprinting after scan enrichment
+- `pkg/models/device.go` -- add `ClassificationConfidence float64` and `ClassificationSource string` fields
+- `internal/recon/store.go` -- persist new fields
+- `internal/recon/migrations.go` -- migration for new device columns
+
+**Dependencies:** Standalone, but benefits from port scanning (can be added incrementally). Issue B data (switch port info) would further improve classification.
+
+---
+
+### Issue D: Hierarchical network topology (WAN -> router -> switch -> devices)
+
+**Title:** `feat(recon): hierarchical network topology with device role layering`
+
+**Description:** Extend the topology system to represent network hierarchy: WAN edge -> router -> switches/hubs -> end devices. Use a combination of: (1) gateway detection from default route, (2) SNMP sysObjectID enterprise OIDs to identify network infrastructure, (3) bridge-MIB FDB tables to map switch-to-device connections, and (4) traceroute hop data to infer multi-hop paths. Add `topology_layer` field to `TopologyLink` (values: `wan`, `core`, `distribution`, `access`, `endpoint`). Update the topology API response to include layer information for the React Flow frontend to render a hierarchical layout.
+
+**Estimated size:** L (large)
+
+**Key files to modify:**
+
+- `internal/recon/store.go` -- add layer field to `TopologyLink`, hierarchical query methods
+- `internal/recon/migrations.go` -- migration for layer field
+- `internal/recon/scanner.go` -- enhanced topology inference with layering
+- `internal/recon/handlers.go` -- update `TopologyGraph` response with layer data
+
+**Dependencies:** Heavily depends on Issue B (switch port mapping) for accuracy. Benefits from Issue A (traceroute) for multi-hop path detection and Issue C (fingerprinting) for infrastructure device identification.
+
+---
+
+### Issue E: TCP port scan for service fingerprinting
+
+**Title:** `feat(recon): TCP port scan for common service detection`
+
+**Description:** Add a lightweight TCP port scan phase to the scan orchestrator. Probe a configurable set of common ports (22, 80, 443, 445, 3389, 8080, 8443, etc.) on discovered hosts. Store open ports on the device record and use them as inputs for the fingerprinting engine (Issue C). For example: port 22 open suggests Linux/server, port 3389 suggests Windows/desktop, port 9100 suggests printer. Keep the default port list small (top 20-30) to avoid slow scans.
+
+**Estimated size:** M (medium)
+
+**Key files to modify:**
+
+- `internal/recon/port_scanner.go` (new) -- TCP connect scanner with configurable port list
+- `internal/recon/scanner.go` -- add port scan phase after ICMP sweep
+- `pkg/models/device.go` -- add `OpenPorts []int` field
+- `internal/recon/store.go` -- persist open ports
+- `internal/recon/migrations.go` -- migration for ports column
+- `internal/recon/config.go` -- add `PortScanEnabled`, `PortScanPorts`, `PortScanTimeout` config
+
+**Dependencies:** None. Feeds into Issue C (fingerprinting).
+
+---
+
+### Issue F: On-demand network diagnostic tools API
+
+**Title:** `feat(recon): on-demand network diagnostic tools (ping, DNS lookup, port check)`
+
+**Description:** Add interactive diagnostic tool endpoints that users can invoke from the dashboard UI for troubleshooting. Endpoints: `POST /api/v1/recon/tools/ping` (ping a target with configurable count), `POST /api/v1/recon/tools/dns` (forward and reverse DNS lookup), `POST /api/v1/recon/tools/port-check` (test TCP connectivity to a specific port). These are one-shot utilities distinct from the automated scan pipeline. Return results immediately (synchronous, with timeout).
+
+**Estimated size:** S (small)
+
+**Key files to modify:**
+
+- `internal/recon/tools.go` (new) -- diagnostic tool handlers
+- `internal/recon/recon.go` -- register new routes
+- `internal/recon/handlers.go` -- add route entries
+
+**Dependencies:** None. Uses existing `pro-bing`, `net.LookupAddr`, and TCP connect primitives.
+
+## 3. Dependency Graph
+
+```text
+Issue F (diagnostic tools) -----> standalone
+Issue A (traceroute)       -----> standalone, feeds into D
+Issue E (port scan)        -----> standalone, feeds into C
+Issue C (fingerprinting)   -----> standalone, enhanced by E and B
+Issue B (bridge-MIB FDB)   -----> standalone, feeds into D
+Issue D (hierarchy)        -----> depends on B, benefits from A and C
+```
+
+## 4. Recommendation
+
+### Current Sprint
+
+1. **Issue F (diagnostic tools) -- S** -- Highest user-facing value for the least effort. Directly addresses the issue's request for "tools to allow user to troubleshoot issues on the network." Can ship independently.
+2. **Issue A (traceroute) -- M** -- Directly requested. Standalone implementation. Also produces data that feeds into hierarchy building later.
+3. **Issue E (port scan) -- M** -- Enables device fingerprinting. Low risk, well-scoped. Builds on existing TCP connect patterns from `pulse/tcp_checker.go`.
+
+### Next Sprint
+
+4. **Issue C (fingerprinting engine) -- L** -- Combines all existing signals plus port scan data. Biggest impact on reducing `unknown` device types.
+5. **Issue B (bridge-MIB FDB) -- L** -- Required foundation for accurate physical topology. Needs real managed switch hardware for testing.
+
+### Defer
+
+6. **Issue D (hierarchical topology) -- L** -- Most complex. Depends on B and benefits from A and C. Should be the capstone after the foundation pieces are in place.
+
+### Issue #327 Disposition
+
+Close #327 and replace with the six child issues above. The original issue is too broad to be actionable -- it mixes features that already exist (ping, reverse DNS, OUI lookup) with genuinely new work (traceroute, port mapping, hierarchy). The child issues are independently shippable and have clear scope.
+
+Update #327's body with a checklist linking to each child issue before closing, so the original reporter can track progress:
+
+```markdown
+Replaced by:
+- [ ] #NNN feat(recon): on-demand network diagnostic tools
+- [ ] #NNN feat(recon): traceroute API endpoint
+- [ ] #NNN feat(recon): TCP port scan for service detection
+- [ ] #NNN feat(recon): multi-signal device fingerprinting engine
+- [ ] #NNN feat(recon): SNMP bridge-MIB switch port mapping
+- [ ] #NNN feat(recon): hierarchical network topology
+```
+
+## 5. What the Issue Reporter Already Has
+
+The reporter may not realize that SubNetree already supports:
+
+- **ICMP ping** during network scans (configurable count, timeout, concurrency)
+- **Reverse DNS** on every discovered host (automatic, 500ms timeout)
+- **MAC address collection** from the system ARP table (cross-platform)
+- **Vendor identification** from MAC address OUI prefix (40k embedded entries)
+- **SNMP device discovery** with sysDescr-based type inference (router, switch, firewall, printer, AP, NAS, server)
+- **mDNS/Bonjour** passive discovery (14 service types)
+- **UPnP/SSDP** device discovery with manufacturer and model extraction
+- **Device type taxonomy** with 15 categories (server, desktop, laptop, mobile, router, switch, printer, IoT, AP, firewall, NAS, phone, tablet, camera, unknown)
+- **Basic topology** linking devices to their subnet gateway
+
+Consider updating the issue with this information before creating child issues, so the reporter understands the starting point.


### PR DESCRIPTION
## Summary

Wave 0 of the backlog sprint plan: research and design deliverables (no code changes).

- **ADR-0007**: Scout WebSocket transport evaluation (#312) - recommends deferring WebSocket in favor of Tailscale for NAT traversal. gRPC is architecturally superior for the current homelab target audience
- **Competitive tracking framework** (#300) - 4 competitor snapshots (NetAlertX, Beszel, Scanopy, WatchYourLAN), 25-capability comparison matrix, monthly update template with ready-to-run `gh` commands
- **Issue #327 scoping** - Capability audit found 6 of 12 requested features already exist. Proposes 6 new sub-issues: on-demand diagnostics API, traceroute, TCP port scan, device fingerprinting, SNMP bridge-MIB mapping, hierarchical topology

## Test plan

- [ ] Verify markdown renders correctly on GitHub
- [ ] Review ADR recommendation against current architecture
- [ ] Validate competitive tracking data against research findings
- [ ] Confirm #327 capability audit matches actual codebase

Closes #312, Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)