### PR TITLE
feat: CI smoke test of Docker image after GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,3 +71,27 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  smoke-test:
+    name: Smoke Test Docker Image
+    needs: release
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull Docker image
+        run: docker pull ghcr.io/herbhall/subnetree:latest
+
+      - name: Run smoke tests
+        run: |
+          chmod +x tools/docker-smoke-test.sh
+          ./tools/docker-smoke-test.sh --ci ghcr.io/herbhall/subnetree:latest


### PR DESCRIPTION
## Summary

- Add `smoke-test` job to `release.yml` that runs after GoReleaser publishes the Docker image
- Enhance `docker-smoke-test.sh` with CI-aware output (`--ci` flag, `::error::`/`::warning::` annotations, `$GITHUB_STEP_SUMMARY` markdown)
- Smoke test failure is informational (`continue-on-error: true`) -- does not block releases

## Details

The existing `tools/docker-smoke-test.sh` already validates health endpoints, dashboard, auth flow, vault, and pulse/insight. This PR integrates it into the release pipeline so broken Docker images are detected automatically.

**CI mode additions:**
- `--ci` flag and `CI` env var auto-detection
- GitHub Actions annotations for failures and warnings
- Step summary with results table and collapsible full output

Closes #392

## Test plan

- [ ] Verify `bash -n tools/docker-smoke-test.sh` passes (syntax check)
- [ ] Verify release.yml YAML is valid
- [ ] Next release tag triggers both `release` and `smoke-test` jobs
- [ ] Smoke test pulls from GHCR and runs the full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)