### PR TITLE
feat: SVG topology export

### DIFF
--- a/web/src/components/topology/topology-toolbar.tsx
+++ b/web/src/components/topology/topology-toolbar.tsx
@@ -11,6 +11,7 @@ import {
   GitBranch,
   LayoutGrid,
   Download,
+  FileImage,
   Activity,
   Save,
   FolderOpen,
@@ -18,6 +19,7 @@ import {
   ArrowDown,
   ArrowRight,
 } from 'lucide-react'
+import { exportTopologyAsSvg } from '@/lib/topology-export'
 import type { SavedLayout } from './layout-storage'
 import type { ElkDirection } from './elk-layout'
 
@@ -72,6 +74,7 @@ export const TopologyToolbar = memo(function TopologyToolbar({
 }: TopologyToolbarProps) {
   const { zoomIn, zoomOut, fitView } = useReactFlow()
   const [exporting, setExporting] = useState(false)
+  const [exportingSvg, setExportingSvg] = useState(false)
   const [layoutsOpen, setLayoutsOpen] = useState(false)
   const [saveName, setSaveName] = useState('')
   const layoutsRef = useRef<HTMLDivElement>(null)
@@ -109,6 +112,25 @@ export const TopologyToolbar = memo(function TopologyToolbar({
       toast.error('Failed to export topology')
     } finally {
       setExporting(false)
+    }
+  }
+
+  const handleExportSvg = async () => {
+    const element = flowRef.current
+    if (!element) return
+
+    setExportingSvg(true)
+    try {
+      const date = new Date().toISOString().split('T')[0]
+      await exportTopologyAsSvg(element, {
+        filename: `subnetree-topology-${date}.svg`,
+        backgroundColor: '#1a1a2e',
+      })
+      toast.success('Topology exported as SVG')
+    } catch {
+      toast.error('Failed to export topology as SVG')
+    } finally {
+      setExportingSvg(false)
     }
   }
 
@@ -327,6 +349,17 @@ export const TopologyToolbar = memo(function TopologyToolbar({
         style={{ color: 'var(--nv-text-secondary)' }}
       >
         <Download className="h-4 w-4" />
+      </button>
+
+      {/* Export SVG */}
+      <button
+        onClick={handleExportSvg}
+        disabled={exportingSvg}
+        title="Export as SVG"
+        className="rounded-md p-1.5 transition-colors hover:bg-[var(--nv-bg-hover)] disabled:opacity-50"
+        style={{ color: 'var(--nv-text-secondary)' }}
+      >
+        <FileImage className="h-4 w-4" />
       </button>
     </div>
   )

--- a/web/src/lib/topology-export.ts
+++ b/web/src/lib/topology-export.ts
@@ -1,0 +1,42 @@
+import { toSvg } from 'html-to-image'
+
+export interface ExportOptions {
+  filename?: string
+  backgroundColor?: string
+}
+
+/**
+ * Exports the React Flow viewport as an SVG file.
+ * Uses html-to-image's toSvg which serializes the DOM to SVG.
+ */
+export async function exportTopologyAsSvg(
+  element: HTMLElement,
+  options: ExportOptions = {},
+): Promise<void> {
+  const { filename = 'topology.svg', backgroundColor } = options
+
+  const svgDataUrl = await toSvg(element, {
+    filter: (node: Node) => {
+      // Exclude minimap and controls from export
+      if (node instanceof HTMLElement) {
+        const classes = node.className?.toString() || ''
+        if (
+          classes.includes('react-flow__minimap') ||
+          classes.includes('react-flow__controls')
+        ) {
+          return false
+        }
+      }
+      return true
+    },
+    backgroundColor: backgroundColor || 'transparent',
+  })
+
+  // Trigger download via temporary anchor element
+  const link = document.createElement('a')
+  link.download = filename
+  link.href = svgDataUrl
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+}


### PR DESCRIPTION
## Summary

- Adds `topology-export.ts` utility using `html-to-image` `toSvg()` function
- Adds "Export SVG" button to topology toolbar alongside existing PNG export
- Filters out minimap and controls from exported SVG
- Timestamped filename: `subnetree-topology-YYYY-MM-DD.svg`
- Toast notifications for success/failure via Sonner

+75 lines, 2 files (1 new, 1 modified)

## Test plan

- [ ] "Export SVG" button appears in topology toolbar
- [ ] Clicking exports a valid SVG file
- [ ] Exported SVG contains topology nodes and edges without minimap/controls
- [ ] Success toast appears after export

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)