### PR TITLE
fix: agent pages - setup link in empty state, shell labels on code blocks

### DIFF
--- a/web/src/pages/agents/index.tsx
+++ b/web/src/pages/agents/index.tsx
@@ -187,8 +187,9 @@ export function AgentsPage() {
             <>
               <h3 className="text-lg font-medium">No agents enrolled</h3>
               <p className="text-sm text-muted-foreground mt-1 max-w-md mx-auto">
-                Install the Scout agent on devices you want to monitor. Create an enrollment
-                token and use it to register agents with the server.
+                Install the Scout agent on devices you want to monitor.
+                See <Link to="/agent-setup" className="text-primary hover:underline">Agent Setup</Link> for
+                download and installation instructions.
               </p>
             </>
           ) : (


### PR DESCRIPTION
## Summary

- **Agents page**: Empty state now links to Agent Setup page instead of generic text about enrollment tokens
- **Agent Setup page**: Every code block now shows a shell label header (bash, PowerShell, CMD) so users know which terminal to use
- **Windows**: Install commands offer both PowerShell and CMD variants via tabs
- **Enrollment / Quick Reference**: Shell labels match the selected platform tab

## Test plan

- [ ] Agents page with 0 agents shows "See Agent Setup" link that navigates to /agent-setup
- [ ] Agent Setup: Linux/macOS code blocks show "bash" label
- [ ] Agent Setup: Windows shows PowerShell/CMD tabs with different install commands
- [ ] Switching platform tabs updates shell labels in enrollment and quick reference sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)