### PR TITLE
Enhanced scan button with device count and elapsed timer

### DIFF
--- a/web/src/components/scan-button.tsx
+++ b/web/src/components/scan-button.tsx
@@ -1,0 +1,93 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { RefreshCw, Radar, CheckCircle2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { useScanStore } from '@/stores/scan'
+
+/** Format elapsed seconds as "M:SS". */
+function formatElapsed(seconds: number): string {
+  const m = Math.floor(seconds / 60)
+  const s = seconds % 60
+  return `${m}:${s.toString().padStart(2, '0')}`
+}
+
+interface ScanButtonProps {
+  onScan: () => void
+  isPending: boolean
+}
+
+export function ScanButton({ onScan, isPending }: ScanButtonProps) {
+  const activeScan = useScanStore((s) => s.activeScan)
+  const [elapsed, setElapsed] = useState(0)
+
+  const isScanning =
+    !!activeScan &&
+    (activeScan.status === 'starting' ||
+      activeScan.status === 'scanning' ||
+      activeScan.status === 'processing')
+
+  const isCompleted = activeScan?.status === 'completed'
+
+  // Store startedAt in a ref via an effect so the interval callback
+  // always has the correct value without restarting the interval.
+  const startedAtRef = useRef(0)
+  const startedAtMs = isScanning && activeScan ? activeScan.startedAt.getTime() : 0
+
+  useEffect(() => {
+    startedAtRef.current = startedAtMs
+  }, [startedAtMs])
+
+  // Elapsed timer: computes elapsed inside the interval callback (not render).
+  useEffect(() => {
+    if (!isScanning) return
+
+    const interval = setInterval(() => {
+      const now = Date.now()
+      setElapsed(Math.floor((now - startedAtRef.current) / 1000))
+    }, 1000)
+
+    return () => {
+      clearInterval(interval)
+    }
+  }, [isScanning])
+
+  const handleClick = useCallback(() => {
+    onScan()
+  }, [onScan])
+
+  const disabled = isPending || isScanning
+
+  // Completion state: the store keeps activeScan as 'completed' for 3 seconds
+  // before clearing it, so we render the summary during that window.
+  if (isCompleted && activeScan) {
+    return (
+      <Button disabled className="gap-2">
+        <CheckCircle2 className="h-4 w-4 text-green-400" />
+        Scan Complete &ndash; {activeScan.devicesFound} device
+        {activeScan.devicesFound !== 1 ? 's' : ''}
+      </Button>
+    )
+  }
+
+  // Scanning state: device count + elapsed timer
+  if (isScanning && activeScan) {
+    const deviceLabel = `${activeScan.devicesFound} device${activeScan.devicesFound !== 1 ? 's' : ''}`
+    return (
+      <Button disabled className="gap-2">
+        <RefreshCw className="h-4 w-4 animate-spin" />
+        Scanning... {deviceLabel} ({formatElapsed(elapsed)})
+      </Button>
+    )
+  }
+
+  // Idle state
+  return (
+    <Button onClick={handleClick} disabled={disabled} className="gap-2">
+      {isPending ? (
+        <RefreshCw className="h-4 w-4 animate-spin" />
+      ) : (
+        <Radar className="h-4 w-4" />
+      )}
+      {isPending ? 'Starting...' : 'Scan Network'}
+    </Button>
+  )
+}

--- a/web/src/pages/devices/index.tsx
+++ b/web/src/pages/devices/index.tsx
@@ -3,7 +3,6 @@ import { Link, useSearchParams } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   RefreshCw,
-  Radar,
   LayoutGrid,
   List,
   Search,
@@ -20,6 +19,7 @@ import {
   AlertCircle,
   AlertTriangle,
   MapPin,
+  Radar,
   Tag,
   User,
   X,
@@ -30,6 +30,7 @@ import { Input } from '@/components/ui/input'
 import { Skeleton } from '@/components/ui/skeleton'
 import { DeviceCard, DeviceCardCompact } from '@/components/device-card'
 import { CreateDeviceDialog } from '@/components/create-device-dialog'
+import { ScanButton } from '@/components/scan-button'
 import {
   listDevices,
   deleteDevice,
@@ -37,7 +38,6 @@ import {
   getInventorySummary,
   bulkUpdateDevices,
 } from '@/api/devices'
-import { useScanStore } from '@/stores/scan'
 import type { DeviceStatus, DeviceType } from '@/api/types'
 import { cn } from '@/lib/utils'
 import { useKeyboardShortcuts } from '@/hooks/use-keyboard-shortcuts'
@@ -87,7 +87,6 @@ function isDeviceStale(lastSeen: string): boolean {
 export function DevicesPage() {
   const [searchParams, setSearchParams] = useSearchParams()
   const queryClient = useQueryClient()
-  const activeScan = useScanStore((s) => s.activeScan)
 
   // State from URL params or defaults
   const statusFilter = (searchParams.get('status') as DeviceStatus | 'all' | 'stale') || 'all'
@@ -416,18 +415,7 @@ export function DevicesPage() {
             Add Device
           </Button>
 
-          <Button
-            onClick={() => scanMutation.mutate()}
-            disabled={scanMutation.isPending || !!activeScan}
-            className="gap-2"
-          >
-            {scanMutation.isPending || activeScan ? (
-              <RefreshCw className="h-4 w-4 animate-spin" />
-            ) : (
-              <Radar className="h-4 w-4" />
-            )}
-            {activeScan ? 'Scanning...' : 'Scan Network'}
-          </Button>
+          <ScanButton onScan={() => scanMutation.mutate()} isPending={scanMutation.isPending} />
 
           <Button variant="outline" size="icon" onClick={() => refetch()} disabled={isLoading}>
             <RefreshCw className={cn('h-4 w-4', isLoading && 'animate-spin')} />
@@ -662,9 +650,7 @@ export function DevicesPage() {
                   <Plus className="h-4 w-4" />
                   Add Device
                 </Button>
-                <Button onClick={() => scanMutation.mutate()} disabled={scanMutation.isPending}>
-                  {scanMutation.isPending ? 'Scanning...' : 'Scan Network'}
-                </Button>
+                <ScanButton onScan={() => scanMutation.mutate()} isPending={scanMutation.isPending} />
               </div>
             </>
           ) : (


### PR DESCRIPTION
## Summary

- Extract scan button into dedicated `ScanButton` component
- Show real-time device count and MM:SS elapsed timer during scans
- Display 3-second completion summary before reverting to idle
- Three states: idle (Scan Network), running (Scanning... N devices M:SS), complete (Scan Complete)

## Test plan

- [x] TypeScript compiles cleanly
- [x] ESLint passes
- [x] Frontend-only change, no backend modifications

Closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)