### PR TITLE
feat: infrastructure port fingerprinting for device classification

### DIFF
--- a/internal/recon/port_fingerprint.go
+++ b/internal/recon/port_fingerprint.go
@@ -1,0 +1,122 @@
+package recon
+
+import "github.com/HerbHall/subnetree/pkg/models"
+
+// portFingerprint maps a set of required and optional ports to a device type.
+type portFingerprint struct {
+	deviceType    models.DeviceType
+	requiredPorts []int // ALL must be open
+	optionalPorts []int // At least one should be open (if specified)
+	description   string
+}
+
+// portFingerprints defines known port combination patterns for infrastructure devices.
+// Order matters: more specific patterns (more required ports) should come first.
+var portFingerprints = []portFingerprint{
+	// Ubiquiti UniFi switch/AP (very specific).
+	{
+		deviceType:    models.DeviceTypeSwitch,
+		requiredPorts: []int{22, 80, 8443},
+		description:   "Ubiquiti UniFi device",
+	},
+	// MikroTik router (Winbox port is distinctive).
+	{
+		deviceType:    models.DeviceTypeRouter,
+		requiredPorts: []int{80, 8291},
+		description:   "MikroTik RouterOS",
+	},
+	// Cisco-like managed switch/router (SSH + Telnet + HTTP + SNMP).
+	{
+		deviceType:    models.DeviceTypeSwitch,
+		requiredPorts: []int{22, 23, 80},
+		description:   "Managed switch (Cisco-like)",
+	},
+	// Managed switch with SNMP or HTTPS alongside SSH + HTTP.
+	{
+		deviceType:    models.DeviceTypeSwitch,
+		requiredPorts: []int{22, 80},
+		optionalPorts: []int{161, 443},
+		description:   "Managed switch with management services",
+	},
+	// SSH + HTTP management (infrastructure OUI required by caller).
+	{
+		deviceType:    models.DeviceTypeSwitch,
+		requiredPorts: []int{22, 80},
+		description:   "Managed switch (generic)",
+	},
+	// Device with only web management (infra OUI required).
+	{
+		deviceType:    models.DeviceTypeRouter,
+		requiredPorts: []int{80, 443},
+		description:   "Consumer router/AP with web management",
+	},
+	// SSH-only device with SNMP (likely embedded/infrastructure).
+	{
+		deviceType:    models.DeviceTypeSwitch,
+		requiredPorts: []int{22},
+		optionalPorts: []int{161},
+		description:   "SSH-managed infrastructure device with SNMP",
+	},
+}
+
+// ClassifyByPorts attempts to classify a device based on its open ports.
+// Only call this for devices with infrastructure OUI vendors.
+// Returns DeviceTypeUnknown if no fingerprint matches.
+func ClassifyByPorts(openPorts []int) models.DeviceType {
+	if len(openPorts) == 0 {
+		return models.DeviceTypeUnknown
+	}
+
+	portSet := make(map[int]bool, len(openPorts))
+	for _, p := range openPorts {
+		portSet[p] = true
+	}
+
+	for i := range portFingerprints {
+		if matchesFingerprint(portSet, &portFingerprints[i]) {
+			return portFingerprints[i].deviceType
+		}
+	}
+
+	return models.DeviceTypeUnknown
+}
+
+// matchesFingerprint checks if the open ports match a fingerprint pattern.
+func matchesFingerprint(portSet map[int]bool, fp *portFingerprint) bool {
+	// All required ports must be open.
+	for _, p := range fp.requiredPorts {
+		if !portSet[p] {
+			return false
+		}
+	}
+
+	// If optional ports specified, at least one must be open.
+	if len(fp.optionalPorts) > 0 {
+		anyOptional := false
+		for _, p := range fp.optionalPorts {
+			if portSet[p] {
+				anyOptional = true
+				break
+			}
+		}
+		if !anyOptional {
+			return false
+		}
+	}
+
+	return true
+}
+
+// IsInfrastructureOUI checks whether a device type from OUI classification
+// suggests the device is network infrastructure worth port scanning.
+func IsInfrastructureOUI(deviceType models.DeviceType) bool {
+	switch deviceType {
+	case models.DeviceTypeRouter,
+		models.DeviceTypeSwitch,
+		models.DeviceTypeAccessPoint,
+		models.DeviceTypeFirewall:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/recon/port_scanner.go
+++ b/internal/recon/port_scanner.go
@@ -1,0 +1,102 @@
+package recon
+
+import (
+	"context"
+	"net"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// PortScanResult holds the results of a port scan for a single host.
+type PortScanResult struct {
+	IP        string
+	OpenPorts []int
+}
+
+// InfrastructurePorts are TCP ports commonly found on network infrastructure devices.
+var InfrastructurePorts = []int{
+	22,   // SSH
+	23,   // Telnet
+	80,   // HTTP management UI
+	161,  // SNMP (checked via TCP; UDP check would require gosnmp)
+	443,  // HTTPS management UI
+	8080, // HTTP alt (Ubiquiti inform, some Netgear)
+	8291, // Winbox (MikroTik RouterOS)
+	8443, // HTTPS alt (Ubiquiti UniFi)
+}
+
+// PortScanner performs targeted TCP port scans on network devices.
+type PortScanner struct {
+	timeout     time.Duration
+	concurrency int
+	logger      *zap.Logger
+}
+
+// NewPortScanner creates a new port scanner.
+func NewPortScanner(timeout time.Duration, concurrency int, logger *zap.Logger) *PortScanner {
+	if timeout <= 0 {
+		timeout = 2 * time.Second
+	}
+	if concurrency <= 0 {
+		concurrency = 10
+	}
+	return &PortScanner{
+		timeout:     timeout,
+		concurrency: concurrency,
+		logger:      logger,
+	}
+}
+
+// ScanPorts checks which of the given ports are open on the target IP.
+func (s *PortScanner) ScanPorts(ctx context.Context, ip string, ports []int) *PortScanResult {
+	result := &PortScanResult{IP: ip}
+
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, s.concurrency)
+
+	for _, port := range ports {
+		if ctx.Err() != nil {
+			break
+		}
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(p int) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			if s.isPortOpen(ctx, ip, p) {
+				mu.Lock()
+				result.OpenPorts = append(result.OpenPorts, p)
+				mu.Unlock()
+			}
+		}(port)
+	}
+	wg.Wait()
+
+	// Sort for deterministic output.
+	sort.Ints(result.OpenPorts)
+
+	s.logger.Debug("port scan complete",
+		zap.String("ip", ip),
+		zap.Ints("open", result.OpenPorts),
+	)
+
+	return result
+}
+
+// isPortOpen attempts a TCP connection to the given port.
+func (s *PortScanner) isPortOpen(ctx context.Context, ip string, port int) bool {
+	addr := net.JoinHostPort(ip, strconv.Itoa(port))
+	d := net.Dialer{Timeout: s.timeout}
+	conn, err := d.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
+}

--- a/internal/recon/port_scanner_test.go
+++ b/internal/recon/port_scanner_test.go
@@ -1,0 +1,229 @@
+package recon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/HerbHall/subnetree/pkg/models"
+	"go.uber.org/zap"
+)
+
+func TestClassifyByPorts(t *testing.T) {
+	tests := []struct {
+		name      string
+		openPorts []int
+		want      models.DeviceType
+	}{
+		// Specific fingerprints.
+		{
+			name:      "UniFi device (SSH + HTTP + HTTPS alt)",
+			openPorts: []int{22, 80, 8443},
+			want:      models.DeviceTypeSwitch,
+		},
+		{
+			name:      "MikroTik router (HTTP + Winbox)",
+			openPorts: []int{80, 8291},
+			want:      models.DeviceTypeRouter,
+		},
+		{
+			name:      "Cisco-like switch (SSH + Telnet + HTTP)",
+			openPorts: []int{22, 23, 80},
+			want:      models.DeviceTypeSwitch,
+		},
+		// Managed switch with optional ports.
+		{
+			name:      "managed switch with SNMP (SSH + HTTP + SNMP)",
+			openPorts: []int{22, 80, 161},
+			want:      models.DeviceTypeSwitch,
+		},
+		{
+			name:      "managed switch with HTTPS (SSH + HTTP + HTTPS)",
+			openPorts: []int{22, 80, 443},
+			want:      models.DeviceTypeSwitch,
+		},
+		// Generic managed switch.
+		{
+			name:      "generic managed switch (SSH + HTTP only)",
+			openPorts: []int{22, 80},
+			want:      models.DeviceTypeSwitch,
+		},
+		// Consumer router.
+		{
+			name:      "consumer router (HTTP + HTTPS)",
+			openPorts: []int{80, 443},
+			want:      models.DeviceTypeRouter,
+		},
+		// SSH-managed with SNMP.
+		{
+			name:      "SSH-managed device with SNMP",
+			openPorts: []int{22, 161},
+			want:      models.DeviceTypeSwitch,
+		},
+		// No match cases.
+		{
+			name:      "empty ports returns unknown",
+			openPorts: []int{},
+			want:      models.DeviceTypeUnknown,
+		},
+		{
+			name:      "nil ports returns unknown",
+			openPorts: nil,
+			want:      models.DeviceTypeUnknown,
+		},
+		{
+			name:      "single HTTP port too generic",
+			openPorts: []int{80},
+			want:      models.DeviceTypeUnknown,
+		},
+		{
+			name:      "RDP and VNC are not infrastructure",
+			openPorts: []int{3389, 5900},
+			want:      models.DeviceTypeUnknown,
+		},
+		{
+			name:      "SSH alone without SNMP returns unknown",
+			openPorts: []int{22},
+			want:      models.DeviceTypeUnknown,
+		},
+		// Full infrastructure device with many ports.
+		{
+			name:      "fully featured device matches most specific first",
+			openPorts: []int{22, 23, 80, 161, 443, 8080, 8443},
+			want:      models.DeviceTypeSwitch, // matches UniFi first (22+80+8443)
+		},
+		// MikroTik with extra ports still matches MikroTik.
+		{
+			name:      "MikroTik with SSH still matches MikroTik",
+			openPorts: []int{22, 80, 8291},
+			want:      models.DeviceTypeRouter, // UniFi needs 8443 (missing), MikroTik [80,8291] matches
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ClassifyByPorts(tt.openPorts)
+			if got != tt.want {
+				t.Errorf("ClassifyByPorts(%v) = %q, want %q", tt.openPorts, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsInfrastructureOUI(t *testing.T) {
+	tests := []struct {
+		name       string
+		deviceType models.DeviceType
+		want       bool
+	}{
+		{"router is infrastructure", models.DeviceTypeRouter, true},
+		{"switch is infrastructure", models.DeviceTypeSwitch, true},
+		{"access point is infrastructure", models.DeviceTypeAccessPoint, true},
+		{"firewall is infrastructure", models.DeviceTypeFirewall, true},
+		{"desktop is not infrastructure", models.DeviceTypeDesktop, false},
+		{"server is not infrastructure", models.DeviceTypeServer, false},
+		{"unknown is not infrastructure", models.DeviceTypeUnknown, false},
+		{"printer is not infrastructure", models.DeviceTypePrinter, false},
+		{"nas is not infrastructure", models.DeviceTypeNAS, false},
+		{"mobile is not infrastructure", models.DeviceTypeMobile, false},
+		{"iot is not infrastructure", models.DeviceTypeIoT, false},
+		{"camera is not infrastructure", models.DeviceTypeCamera, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsInfrastructureOUI(tt.deviceType)
+			if got != tt.want {
+				t.Errorf("IsInfrastructureOUI(%q) = %v, want %v", tt.deviceType, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPortScannerCreation(t *testing.T) {
+	logger := zap.NewNop()
+
+	t.Run("defaults when zero values provided", func(t *testing.T) {
+		ps := NewPortScanner(0, 0, logger)
+		if ps.timeout != 2*time.Second {
+			t.Errorf("expected default timeout 2s, got %v", ps.timeout)
+		}
+		if ps.concurrency != 10 {
+			t.Errorf("expected default concurrency 10, got %d", ps.concurrency)
+		}
+	})
+
+	t.Run("defaults when negative values provided", func(t *testing.T) {
+		ps := NewPortScanner(-1*time.Second, -5, logger)
+		if ps.timeout != 2*time.Second {
+			t.Errorf("expected default timeout 2s, got %v", ps.timeout)
+		}
+		if ps.concurrency != 10 {
+			t.Errorf("expected default concurrency 10, got %d", ps.concurrency)
+		}
+	})
+
+	t.Run("custom values preserved", func(t *testing.T) {
+		ps := NewPortScanner(5*time.Second, 20, logger)
+		if ps.timeout != 5*time.Second {
+			t.Errorf("expected timeout 5s, got %v", ps.timeout)
+		}
+		if ps.concurrency != 20 {
+			t.Errorf("expected concurrency 20, got %d", ps.concurrency)
+		}
+	})
+}
+
+func TestMatchesFingerprint(t *testing.T) {
+	tests := []struct {
+		name  string
+		ports map[int]bool
+		fp    portFingerprint
+		want  bool
+	}{
+		{
+			name:  "all required ports present",
+			ports: map[int]bool{22: true, 80: true},
+			fp:    portFingerprint{requiredPorts: []int{22, 80}},
+			want:  true,
+		},
+		{
+			name:  "missing required port",
+			ports: map[int]bool{22: true},
+			fp:    portFingerprint{requiredPorts: []int{22, 80}},
+			want:  false,
+		},
+		{
+			name:  "required met with optional present",
+			ports: map[int]bool{22: true, 80: true, 161: true},
+			fp:    portFingerprint{requiredPorts: []int{22, 80}, optionalPorts: []int{161, 443}},
+			want:  true,
+		},
+		{
+			name:  "required met but no optional present",
+			ports: map[int]bool{22: true, 80: true},
+			fp:    portFingerprint{requiredPorts: []int{22, 80}, optionalPorts: []int{161, 443}},
+			want:  false,
+		},
+		{
+			name:  "no required or optional ports",
+			ports: map[int]bool{22: true},
+			fp:    portFingerprint{},
+			want:  true,
+		},
+		{
+			name:  "extra ports do not prevent match",
+			ports: map[int]bool{22: true, 80: true, 443: true, 8080: true},
+			fp:    portFingerprint{requiredPorts: []int{22, 80}},
+			want:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchesFingerprint(tt.ports, &tt.fp)
+			if got != tt.want {
+				t.Errorf("matchesFingerprint() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/recon/store.go
+++ b/internal/recon/store.go
@@ -629,6 +629,17 @@ func (s *ReconStore) UpdateDevice(ctx context.Context, id string, params UpdateD
 	return nil
 }
 
+// UpdateDeviceType updates just the device_type field for a device.
+func (s *ReconStore) UpdateDeviceType(ctx context.Context, deviceID string, deviceType models.DeviceType) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE recon_devices SET device_type = ? WHERE id = ?`,
+		string(deviceType), deviceID)
+	if err != nil {
+		return fmt.Errorf("update device type: %w", err)
+	}
+	return nil
+}
+
 // DeleteDevice removes a device by ID. Returns an error if the device does not exist.
 func (s *ReconStore) DeleteDevice(ctx context.Context, id string) error {
 	res, err := s.db.ExecContext(ctx, `DELETE FROM recon_devices WHERE id = ?`, id)


### PR DESCRIPTION
## Summary

- Add targeted TCP port scanning of infrastructure-specific ports (SSH, HTTP, SNMP, Winbox, UniFi)
- Only scan devices with infrastructure vendor OUI (routers, switches, APs, firewalls)
- Port combination fingerprints identify Ubiquiti UniFi, MikroTik, Cisco-like, and generic managed devices
- Integrate port scanning into scan pipeline after OUI classification, before topology inference
- Port fingerprinting only upgrades device types (never downgrades from more specific classification)
- Add `UpdateDeviceType` and `IsInfrastructureOUI` helpers
- 31 test cases for classification logic, fingerprint matching, and scanner creation

Closes #357

## Test plan

- [x] All 31 port fingerprinting tests pass locally
- [x] `go build ./...` compiles
- [x] `GOOS=linux GOARCH=amd64 go build ./...` cross-compiles
- [x] `go vet ./internal/recon/...` clean
- [ ] CI passes

Generated with [Claude Code](https://claude.com/claude-code)