### PR TITLE
fix: update device last_seen on successful monitoring checks

### DIFF
--- a/internal/pulse/pulse.go
+++ b/internal/pulse/pulse.go
@@ -164,6 +164,16 @@ func (m *Module) executeCheck(ctx context.Context, check Check) {
 		)
 	}
 
+	// Update device last_seen on successful checks.
+	if result.Success && check.DeviceID != "" {
+		if err := m.store.UpdateDeviceLastSeen(ctx, check.DeviceID, time.Now()); err != nil {
+			m.logger.Debug("failed to update device last_seen",
+				zap.String("device_id", check.DeviceID),
+				zap.Error(err),
+			)
+		}
+	}
+
 	// Process alert state machine.
 	if m.alerter != nil {
 		m.alerter.ProcessResult(ctx, check, result)

--- a/internal/pulse/store.go
+++ b/internal/pulse/store.go
@@ -273,6 +273,18 @@ func (s *PulseStore) InsertResult(ctx context.Context, r *CheckResult) error {
 	return nil
 }
 
+// UpdateDeviceLastSeen updates the last_seen timestamp on a device after a successful check.
+func (s *PulseStore) UpdateDeviceLastSeen(ctx context.Context, deviceID string, t time.Time) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE recon_devices SET last_seen = ? WHERE id = ?`,
+		t.UTC().Format(time.RFC3339), deviceID,
+	)
+	if err != nil {
+		return fmt.Errorf("update device last_seen: %w", err)
+	}
+	return nil
+}
+
 // ListResults returns check results for a device, ordered by checked_at descending.
 // If limit <= 0, defaults to 100.
 func (s *PulseStore) ListResults(ctx context.Context, deviceID string, limit int) ([]CheckResult, error) {


### PR DESCRIPTION
## Summary

- Device detail page shows stale "Last Seen" (e.g., 29 minutes ago) while the metrics chart below shows active monitoring data up to the current time
- Root cause: Pulse `executeCheck()` stores check results and publishes metrics but never updates `recon_devices.last_seen` -- only Recon scans did
- Added `UpdateDeviceLastSeen()` to PulseStore, called after each successful check

## Changes

- `internal/pulse/store.go`: Add `UpdateDeviceLastSeen(ctx, deviceID, time)` method
- `internal/pulse/pulse.go`: Call it in `executeCheck()` after successful result storage

## Test plan

- [ ] Run a scan to create a device
- [ ] Wait for Pulse to run a monitoring check (~90s)
- [ ] Verify "Last Seen" on device detail page updates to match latest check time
- [ ] Verify metrics chart and Last Seen stay in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)