### PR TITLE
feat: SNMP FDB table walks for switch port mapping

### DIFF
--- a/internal/recon/snmp_oids.go
+++ b/internal/recon/snmp_oids.go
@@ -22,6 +22,16 @@ const (
 	OIDBridgeType     = "1.3.6.1.2.1.17.1.3.0" // dot1dBaseType
 )
 
+// BRIDGE-MIB Forwarding Database (1.3.6.1.2.1.17.4.3.1).
+const (
+	OIDFdbAddress = "1.3.6.1.2.1.17.4.3.1.1" // dot1dTpFdbAddress (MAC)
+	OIDFdbPort    = "1.3.6.1.2.1.17.4.3.1.2" // dot1dTpFdbPort (bridge port number)
+	OIDFdbStatus  = "1.3.6.1.2.1.17.4.3.1.3" // dot1dTpFdbStatus (1=other,2=invalid,3=learned,4=self,5=mgmt)
+)
+
+// BRIDGE-MIB port-to-ifIndex mapping.
+const OIDBasePortIfIndex = "1.3.6.1.2.1.17.1.4.1.2" // dot1dBasePortIfIndex
+
 // IF-MIB interface table (1.3.6.1.2.1.2.2.1).
 const (
 	OIDIfIndex       = "1.3.6.1.2.1.2.2.1.1"
@@ -33,3 +43,6 @@ const (
 	OIDIfAdminStatus = "1.3.6.1.2.1.2.2.1.7"
 	OIDIfOperStatus  = "1.3.6.1.2.1.2.2.1.8"
 )
+
+// IF-MIB extensions (1.3.6.1.2.1.31.1.1.1).
+const OIDIfName = "1.3.6.1.2.1.31.1.1.1.1" // ifName (short name like "Gi0/1")

--- a/internal/recon/store.go
+++ b/internal/recon/store.go
@@ -919,6 +919,18 @@ func (s *ReconStore) RemoveARPLinksForDevice(ctx context.Context, deviceID strin
 	return nil
 }
 
+// RemoveFDBLinksForDevice removes FDB-inferred topology links where the given
+// device is the source (switch). Called before re-inserting fresh FDB data.
+func (s *ReconStore) RemoveFDBLinksForDevice(ctx context.Context, deviceID string) error {
+	_, err := s.db.ExecContext(ctx,
+		`DELETE FROM recon_topology_links WHERE link_type = 'fdb' AND source_device_id = ?`,
+		deviceID)
+	if err != nil {
+		return fmt.Errorf("remove FDB links for device %s: %w", deviceID, err)
+	}
+	return nil
+}
+
 // BulkUpdateDevices applies the same partial update to all devices matching the given IDs.
 // Returns the number of updated rows.
 func (s *ReconStore) BulkUpdateDevices(ctx context.Context, ids []string, params UpdateDeviceParams) (int, error) {


### PR DESCRIPTION
## Summary

- Walk BRIDGE-MIB forwarding database (FDB) tables on classified switches during scan post-processing to map MAC-to-port relationships
- Create topology links with `link_type = "fdb"` for accurate switch-port-to-device mapping in the topology view
- Support Cisco VLAN-indexed community string fallback (`community@1`) for per-VLAN FDB access

## Changes

**snmp_oids.go**: Add FDB OIDs (`dot1dTpFdbAddress`, `dot1dTpFdbPort`, `dot1dTpFdbStatus`), `dot1dBasePortIfIndex` for bridge-port-to-ifIndex mapping, and `ifName` for human-readable port names.

**snmp_collector.go**: Add `FDBEntry` type, `WalkFDB` method (connects to switch, walks FDB tables, tries Cisco VLAN community on empty result), `walkFDBTables` helper (walks 4 MIB tables, assembles entries filtering out self/invalid), and `extractMACFromOID` helper.

**scanner.go**: Add `SNMPWalker` and `CredentialLookup` consumer-side interfaces. Add `snmpWalker`, `credLookup`, `credAccess` fields with setter methods. Add `"fdb-walk"` pipeline stage after classification. Add `walkSwitchFDBTables` method that iterates classified switches (confidence >= 50), finds SNMP credentials, walks FDB, removes stale links, and upserts new topology links.

**store.go**: Add `RemoveFDBLinksForDevice` to clean stale FDB topology links before re-inserting fresh data.

**recon.go**: Wire `SetSNMPWalker` and `SetCredentialLookup` in `Start()`. Pass `SetCredentialAccessor` through to orchestrator. Add `FindSNMPCredentialForDevice` implementing `CredentialLookup`.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/recon/...` passes
- [x] `GOOS=linux GOARCH=amd64 go build ./...` passes
- [ ] CI checks pass

Closes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)