### PR TITLE
fix: disable mDNS/UPnP auto-discovery in QC container

### DIFF
--- a/docker-compose.qc.yml
+++ b/docker-compose.qc.yml
@@ -35,6 +35,9 @@ services:
       - NV_LOG_LEVEL=debug
       - NV_DEV_MODE=true
       - NV_SEED_DATA=true
+      - NV_RECON_MDNS_ENABLED=false
+      - NV_RECON_UPNP_ENABLED=false
+      - NV_RECON_SCHEDULE_ENABLED=false
       - SUBNETREE_VAULT_PASSPHRASE=QCVaultPass123!
     cap_add:
       - NET_RAW

--- a/internal/recon/recon.go
+++ b/internal/recon/recon.go
@@ -2,7 +2,9 @@ package recon
 
 import (
 	"context"
+	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -106,6 +108,20 @@ func (m *Module) Init(ctx context.Context, deps plugin.Dependencies) error {
 		if v := deps.Config.GetString("schedule.subnet"); v != "" {
 			m.cfg.Schedule.Subnet = v
 		}
+	}
+
+	// Allow disabling discovery via environment for QC/testing containers.
+	// Viper's Sub() does not inherit AutomaticEnv, so plugin-scoped env vars
+	// like NV_RECON_MDNS_ENABLED are not visible to the sub-Viper. We check
+	// them explicitly here.
+	if v := os.Getenv("NV_RECON_MDNS_ENABLED"); strings.EqualFold(v, "false") {
+		m.cfg.MDNSEnabled = false
+	}
+	if v := os.Getenv("NV_RECON_UPNP_ENABLED"); strings.EqualFold(v, "false") {
+		m.cfg.UPNPEnabled = false
+	}
+	if v := os.Getenv("NV_RECON_SCHEDULE_ENABLED"); strings.EqualFold(v, "false") {
+		m.cfg.Schedule.Enabled = false
 	}
 
 	// Run database migrations.


### PR DESCRIPTION
## Summary

- Added explicit env var checks in Recon module Init for `NV_RECON_MDNS_ENABLED`, `NV_RECON_UPNP_ENABLED`, and `NV_RECON_SCHEDULE_ENABLED`
- Viper's `Sub()` doesn't inherit `AutomaticEnv()`, so plugin-scoped env vars need explicit handling
- Set all three to `false` in `docker-compose.qc.yml` so QC container only shows curated seed devices

## Root Cause

mDNS and UPnP auto-discovery were enabled by default, discovering 34+ Docker network devices and polluting the 20-device seed data with junk "Unknown" entries. No env var path existed to disable these per-plugin settings.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/recon/...` passes
- [x] `GOOS=linux GOARCH=amd64 go build ./...` passes
- [ ] CI checks pass

Closes #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)