### PR TITLE
Fix device classification for existing devices on rescan

### DIFF
--- a/internal/recon/classifier.go
+++ b/internal/recon/classifier.go
@@ -51,7 +51,7 @@ const (
 	WeightUPnPDeviceType  = 25 // UPnP device type URN
 	WeightMDNSService     = 20 // mDNS vendor-specific service
 	WeightPortProfile     = 15 // Port combination fingerprint
-	WeightOUIVendor       = 15 // OUI manufacturer hint
+	WeightOUIVendor       = 25 // OUI manufacturer hint
 	WeightTTLNetwork      = 10 // TTL=255 (network equipment)
 	WeightSNMPSysDescr    = 10 // sysDescr keyword match
 )

--- a/internal/recon/classifier_test.go
+++ b/internal/recon/classifier_test.go
@@ -165,7 +165,7 @@ func TestClassify_LLDPHighPriority(t *testing.T) {
 
 	result := Classify(signals)
 
-	// LLDP(40) for Router vs OUI(15) for Switch -> Router wins
+	// LLDP(40) for Router vs OUI(25) for Switch -> Router wins
 	if result.DeviceType != models.DeviceTypeRouter {
 		t.Errorf("expected Router (LLDP higher weight), got %s", result.DeviceType)
 	}
@@ -186,7 +186,7 @@ func TestClassify_TTLBoost(t *testing.T) {
 
 	result := Classify(signals)
 
-	// OUI(15) + TTL(10) both say Router = 25
+	// OUI(25) + TTL(10) both say Router = 35
 	if result.DeviceType != models.DeviceTypeRouter {
 		t.Errorf("expected Router, got %s", result.DeviceType)
 	}
@@ -217,7 +217,7 @@ func TestClassify_AllSignalsAgree(t *testing.T) {
 	if result.DeviceType != models.DeviceTypeSwitch {
 		t.Errorf("expected Switch, got %s", result.DeviceType)
 	}
-	// OUI(15) + sysDescr(10) + BRIDGE-MIB(35) + sysServices(30) + LLDP(40) + Port(15) = 145, capped at 100
+	// OUI(25) + sysDescr(10) + BRIDGE-MIB(35) + sysServices(30) + LLDP(40) + Port(15) = 155, capped at 100
 	if result.Confidence != 100 {
 		t.Errorf("expected confidence capped at 100, got %d", result.Confidence)
 	}

--- a/internal/recon/store.go
+++ b/internal/recon/store.go
@@ -137,16 +137,20 @@ func (s *ReconStore) UpsertDevice(ctx context.Context, device *models.Device) (c
 		if device.DiscoveryMethod != "" {
 			method = device.DiscoveryMethod
 		}
+		deviceType := string(existing.DeviceType)
+		if existing.DeviceType == models.DeviceTypeUnknown && device.DeviceType != models.DeviceTypeUnknown {
+			deviceType = string(device.DeviceType)
+		}
 
 		newStatus := string(models.DeviceStatusOnline)
 
 		_, err = s.db.ExecContext(ctx, `
 			UPDATE recon_devices SET
 				ip_addresses = ?, mac_address = ?, manufacturer = ?,
-				status = ?, discovery_method = ?, last_seen = ?
+				status = ?, discovery_method = ?, device_type = ?, last_seen = ?
 			WHERE id = ?`,
 			string(ipsJSON), mac, manufacturer,
-			newStatus, string(method), now,
+			newStatus, string(method), deviceType, now,
 			existing.ID,
 		)
 		if err != nil {


### PR DESCRIPTION
## Summary

- UpsertDevice UPDATE now includes `device_type` when upgrading from "unknown" to a classified type (never overwrites non-unknown)
- OUI vendor weight raised from 15 to 25 so single-signal classification meets the minimum confidence threshold for common home devices (routers, printers, NAS, etc.)

## Test plan

- [x] `TestUpsertDevice_UpdatesDeviceTypeFromUnknown` -- verifies unknown->classified upgrade
- [x] `TestUpsertDevice_DoesNotDowngradeDeviceType` -- verifies non-unknown types preserved
- [x] Updated classifier test comments to reflect new OUI weight
- [x] All existing recon tests pass
- [x] Cross-compilation verified

Closes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)