### PR TITLE
feat: store classification confidence on device model

### DIFF
--- a/api/swagger/docs.go
+++ b/api/swagger/docs.go
@@ -4874,6 +4874,19 @@ const docTemplate = `{
                     "type": "string",
                     "example": "production"
                 },
+                "classification_confidence": {
+                    "description": "Classification metadata from the composite classifier.",
+                    "type": "integer",
+                    "example": 75
+                },
+                "classification_signals": {
+                    "description": "JSON-encoded signal breakdown",
+                    "type": "string"
+                },
+                "classification_source": {
+                    "type": "string",
+                    "example": "snmp_bridge_mib"
+                },
                 "custom_fields": {
                     "type": "object",
                     "additionalProperties": {

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -4867,6 +4867,19 @@
                     "type": "string",
                     "example": "production"
                 },
+                "classification_confidence": {
+                    "description": "Classification metadata from the composite classifier.",
+                    "type": "integer",
+                    "example": 75
+                },
+                "classification_signals": {
+                    "description": "JSON-encoded signal breakdown",
+                    "type": "string"
+                },
+                "classification_source": {
+                    "type": "string",
+                    "example": "snmp_bridge_mib"
+                },
                 "custom_fields": {
                     "type": "object",
                     "additionalProperties": {

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -318,6 +318,16 @@ definitions:
       category:
         example: production
         type: string
+      classification_confidence:
+        description: Classification metadata from the composite classifier.
+        example: 75
+        type: integer
+      classification_signals:
+        description: JSON-encoded signal breakdown
+        type: string
+      classification_source:
+        example: snmp_bridge_mib
+        type: string
       custom_fields:
         additionalProperties:
           type: string

--- a/internal/recon/migrations.go
+++ b/internal/recon/migrations.go
@@ -203,5 +203,22 @@ func migrations() []plugin.Migration {
 				return nil
 			},
 		},
+		{
+			Version:     8,
+			Description: "add classification confidence columns to recon_devices",
+			Up: func(tx *sql.Tx) error {
+				stmts := []string{
+					`ALTER TABLE recon_devices ADD COLUMN classification_confidence INTEGER NOT NULL DEFAULT 0`,
+					`ALTER TABLE recon_devices ADD COLUMN classification_source TEXT NOT NULL DEFAULT ''`,
+					`ALTER TABLE recon_devices ADD COLUMN classification_signals TEXT NOT NULL DEFAULT ''`,
+				}
+				for _, stmt := range stmts {
+					if _, err := tx.Exec(stmt); err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+		},
 	}
 }

--- a/pkg/models/device.go
+++ b/pkg/models/device.go
@@ -68,4 +68,9 @@ type Device struct {
 	Category        string            `json:"category,omitempty" example:"production"`
 	PrimaryRole     string            `json:"primary_role,omitempty" example:"web-server"`
 	Owner           string            `json:"owner,omitempty" example:"platform-team"`
+
+	// Classification metadata from the composite classifier.
+	ClassificationConfidence int    `json:"classification_confidence,omitempty" example:"75"`
+	ClassificationSource     string `json:"classification_source,omitempty" example:"snmp_bridge_mib"`
+	ClassificationSignals    string `json:"classification_signals,omitempty"` // JSON-encoded signal breakdown
 }

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -98,6 +98,9 @@ export interface Device {
   category?: string
   primary_role?: string
   owner?: string
+  classification_confidence?: number
+  classification_source?: string
+  classification_signals?: string
 }
 
 /** Topology node (simplified device for graph display). */


### PR DESCRIPTION
## Summary

- Add `ClassificationConfidence`, `ClassificationSource`, `ClassificationSignals` fields to Device model
- Database migration (v8) adds columns to `recon_devices`
- Classifier results now persisted through scanner pipeline
- Manual type overrides set confidence=100, source="manual"
- Device detail page shows classification section with color-coded confidence badge and signal breakdown table

## Details

The composite classifier already computed confidence scores and signal breakdowns but discarded them after setting `device_type`. Now users can see **why** a device was classified a certain way.

**Backend:** UpsertDevice merges confidence (keeps higher). All SELECT queries and scan helpers updated. New `UpdateDeviceClassification` method for scanner use.

**Frontend:** Classification section on device detail page renders when confidence > 0. Shows confidence tier (Identified/Probable/Unknown) with color badge, primary source, and expandable signal table.

Closes #395

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes
- [ ] `GOOS=linux GOARCH=amd64 go build ./...` passes
- [ ] `npx tsc --noEmit` passes
- [ ] `npx eslint src/pages/devices/` passes
- [ ] Swagger spec regenerated and committed
- [ ] Device detail page shows classification for scanned devices
- [ ] Manual type override sets confidence to 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)