### PR TITLE
fix: use global inventory counts for status filter pills

### DIFF
--- a/web/src/pages/devices/index.tsx
+++ b/web/src/pages/devices/index.tsx
@@ -351,15 +351,7 @@ export function DevicesPage() {
     setSearchParams(searchParams)
   }
 
-  // Count devices by status and type (from current page data for display)
-  const statusCounts = devices.reduce(
-    (acc, d) => {
-      acc[d.status] = (acc[d.status] || 0) + 1
-      return acc
-    },
-    {} as Record<string, number>
-  )
-
+  // Count devices by type (from current page data for type filter dropdown)
   const typeCounts = devices.reduce(
     (acc, d) => {
       acc[d.device_type] = (acc[d.device_type] || 0) + 1
@@ -503,14 +495,14 @@ export function DevicesPage() {
             />
             <StatusPill
               label="Online"
-              count={statusCounts.online || 0}
+              count={inventorySummary?.online_count ?? 0}
               status="online"
               active={statusFilter === 'online'}
               onClick={() => updateFilter('status', 'online')}
             />
             <StatusPill
               label="Offline"
-              count={statusCounts.offline || 0}
+              count={inventorySummary?.offline_count ?? 0}
               status="offline"
               active={statusFilter === 'offline'}
               onClick={() => updateFilter('status', 'offline')}


### PR DESCRIPTION
## Summary

- Online/Offline filter pills now use `inventorySummary.online_count` / `offline_count` from the API instead of page-local `statusCounts` computed from the current page's device array
- Removed dead `statusCounts` computation (was only used by those two pills)
- All four status pills now consistently use global data: All (totalDevices), Online/Offline (inventorySummary), Stale (inventorySummary)

## Root Cause

Filter pills computed counts from the paginated `devices` array (e.g., 25 devices on page 1), showing "Online 25" when the actual global total was 51. The `inventorySummary` API already provided correct global counts but was only used for the Stale pill.

## Test plan

- [x] `tsc --noEmit` passes
- [x] `eslint` passes
- [ ] CI checks pass

Closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)