### PR TITLE
chore: add Docker QC workflow for pre-release local testing

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -109,6 +109,32 @@
       "type": "shell",
       "command": "make clean",
       "problemMatcher": []
+    },
+    {
+      "label": "Docker: QC Build & Run",
+      "detail": "Build from source + seed data for manual QC testing",
+      "type": "shell",
+      "command": "make docker-qc",
+      "problemMatcher": [],
+      "presentation": { "reveal": "always", "panel": "dedicated", "focus": true },
+      "group": "test"
+    },
+    {
+      "label": "Docker: QC Smoke Test",
+      "detail": "Build, start, run smoke tests, tear down",
+      "type": "shell",
+      "command": "make docker-qc-smoke",
+      "problemMatcher": [],
+      "presentation": { "reveal": "always", "panel": "dedicated", "focus": true },
+      "group": "test"
+    },
+    {
+      "label": "Docker: QC Teardown",
+      "detail": "Stop QC container and remove volumes",
+      "type": "shell",
+      "command": "make docker-qc-down",
+      "problemMatcher": [],
+      "presentation": { "reveal": "silent" }
     }
   ]
 }

--- a/docker-compose.qc.yml
+++ b/docker-compose.qc.yml
@@ -1,0 +1,50 @@
+# SubNetree - Pre-Release QC Compose
+#
+# Builds from local source AND loads seed data for manual QC testing.
+# Use this before creating PRs to catch issues that unit tests miss.
+#
+# Usage:
+#   make docker-qc           # Build, start, and open browser
+#   make docker-qc-down      # Tear down and clean volumes
+#   make docker-qc-smoke     # Build, start, and run smoke tests
+#
+# Or directly:
+#   docker compose -f docker-compose.qc.yml up --build
+#
+# Then open http://localhost:8080 and walk through the setup wizard.
+# Default credentials after setup: admin / TestPass123!
+
+services:
+  subnetree:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        VERSION: ${VERSION:-dev-qc}
+        COMMIT: ${COMMIT:-unknown}
+        BUILD_TIME: ${BUILD_TIME:-unknown}
+    container_name: subnetree-qc
+    restart: "no"
+    ports:
+      - "8080:8080"
+      - "9090:9090"
+    volumes:
+      - qc-data:/data
+    environment:
+      - NV_DATABASE_DSN=/data/subnetree.db
+      - NV_LOG_LEVEL=debug
+      - NV_DEV_MODE=true
+      - NV_SEED_DATA=true
+      - SUBNETREE_VAULT_PASSPHRASE=QCVaultPass123!
+    cap_add:
+      - NET_RAW
+      - NET_ADMIN
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 15s
+
+volumes:
+  qc-data:


### PR DESCRIPTION
## Summary

- Add `docker-compose.qc.yml` that builds from local source with seed data and vault auto-unseal for manual QC testing
- Add `make docker-qc`, `make docker-qc-down`, and `make docker-qc-smoke` Makefile targets
- Add VS Code tasks ("Docker: QC Build & Run", "Docker: QC Smoke Test", "Docker: QC Teardown")

This fills the gap between `docker-compose.dev.yml` (builds locally but no seed data) and `docker-compose.staging.yml` (has seed data but pulls from GHCR). Now `make docker-qc` gives a one-command workflow to build from your working tree and test with 20 demo devices before pushing.

## Test plan

- [ ] Run `make docker-qc` and verify container builds and starts with seed data
- [ ] Browse http://localhost:8080, complete setup wizard, verify dashboard shows devices
- [ ] Run `make docker-qc-down` and verify clean teardown
- [ ] Run `make docker-qc-smoke` and verify automated smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)