### PR TITLE
fix: increase default page size to 256 for full Class C

### DIFF
--- a/web/src/pages/devices/index.tsx
+++ b/web/src/pages/devices/index.tsx
@@ -103,7 +103,7 @@ export function DevicesPage() {
   const [searchQuery, setSearchQuery] = useState('')
   const [sortField, setSortField] = useState<SortField>('ip')
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
-  const [pageSize, setPageSize] = useState(100)
+  const [pageSize, setPageSize] = useState(256)
   const [currentPage, setCurrentPage] = useState(1)
   const [createDialogOpen, setCreateDialogOpen] = useState(false)
   const [deletingId, setDeletingId] = useState<string | null>(null)


### PR DESCRIPTION
## Summary

- Default page size changed from 100 to 256 to actually fit a full Class C subnet (256 addresses)

## Context

PR #422 set it to 100 which doesn't cover a full /24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)