### PR TITLE
fix: seed built-in themes in handleGetTheme for theme-provider

### DIFF
--- a/internal/settings/handler.go
+++ b/internal/settings/handler.go
@@ -321,6 +321,11 @@ func (h *Handler) handleListThemes(w http.ResponseWriter, r *http.Request) {
 //	@Failure		500	{object}	SettingsProblemDetail	"Internal server error"
 //	@Router			/settings/themes/{id} [get]
 func (h *Handler) handleGetTheme(w http.ResponseWriter, r *http.Request) {
+	// Ensure built-in themes are seeded (theme-provider fetches before list).
+	if err := h.ensureBuiltInThemes(r.Context()); err != nil {
+		h.logger.Error("failed to ensure built-in themes", zap.Error(err))
+	}
+
 	id := r.PathValue("id")
 	setting, err := h.settings.Get(r.Context(), themeKeyPrefix+id)
 	if err != nil {


### PR DESCRIPTION
## Summary

- After setup completes, the theme-provider component fetches the active theme definition via `GET /settings/themes/{id}`
- If this call arrives before any theme list endpoint is called, built-in themes may not be seeded yet
- Adds `ensureBuiltInThemes()` to `handleGetTheme()` as defense-in-depth alongside the `handleSetActiveTheme` fix in PR #341

## Test plan

- [ ] Complete setup wizard, verify theme applies immediately without error
- [ ] Refresh app after setup, verify theme loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)