### PR TITLE
feat: scan metrics collection with per-phase timing

### DIFF
--- a/internal/recon/handlers.go
+++ b/internal/recon/handlers.go
@@ -202,6 +202,28 @@ func (m *Module) handleGetScan(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, scan)
 }
 
+// handleGetScanMetrics returns timing and count metrics for a single scan.
+func (m *Module) handleGetScanMetrics(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "scan ID is required")
+		return
+	}
+
+	metrics, err := m.store.GetScanMetrics(r.Context(), id)
+	if err != nil {
+		m.logger.Error("failed to get scan metrics", zap.String("scan_id", id), zap.Error(err))
+		writeError(w, http.StatusInternalServerError, "failed to get scan metrics")
+		return
+	}
+	if metrics == nil {
+		writeError(w, http.StatusNotFound, "scan metrics not found")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, metrics)
+}
+
 // handleTopology returns the network topology as a graph.
 //
 //	@Summary		Get topology

--- a/internal/recon/migrations.go
+++ b/internal/recon/migrations.go
@@ -152,5 +152,24 @@ func migrations() []plugin.Migration {
 				return nil
 			},
 		},
+		{
+			Version:     6,
+			Description: "create scan_metrics table for per-scan timing and count data",
+			Up: func(tx *sql.Tx) error {
+				_, err := tx.Exec(`CREATE TABLE IF NOT EXISTS recon_scan_metrics (
+					scan_id TEXT PRIMARY KEY REFERENCES recon_scans(id) ON DELETE CASCADE,
+					duration_ms INTEGER NOT NULL,
+					ping_phase_ms INTEGER NOT NULL,
+					enrich_phase_ms INTEGER NOT NULL,
+					post_process_ms INTEGER NOT NULL,
+					hosts_scanned INTEGER NOT NULL,
+					hosts_alive INTEGER NOT NULL,
+					devices_created INTEGER NOT NULL,
+					devices_updated INTEGER NOT NULL,
+					created_at TEXT NOT NULL DEFAULT (datetime('now'))
+				)`)
+				return err
+			},
+		},
 	}
 }

--- a/internal/recon/recon.go
+++ b/internal/recon/recon.go
@@ -230,6 +230,7 @@ func (m *Module) Routes() []plugin.Route {
 		{Method: "POST", Path: "/scan", Handler: m.handleScan},
 		{Method: "GET", Path: "/scans", Handler: m.handleListScans},
 		{Method: "GET", Path: "/scans/{id}", Handler: m.handleGetScan},
+		{Method: "GET", Path: "/scans/{id}/metrics", Handler: m.handleGetScanMetrics},
 		{Method: "GET", Path: "/topology", Handler: m.handleTopology},
 		{Method: "GET", Path: "/topology/layouts", Handler: m.handleListTopologyLayouts},
 		{Method: "POST", Path: "/topology/layouts", Handler: m.handleCreateTopologyLayout},

--- a/pkg/models/network.go
+++ b/pkg/models/network.go
@@ -32,6 +32,20 @@ type ScanResult struct {
 	Online    int      `json:"online" example:"8"`
 }
 
+// ScanMetrics holds detailed timing and performance data for a scan.
+type ScanMetrics struct {
+	ScanID        string `json:"scan_id" db:"scan_id"`
+	DurationMs    int64  `json:"duration_ms" db:"duration_ms"`
+	PingPhaseMs   int64  `json:"ping_phase_ms" db:"ping_phase_ms"`
+	EnrichPhaseMs int64  `json:"enrich_phase_ms" db:"enrich_phase_ms"`
+	PostProcessMs int64  `json:"post_process_ms" db:"post_process_ms"`
+	HostsScanned  int    `json:"hosts_scanned" db:"hosts_scanned"`
+	HostsAlive    int    `json:"hosts_alive" db:"hosts_alive"`
+	DevicesCreated int   `json:"devices_created" db:"devices_created"`
+	DevicesUpdated int   `json:"devices_updated" db:"devices_updated"`
+	CreatedAt     string `json:"created_at" db:"created_at"`
+}
+
 // AgentInfo represents the state of a connected Scout agent.
 type AgentInfo struct {
 	ID          string `json:"id" example:"agent-550e8400"`


### PR DESCRIPTION
## Summary

- Adds `recon_scan_metrics` table (migration v6) with per-phase timing breakdown
- Instruments `RunScan()` with `time.Now()` checkpoints at each phase boundary
- Tracks devices created vs updated counts from UpsertDevice return values
- New `GET /scans/{id}/metrics` endpoint returns timing data
- `SaveScanMetrics` / `GetScanMetrics` store methods

Closes #346

## Test plan

- [x] `TestSaveScanMetrics` -- save and retrieve metrics, verify all fields
- [x] `TestGetScanMetrics_NotFound` -- returns nil for missing scan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [ ] CI passes all checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)