### PR TITLE
feat: multiple topology view modes

### DIFF
--- a/web/src/components/topology/group-node.tsx
+++ b/web/src/components/topology/group-node.tsx
@@ -1,0 +1,81 @@
+import { memo } from 'react'
+import { type NodeProps, type Node } from '@xyflow/react'
+import type { GroupNodeData } from '@/lib/topology-grouping'
+
+export type GroupNodeType = Node<GroupNodeData, 'group'>
+
+/** Background color for group containers, keyed by groupKind + label context. */
+const STATUS_COLORS: Record<string, string> = {
+  online: 'rgba(74, 222, 128, 0.06)',
+  offline: 'rgba(248, 113, 113, 0.06)',
+  degraded: 'rgba(251, 191, 36, 0.06)',
+  unknown: 'rgba(148, 163, 184, 0.06)',
+}
+
+/** Border color for group containers by status. */
+const STATUS_BORDER_COLORS: Record<string, string> = {
+  online: 'rgba(74, 222, 128, 0.25)',
+  offline: 'rgba(248, 113, 113, 0.25)',
+  degraded: 'rgba(251, 191, 36, 0.25)',
+  unknown: 'rgba(148, 163, 184, 0.25)',
+}
+
+/**
+ * Determine subtle background and border colors based on the group kind and label.
+ * Status groups get colored backgrounds; type and subnet groups get neutral styling.
+ */
+function getGroupColors(data: GroupNodeData): { bg: string; border: string } {
+  if (data.groupKind === 'by-status') {
+    const statusKey = data.label.toLowerCase()
+    return {
+      bg: STATUS_COLORS[statusKey] ?? 'rgba(148, 163, 184, 0.04)',
+      border: STATUS_BORDER_COLORS[statusKey] ?? 'rgba(148, 163, 184, 0.15)',
+    }
+  }
+  // Type and subnet groups use a neutral, slightly tinted background
+  return {
+    bg: 'rgba(148, 163, 184, 0.04)',
+    border: 'rgba(148, 163, 184, 0.15)',
+  }
+}
+
+/**
+ * GroupNode renders a labeled container around grouped device nodes.
+ * Used when the topology is in a grouped view mode (by-type, by-status, by-subnet).
+ */
+export const GroupNode = memo(function GroupNode({
+  data,
+}: NodeProps<GroupNodeType>) {
+  const { bg, border } = getGroupColors(data)
+
+  return (
+    <div
+      className="w-full h-full rounded-xl"
+      style={{
+        backgroundColor: bg,
+        border: `1px dashed ${border}`,
+      }}
+    >
+      {/* Group header label */}
+      <div
+        className="flex items-center gap-2 px-3 py-2"
+      >
+        <span
+          className="text-xs font-semibold tracking-wide"
+          style={{ color: 'var(--nv-text-primary)' }}
+        >
+          {data.label}
+        </span>
+        <span
+          className="inline-flex items-center justify-center rounded-full px-1.5 py-0.5 text-[10px] font-medium"
+          style={{
+            backgroundColor: 'var(--nv-bg-active)',
+            color: 'var(--nv-text-secondary)',
+          }}
+        >
+          {data.count}
+        </span>
+      </div>
+    </div>
+  )
+})

--- a/web/src/components/topology/topology-view-tabs.tsx
+++ b/web/src/components/topology/topology-view-tabs.tsx
@@ -1,0 +1,51 @@
+import { memo } from 'react'
+import { Layers, LayoutGrid, Activity, Globe } from 'lucide-react'
+import type { ViewMode } from '@/lib/topology-grouping'
+
+interface TopologyViewTabsProps {
+  viewMode: ViewMode
+  onViewModeChange: (mode: ViewMode) => void
+}
+
+const viewOptions: { value: ViewMode; label: string; Icon: typeof Layers }[] = [
+  { value: 'all', label: 'All Devices', Icon: Layers },
+  { value: 'by-type', label: 'By Type', Icon: LayoutGrid },
+  { value: 'by-status', label: 'By Status', Icon: Activity },
+  { value: 'by-subnet', label: 'By Subnet', Icon: Globe },
+]
+
+/**
+ * Tab bar for switching between topology view modes.
+ * Rendered above the topology canvas, below the page header.
+ */
+export const TopologyViewTabs = memo(function TopologyViewTabs({
+  viewMode,
+  onViewModeChange,
+}: TopologyViewTabsProps) {
+  return (
+    <div
+      className="flex items-center gap-1 rounded-lg px-2 py-1.5 shadow-md"
+      style={{
+        backgroundColor: 'var(--nv-bg-card)',
+        border: '1px solid var(--nv-border-default)',
+        backdropFilter: 'blur(8px)',
+      }}
+    >
+      {viewOptions.map(({ value, label, Icon }) => (
+        <button
+          key={value}
+          onClick={() => onViewModeChange(value)}
+          title={`View: ${label}`}
+          className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors"
+          style={{
+            backgroundColor: viewMode === value ? 'var(--nv-bg-active)' : 'transparent',
+            color: viewMode === value ? 'var(--nv-text-accent)' : 'var(--nv-text-secondary)',
+          }}
+        >
+          <Icon className="h-3.5 w-3.5" />
+          <span className="hidden sm:inline">{label}</span>
+        </button>
+      ))}
+    </div>
+  )
+})

--- a/web/src/lib/topology-grouping.ts
+++ b/web/src/lib/topology-grouping.ts
@@ -1,0 +1,250 @@
+import type { TopologyNode } from '@/api/types'
+import type { DeviceNodeData } from '@/components/topology/device-node'
+import type { Node } from '@xyflow/react'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ViewMode = 'all' | 'by-type' | 'by-status' | 'by-subnet'
+
+export interface GroupInfo {
+  id: string
+  label: string
+  nodeIds: string[]
+}
+
+/** Data shape for the group (container) node rendered by GroupNode. */
+export interface GroupNodeData {
+  label: string
+  count: number
+  groupKind: ViewMode
+  [key: string]: unknown
+}
+
+export type GroupNodeType = Node<GroupNodeData, 'group'>
+
+// ---------------------------------------------------------------------------
+// Subnet helpers
+// ---------------------------------------------------------------------------
+
+/** Extract the /24 subnet string from an IP address. Returns null for unusable values. */
+export function extractSubnet(ip: string): string | null {
+  const parts = ip.split('.')
+  if (parts.length !== 4) return null
+  // Validate each octet is a number 0-255
+  for (const p of parts) {
+    const n = Number(p)
+    if (!Number.isFinite(n) || n < 0 || n > 255) return null
+  }
+  return `${parts[0]}.${parts[1]}.${parts[2]}.0/24`
+}
+
+// ---------------------------------------------------------------------------
+// Grouping functions -- pure, no side effects
+// ---------------------------------------------------------------------------
+
+/** Group nodes by device_type. */
+export function groupByType(nodes: TopologyNode[]): GroupInfo[] {
+  const groups = new Map<string, string[]>()
+  for (const node of nodes) {
+    const key = node.device_type
+    const list = groups.get(key)
+    if (list) {
+      list.push(node.id)
+    } else {
+      groups.set(key, [node.id])
+    }
+  }
+  return Array.from(groups.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, ids]) => ({
+      id: `group-type-${key}`,
+      label: formatTypeLabel(key),
+      nodeIds: ids,
+    }))
+}
+
+/** Group nodes by status. */
+export function groupByStatus(nodes: TopologyNode[]): GroupInfo[] {
+  const groups = new Map<string, string[]>()
+  for (const node of nodes) {
+    const key = node.status
+    const list = groups.get(key)
+    if (list) {
+      list.push(node.id)
+    } else {
+      groups.set(key, [node.id])
+    }
+  }
+  // Use a fixed order for statuses
+  const order = ['online', 'degraded', 'offline', 'unknown']
+  return order
+    .filter((s) => groups.has(s))
+    .map((key) => ({
+      id: `group-status-${key}`,
+      label: formatStatusLabel(key),
+      nodeIds: groups.get(key)!,
+    }))
+}
+
+/** Group nodes by /24 subnet extracted from their first IP address. */
+export function groupBySubnet(nodes: TopologyNode[]): GroupInfo[] {
+  const groups = new Map<string, string[]>()
+  for (const node of nodes) {
+    const ip = node.ip_addresses?.[0]
+    const subnet = ip ? extractSubnet(ip) : null
+    const key = subnet ?? 'Unknown Subnet'
+    const list = groups.get(key)
+    if (list) {
+      list.push(node.id)
+    } else {
+      groups.set(key, [node.id])
+    }
+  }
+  return Array.from(groups.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, ids]) => ({
+      id: `group-subnet-${key.replace(/[./]/g, '-')}`,
+      label: key,
+      nodeIds: ids,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// Layout -- positions group nodes and their children in a grid-of-grids
+// ---------------------------------------------------------------------------
+
+/** Spacing constants (pixels). */
+const GROUP_PADDING_X = 40
+const GROUP_PADDING_TOP = 50 // Extra top padding for the group label
+const GROUP_PADDING_BOTTOM = 30
+const CHILD_CELL_W = 200
+const CHILD_CELL_H = 120
+const GROUP_GAP = 60
+
+/**
+ * Given groups and the original API nodes, produce React Flow nodes:
+ *   - One group node per group (type = 'group')
+ *   - Device nodes with `parentId` set so they live inside the group
+ *
+ * Returns { groupNodes, deviceNodes } so the caller can merge them into a
+ * single flat array (groups first, then devices -- React Flow requires
+ * parents before children).
+ */
+export function layoutGroups(
+  groups: GroupInfo[],
+  apiNodes: TopologyNode[],
+  viewMode: ViewMode,
+): { groupNodes: GroupNodeType[]; deviceNodes: Node<DeviceNodeData, 'device'>[] } {
+  const nodeMap = new Map<string, TopologyNode>()
+  for (const n of apiNodes) nodeMap.set(n.id, n)
+
+  const groupNodes: GroupNodeType[] = []
+  const deviceNodes: Node<DeviceNodeData, 'device'>[] = []
+
+  // Lay groups out horizontally, wrapping after a maximum width
+  let groupX = 0
+  let groupY = 0
+  let rowMaxHeight = 0
+  const MAX_ROW_WIDTH = 1600
+
+  for (const group of groups) {
+    const memberCount = group.nodeIds.length
+    const cols = Math.max(1, Math.ceil(Math.sqrt(memberCount)))
+    const rows = Math.ceil(memberCount / cols)
+    const groupW = GROUP_PADDING_X * 2 + cols * CHILD_CELL_W
+    const groupH = GROUP_PADDING_TOP + rows * CHILD_CELL_H + GROUP_PADDING_BOTTOM
+
+    // Wrap to next row if this group would exceed max width
+    if (groupX > 0 && groupX + groupW > MAX_ROW_WIDTH) {
+      groupX = 0
+      groupY += rowMaxHeight + GROUP_GAP
+      rowMaxHeight = 0
+    }
+
+    // Create the group (container) node
+    groupNodes.push({
+      id: group.id,
+      type: 'group',
+      position: { x: groupX, y: groupY },
+      data: {
+        label: group.label,
+        count: memberCount,
+        groupKind: viewMode,
+      },
+      style: {
+        width: groupW,
+        height: groupH,
+      },
+    })
+
+    // Create child device nodes positioned relative to the group
+    group.nodeIds.forEach((nodeId, idx) => {
+      const apiNode = nodeMap.get(nodeId)
+      if (!apiNode) return
+
+      const col = idx % cols
+      const row = Math.floor(idx / cols)
+      deviceNodes.push({
+        id: nodeId,
+        type: 'device',
+        position: {
+          x: GROUP_PADDING_X + col * CHILD_CELL_W,
+          y: GROUP_PADDING_TOP + row * CHILD_CELL_H,
+        },
+        parentId: group.id,
+        extent: 'parent' as const,
+        data: {
+          label: apiNode.label,
+          deviceType: apiNode.device_type,
+          status: apiNode.status,
+          ip: apiNode.ip_addresses?.[0] || 'No IP',
+          openPorts: apiNode.open_ports,
+        },
+      })
+    })
+
+    groupX += groupW + GROUP_GAP
+    rowMaxHeight = Math.max(rowMaxHeight, groupH)
+  }
+
+  return { groupNodes, deviceNodes }
+}
+
+// ---------------------------------------------------------------------------
+// Label formatting helpers
+// ---------------------------------------------------------------------------
+
+const TYPE_LABELS: Record<string, string> = {
+  server: 'Servers',
+  desktop: 'Desktops',
+  laptop: 'Laptops',
+  mobile: 'Mobile Devices',
+  router: 'Routers',
+  switch: 'Switches',
+  access_point: 'Access Points',
+  firewall: 'Firewalls',
+  printer: 'Printers',
+  nas: 'NAS',
+  iot: 'IoT Devices',
+  phone: 'Phones',
+  tablet: 'Tablets',
+  camera: 'Cameras',
+  unknown: 'Unknown',
+}
+
+function formatTypeLabel(type: string): string {
+  return TYPE_LABELS[type] ?? type.charAt(0).toUpperCase() + type.slice(1)
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  online: 'Online',
+  offline: 'Offline',
+  degraded: 'Degraded',
+  unknown: 'Unknown',
+}
+
+function formatStatusLabel(status: string): string {
+  return STATUS_LABELS[status] ?? status.charAt(0).toUpperCase() + status.slice(1)
+}


### PR DESCRIPTION
## Summary

- Add view mode tabs to topology page: All Devices, By Type, By Status, By Subnet
- Grouped modes use React Flow parent/child nodes with grid-of-grids layout
- Group nodes are labeled containers with count badges and color-coded backgrounds (status mode)
- New files: `topology-grouping.ts` (251 lines), `group-node.tsx` (82 lines), `topology-view-tabs.tsx` (52 lines)
- Modified `topology.tsx` (+72/-16 lines) to integrate view switching

## Test plan

- [ ] Verify "All Devices" mode preserves existing flat topology behavior
- [ ] Verify "By Type" groups devices by device_type with pluralized labels
- [ ] Verify "By Status" shows color-coded groups (green/yellow/red/gray)
- [ ] Verify "By Subnet" groups by /24 subnet extracted from IP addresses
- [ ] Verify edges render correctly between nodes in different groups
- [ ] Verify search/filter works across all view modes
- [ ] Verify TypeScript and ESLint pass (`npx tsc --noEmit && pnpm run lint`)

Closes #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)