### PR TITLE
fix: seed built-in themes before activation in setup wizard

### DIFF
--- a/internal/settings/handler.go
+++ b/internal/settings/handler.go
@@ -620,6 +620,11 @@ func (h *Handler) handleSetActiveTheme(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Ensure built-in themes are seeded (setup wizard sets theme before listing).
+	if err := h.ensureBuiltInThemes(r.Context()); err != nil {
+		h.logger.Error("failed to ensure built-in themes", zap.Error(err))
+	}
+
 	// Verify the theme exists.
 	if _, err := h.settings.Get(r.Context(), themeKeyPrefix+req.ThemeID); err != nil {
 		if err == services.ErrNotFound {


### PR DESCRIPTION
## Summary

- Setup wizard calls `setActiveTheme('builtin-forest-dark')` during completion, but `ensureBuiltInThemes()` was only called from `handleListThemes()` - never reached during setup flow
- Built-in themes were never seeded to the database, causing a 404 "theme not found" that **blocks setup completion entirely** (both light and dark)
- Added `ensureBuiltInThemes()` call to `handleSetActiveTheme()` so themes are seeded on first activation

## Test plan

- [ ] Fresh install: complete setup wizard with dark theme - should succeed
- [ ] Fresh install: complete setup wizard with light theme - should succeed
- [ ] Existing install: changing active theme still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)