### PR TITLE
docs: ADR-0008 consolidate workspace

### DIFF
--- a/docs/adr/0008-consolidate-workspace.md
+++ b/docs/adr/0008-consolidate-workspace.md
@@ -1,0 +1,32 @@
+# 8. Consolidate workspace -- absorb coordination and research
+
+Date: 2026-02-16
+
+## Status
+
+Accepted
+
+## Context
+
+SubNetree development used three separate git repos in one VS Code workspace:
+SubNetree (GitHub), .coordination (local git), and research/HomeLab (local git).
+This created unnecessary complexity for a solo developer -- three repos to manage,
+absolute paths in documentation, and Claude Code needing to understand multi-repo layout.
+
+The Runbooks project demonstrated that project-local `.coordination/` (gitignored)
+is simpler and sufficient for a single-project coordination pattern.
+
+## Decision
+
+Move `.coordination/` and `research/HomeLab/` inside `SubNetree/` as gitignored
+directories. The workspace file becomes single-root. Research outputs are published
+to `docs/research/` (committed) when ready for public consumption.
+
+## Consequences
+
+- Single project directory, single workspace root, single mental model
+- Claude Code sees everything in one tree
+- Two fewer local git repos to manage
+- Clear publishing pipeline: research/ (private) -> docs/research/ (public)
+- Path references in CLAUDE.md, settings.json, and DASHBOARD.md updated to relative
+- No impact on Go code, CI/CD, or public repo structure


### PR DESCRIPTION
## Summary

- Records the architectural decision to consolidate 3 repos into 1
- `.coordination/` and `research/HomeLab/` absorbed as gitignored directories
- See PR #406 for the implementation

## Test plan

- [x] ADR follows existing format (docs/adr/template.md)
- [x] No code changes, docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)