### PR TITLE
feat: hardware asset profile schema and store layer (#437)

### DIFF
--- a/internal/recon/hardware_store.go
+++ b/internal/recon/hardware_store.go
@@ -1,0 +1,553 @@
+package recon
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/HerbHall/subnetree/pkg/models"
+	"github.com/google/uuid"
+)
+
+// UpsertDeviceHardware inserts or updates a hardware profile for a device.
+// If an existing record has collection_source = "manual" and the incoming source
+// is not "manual", only empty/zero fields are filled (manual data is preserved).
+func (s *ReconStore) UpsertDeviceHardware(ctx context.Context, hw *models.DeviceHardware) error {
+	now := time.Now().UTC()
+
+	// Check for existing manual override.
+	var existingSource string
+	err := s.db.QueryRowContext(ctx,
+		"SELECT collection_source FROM recon_device_hardware WHERE device_id = ?",
+		hw.DeviceID).Scan(&existingSource)
+
+	if err == nil && existingSource == "manual" && hw.CollectionSource != "manual" {
+		// Existing record is manual, incoming is auto-collected.
+		// Only update fields that are currently empty/zero.
+		_, err = s.db.ExecContext(ctx, `UPDATE recon_device_hardware SET
+			hostname = CASE WHEN hostname = '' THEN ? ELSE hostname END,
+			fqdn = CASE WHEN fqdn = '' THEN ? ELSE fqdn END,
+			os_name = CASE WHEN os_name = '' THEN ? ELSE os_name END,
+			os_version = CASE WHEN os_version = '' THEN ? ELSE os_version END,
+			os_arch = CASE WHEN os_arch = '' THEN ? ELSE os_arch END,
+			kernel = CASE WHEN kernel = '' THEN ? ELSE kernel END,
+			cpu_model = CASE WHEN cpu_model = '' THEN ? ELSE cpu_model END,
+			cpu_cores = CASE WHEN cpu_cores = 0 THEN ? ELSE cpu_cores END,
+			cpu_threads = CASE WHEN cpu_threads = 0 THEN ? ELSE cpu_threads END,
+			cpu_arch = CASE WHEN cpu_arch = '' THEN ? ELSE cpu_arch END,
+			ram_total_mb = CASE WHEN ram_total_mb = 0 THEN ? ELSE ram_total_mb END,
+			ram_type = CASE WHEN ram_type = '' THEN ? ELSE ram_type END,
+			ram_slots_used = CASE WHEN ram_slots_used = 0 THEN ? ELSE ram_slots_used END,
+			ram_slots_total = CASE WHEN ram_slots_total = 0 THEN ? ELSE ram_slots_total END,
+			platform_type = CASE WHEN platform_type = '' THEN ? ELSE platform_type END,
+			hypervisor = CASE WHEN hypervisor = '' THEN ? ELSE hypervisor END,
+			vm_host_id = CASE WHEN vm_host_id = '' THEN ? ELSE vm_host_id END,
+			system_manufacturer = CASE WHEN system_manufacturer = '' THEN ? ELSE system_manufacturer END,
+			system_model = CASE WHEN system_model = '' THEN ? ELSE system_model END,
+			serial_number = CASE WHEN serial_number = '' THEN ? ELSE serial_number END,
+			bios_version = CASE WHEN bios_version = '' THEN ? ELSE bios_version END,
+			updated_at = ?
+			WHERE device_id = ?`,
+			hw.Hostname, hw.FQDN, hw.OSName, hw.OSVersion, hw.OSArch,
+			hw.Kernel, hw.CPUModel, hw.CPUCores, hw.CPUThreads, hw.CPUArch,
+			hw.RAMTotalMB, hw.RAMType, hw.RAMSlotsUsed, hw.RAMSlotsTotal,
+			hw.PlatformType, hw.Hypervisor, hw.VMHostID,
+			hw.SystemManufacturer, hw.SystemModel, hw.SerialNumber, hw.BIOSVersion,
+			now, hw.DeviceID)
+		if err != nil {
+			return fmt.Errorf("update hardware (manual override): %w", err)
+		}
+		return nil
+	}
+
+	// Normal upsert (INSERT OR REPLACE).
+	collectedAt := &now
+	if hw.CollectedAt != nil {
+		collectedAt = hw.CollectedAt
+	}
+
+	_, err = s.db.ExecContext(ctx, `INSERT OR REPLACE INTO recon_device_hardware (
+		device_id, hostname, fqdn, os_name, os_version, os_arch, kernel,
+		cpu_model, cpu_cores, cpu_threads, cpu_arch,
+		ram_total_mb, ram_type, ram_slots_used, ram_slots_total,
+		platform_type, hypervisor, vm_host_id,
+		system_manufacturer, system_model, serial_number, bios_version,
+		collection_source, collected_at, updated_at
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		hw.DeviceID, hw.Hostname, hw.FQDN, hw.OSName, hw.OSVersion, hw.OSArch, hw.Kernel,
+		hw.CPUModel, hw.CPUCores, hw.CPUThreads, hw.CPUArch,
+		hw.RAMTotalMB, hw.RAMType, hw.RAMSlotsUsed, hw.RAMSlotsTotal,
+		hw.PlatformType, hw.Hypervisor, hw.VMHostID,
+		hw.SystemManufacturer, hw.SystemModel, hw.SerialNumber, hw.BIOSVersion,
+		hw.CollectionSource, collectedAt, now)
+	if err != nil {
+		return fmt.Errorf("upsert device hardware: %w", err)
+	}
+	return nil
+}
+
+// GetDeviceHardware returns the hardware profile for a device.
+func (s *ReconStore) GetDeviceHardware(ctx context.Context, deviceID string) (*models.DeviceHardware, error) {
+	var hw models.DeviceHardware
+	var collectedAt, updatedAt sql.NullTime
+	err := s.db.QueryRowContext(ctx, `SELECT
+		device_id, hostname, fqdn, os_name, os_version, os_arch, kernel,
+		cpu_model, cpu_cores, cpu_threads, cpu_arch,
+		ram_total_mb, ram_type, ram_slots_used, ram_slots_total,
+		platform_type, hypervisor, vm_host_id,
+		system_manufacturer, system_model, serial_number, bios_version,
+		collection_source, collected_at, updated_at
+		FROM recon_device_hardware WHERE device_id = ?`, deviceID).Scan(
+		&hw.DeviceID, &hw.Hostname, &hw.FQDN, &hw.OSName, &hw.OSVersion, &hw.OSArch, &hw.Kernel,
+		&hw.CPUModel, &hw.CPUCores, &hw.CPUThreads, &hw.CPUArch,
+		&hw.RAMTotalMB, &hw.RAMType, &hw.RAMSlotsUsed, &hw.RAMSlotsTotal,
+		&hw.PlatformType, &hw.Hypervisor, &hw.VMHostID,
+		&hw.SystemManufacturer, &hw.SystemModel, &hw.SerialNumber, &hw.BIOSVersion,
+		&hw.CollectionSource, &collectedAt, &updatedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get device hardware: %w", err)
+	}
+	if collectedAt.Valid {
+		hw.CollectedAt = &collectedAt.Time
+	}
+	if updatedAt.Valid {
+		hw.UpdatedAt = &updatedAt.Time
+	}
+	return &hw, nil
+}
+
+// UpsertDeviceStorage replaces auto-collected storage records for a device.
+// Manual records (collection_source = "manual") are preserved.
+func (s *ReconStore) UpsertDeviceStorage(ctx context.Context, deviceID string, disks []models.DeviceStorage) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck // rollback after commit is a no-op
+
+	// Delete existing non-manual rows for this device.
+	_, err = tx.ExecContext(ctx,
+		"DELETE FROM recon_device_storage WHERE device_id = ? AND collection_source != 'manual'",
+		deviceID)
+	if err != nil {
+		return fmt.Errorf("delete non-manual storage: %w", err)
+	}
+
+	now := time.Now().UTC()
+	for i := range disks {
+		if disks[i].ID == "" {
+			disks[i].ID = uuid.New().String()
+		}
+		collectedAt := &now
+		if disks[i].CollectedAt != nil {
+			collectedAt = disks[i].CollectedAt
+		}
+		_, err = tx.ExecContext(ctx, `INSERT INTO recon_device_storage (
+			id, device_id, name, disk_type, interface, capacity_gb, model, role,
+			collection_source, collected_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			disks[i].ID, deviceID, disks[i].Name, disks[i].DiskType, disks[i].Interface,
+			disks[i].CapacityGB, disks[i].Model, disks[i].Role,
+			disks[i].CollectionSource, collectedAt)
+		if err != nil {
+			return fmt.Errorf("insert storage disk: %w", err)
+		}
+	}
+
+	return tx.Commit()
+}
+
+// GetDeviceStorage returns all storage records for a device.
+func (s *ReconStore) GetDeviceStorage(ctx context.Context, deviceID string) ([]models.DeviceStorage, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT
+		id, device_id, name, disk_type, interface, capacity_gb, model, role,
+		collection_source, collected_at
+		FROM recon_device_storage WHERE device_id = ?`, deviceID)
+	if err != nil {
+		return nil, fmt.Errorf("get device storage: %w", err)
+	}
+	defer rows.Close()
+
+	var result []models.DeviceStorage
+	for rows.Next() {
+		var d models.DeviceStorage
+		var collectedAt sql.NullTime
+		if err := rows.Scan(&d.ID, &d.DeviceID, &d.Name, &d.DiskType, &d.Interface,
+			&d.CapacityGB, &d.Model, &d.Role, &d.CollectionSource, &collectedAt); err != nil {
+			return nil, fmt.Errorf("scan storage row: %w", err)
+		}
+		if collectedAt.Valid {
+			d.CollectedAt = &collectedAt.Time
+		}
+		result = append(result, d)
+	}
+	return result, rows.Err()
+}
+
+// UpsertDeviceGPU replaces auto-collected GPU records for a device.
+// Manual records (collection_source = "manual") are preserved.
+func (s *ReconStore) UpsertDeviceGPU(ctx context.Context, deviceID string, gpus []models.DeviceGPU) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck // rollback after commit is a no-op
+
+	// Delete existing non-manual rows for this device.
+	_, err = tx.ExecContext(ctx,
+		"DELETE FROM recon_device_gpu WHERE device_id = ? AND collection_source != 'manual'",
+		deviceID)
+	if err != nil {
+		return fmt.Errorf("delete non-manual gpu: %w", err)
+	}
+
+	now := time.Now().UTC()
+	for i := range gpus {
+		if gpus[i].ID == "" {
+			gpus[i].ID = uuid.New().String()
+		}
+		collectedAt := &now
+		if gpus[i].CollectedAt != nil {
+			collectedAt = gpus[i].CollectedAt
+		}
+		_, err = tx.ExecContext(ctx, `INSERT INTO recon_device_gpu (
+			id, device_id, model, vendor, vram_mb, driver_version,
+			collection_source, collected_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+			gpus[i].ID, deviceID, gpus[i].Model, gpus[i].Vendor,
+			gpus[i].VRAMMB, gpus[i].DriverVersion,
+			gpus[i].CollectionSource, collectedAt)
+		if err != nil {
+			return fmt.Errorf("insert gpu: %w", err)
+		}
+	}
+
+	return tx.Commit()
+}
+
+// GetDeviceGPU returns all GPU records for a device.
+func (s *ReconStore) GetDeviceGPU(ctx context.Context, deviceID string) ([]models.DeviceGPU, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT
+		id, device_id, model, vendor, vram_mb, driver_version,
+		collection_source, collected_at
+		FROM recon_device_gpu WHERE device_id = ?`, deviceID)
+	if err != nil {
+		return nil, fmt.Errorf("get device gpu: %w", err)
+	}
+	defer rows.Close()
+
+	var result []models.DeviceGPU
+	for rows.Next() {
+		var g models.DeviceGPU
+		var collectedAt sql.NullTime
+		if err := rows.Scan(&g.ID, &g.DeviceID, &g.Model, &g.Vendor,
+			&g.VRAMMB, &g.DriverVersion, &g.CollectionSource, &collectedAt); err != nil {
+			return nil, fmt.Errorf("scan gpu row: %w", err)
+		}
+		if collectedAt.Valid {
+			g.CollectedAt = &collectedAt.Time
+		}
+		result = append(result, g)
+	}
+	return result, rows.Err()
+}
+
+// UpsertDeviceServices replaces auto-collected service records for a device.
+// Manual records (collection_source = "manual") are preserved.
+func (s *ReconStore) UpsertDeviceServices(ctx context.Context, deviceID string, svcs []models.DeviceService) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck // rollback after commit is a no-op
+
+	// Delete existing non-manual rows for this device.
+	_, err = tx.ExecContext(ctx,
+		"DELETE FROM recon_device_services WHERE device_id = ? AND collection_source != 'manual'",
+		deviceID)
+	if err != nil {
+		return fmt.Errorf("delete non-manual services: %w", err)
+	}
+
+	now := time.Now().UTC()
+	for i := range svcs {
+		if svcs[i].ID == "" {
+			svcs[i].ID = uuid.New().String()
+		}
+		collectedAt := &now
+		if svcs[i].CollectedAt != nil {
+			collectedAt = svcs[i].CollectedAt
+		}
+		_, err = tx.ExecContext(ctx, `INSERT INTO recon_device_services (
+			id, device_id, name, service_type, port, url, version, status,
+			collection_source, collected_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			svcs[i].ID, deviceID, svcs[i].Name, svcs[i].ServiceType,
+			svcs[i].Port, svcs[i].URL, svcs[i].Version, svcs[i].Status,
+			svcs[i].CollectionSource, collectedAt)
+		if err != nil {
+			return fmt.Errorf("insert service: %w", err)
+		}
+	}
+
+	return tx.Commit()
+}
+
+// GetDeviceServices returns all service records for a device.
+func (s *ReconStore) GetDeviceServices(ctx context.Context, deviceID string) ([]models.DeviceService, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT
+		id, device_id, name, service_type, port, url, version, status,
+		collection_source, collected_at
+		FROM recon_device_services WHERE device_id = ?`, deviceID)
+	if err != nil {
+		return nil, fmt.Errorf("get device services: %w", err)
+	}
+	defer rows.Close()
+
+	var result []models.DeviceService
+	for rows.Next() {
+		var svc models.DeviceService
+		var collectedAt sql.NullTime
+		if err := rows.Scan(&svc.ID, &svc.DeviceID, &svc.Name, &svc.ServiceType,
+			&svc.Port, &svc.URL, &svc.Version, &svc.Status,
+			&svc.CollectionSource, &collectedAt); err != nil {
+			return nil, fmt.Errorf("scan service row: %w", err)
+		}
+		if collectedAt.Valid {
+			svc.CollectedAt = &collectedAt.Time
+		}
+		result = append(result, svc)
+	}
+	return result, rows.Err()
+}
+
+// GetHardwareSummary returns fleet-wide aggregate hardware statistics.
+func (s *ReconStore) GetHardwareSummary(ctx context.Context) (*models.HardwareSummary, error) {
+	summary := &models.HardwareSummary{
+		ByOS:           make(map[string]int),
+		ByCPUModel:     make(map[string]int),
+		ByPlatformType: make(map[string]int),
+		ByGPUVendor:    make(map[string]int),
+	}
+
+	// Total devices with hardware profiles and total RAM.
+	err := s.db.QueryRowContext(ctx, `SELECT
+		COUNT(*), COALESCE(SUM(ram_total_mb), 0)
+		FROM recon_device_hardware`).Scan(&summary.TotalWithHardware, &summary.TotalRAMMB)
+	if err != nil {
+		return nil, fmt.Errorf("hardware totals: %w", err)
+	}
+
+	// Total storage.
+	err = s.db.QueryRowContext(ctx,
+		`SELECT COALESCE(SUM(capacity_gb), 0) FROM recon_device_storage`).Scan(&summary.TotalStorageGB)
+	if err != nil {
+		return nil, fmt.Errorf("storage total: %w", err)
+	}
+
+	// Total GPUs.
+	err = s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM recon_device_gpu`).Scan(&summary.TotalGPUs)
+	if err != nil {
+		return nil, fmt.Errorf("gpu count: %w", err)
+	}
+
+	// Group by OS.
+	osRows, err := s.db.QueryContext(ctx,
+		`SELECT os_name, COUNT(*) FROM recon_device_hardware WHERE os_name != '' GROUP BY os_name`)
+	if err != nil {
+		return nil, fmt.Errorf("by os: %w", err)
+	}
+	defer osRows.Close()
+	for osRows.Next() {
+		var name string
+		var cnt int
+		if err := osRows.Scan(&name, &cnt); err != nil {
+			return nil, fmt.Errorf("scan os row: %w", err)
+		}
+		summary.ByOS[name] = cnt
+	}
+	if err := osRows.Err(); err != nil {
+		return nil, fmt.Errorf("os rows: %w", err)
+	}
+
+	// Group by CPU model.
+	cpuRows, err := s.db.QueryContext(ctx,
+		`SELECT cpu_model, COUNT(*) FROM recon_device_hardware WHERE cpu_model != '' GROUP BY cpu_model`)
+	if err != nil {
+		return nil, fmt.Errorf("by cpu: %w", err)
+	}
+	defer cpuRows.Close()
+	for cpuRows.Next() {
+		var model string
+		var cnt int
+		if err := cpuRows.Scan(&model, &cnt); err != nil {
+			return nil, fmt.Errorf("scan cpu row: %w", err)
+		}
+		summary.ByCPUModel[model] = cnt
+	}
+	if err := cpuRows.Err(); err != nil {
+		return nil, fmt.Errorf("cpu rows: %w", err)
+	}
+
+	// Group by platform type.
+	platRows, err := s.db.QueryContext(ctx,
+		`SELECT platform_type, COUNT(*) FROM recon_device_hardware WHERE platform_type != '' GROUP BY platform_type`)
+	if err != nil {
+		return nil, fmt.Errorf("by platform: %w", err)
+	}
+	defer platRows.Close()
+	for platRows.Next() {
+		var pt string
+		var cnt int
+		if err := platRows.Scan(&pt, &cnt); err != nil {
+			return nil, fmt.Errorf("scan platform row: %w", err)
+		}
+		summary.ByPlatformType[pt] = cnt
+	}
+	if err := platRows.Err(); err != nil {
+		return nil, fmt.Errorf("platform rows: %w", err)
+	}
+
+	// Group by GPU vendor.
+	gpuRows, err := s.db.QueryContext(ctx,
+		`SELECT vendor, COUNT(*) FROM recon_device_gpu WHERE vendor != '' GROUP BY vendor`)
+	if err != nil {
+		return nil, fmt.Errorf("by gpu vendor: %w", err)
+	}
+	defer gpuRows.Close()
+	for gpuRows.Next() {
+		var vendor string
+		var cnt int
+		if err := gpuRows.Scan(&vendor, &cnt); err != nil {
+			return nil, fmt.Errorf("scan gpu vendor row: %w", err)
+		}
+		summary.ByGPUVendor[vendor] = cnt
+	}
+	if err := gpuRows.Err(); err != nil {
+		return nil, fmt.Errorf("gpu vendor rows: %w", err)
+	}
+
+	return summary, nil
+}
+
+// QueryDevicesByHardware returns devices matching hardware filters with pagination.
+// Returns matching devices, total count, and any error.
+func (s *ReconStore) QueryDevicesByHardware(ctx context.Context, q models.HardwareQuery) ([]models.Device, int, error) {
+	if q.Limit <= 0 {
+		q.Limit = 50
+	}
+
+	where := []string{"1=1"}
+	args := []any{}
+
+	if q.MinRAMMB > 0 {
+		where = append(where, "h.ram_total_mb >= ?")
+		args = append(args, q.MinRAMMB)
+	}
+	if q.MaxRAMMB > 0 {
+		where = append(where, "h.ram_total_mb <= ?")
+		args = append(args, q.MaxRAMMB)
+	}
+	if q.CPUModel != "" {
+		where = append(where, "h.cpu_model LIKE ?")
+		args = append(args, "%"+q.CPUModel+"%")
+	}
+	if q.OSName != "" {
+		where = append(where, "h.os_name LIKE ?")
+		args = append(args, "%"+q.OSName+"%")
+	}
+	if q.PlatformType != "" {
+		where = append(where, "h.platform_type = ?")
+		args = append(args, q.PlatformType)
+	}
+	if q.HasGPU != nil && *q.HasGPU {
+		where = append(where, "EXISTS (SELECT 1 FROM recon_device_gpu g WHERE g.device_id = d.id)")
+	}
+	if q.HasGPU != nil && !*q.HasGPU {
+		where = append(where, "NOT EXISTS (SELECT 1 FROM recon_device_gpu g WHERE g.device_id = d.id)")
+	}
+	if q.GPUVendor != "" {
+		where = append(where, "EXISTS (SELECT 1 FROM recon_device_gpu g WHERE g.device_id = d.id AND g.vendor = ?)")
+		args = append(args, q.GPUVendor)
+	}
+
+	whereClause := strings.Join(where, " AND ")
+
+	// Count total.
+	var total int
+	countQuery := "SELECT COUNT(*) FROM recon_devices d " +
+		"JOIN recon_device_hardware h ON h.device_id = d.id " +
+		"WHERE " + whereClause //nolint:gosec // where uses parameterized placeholders only
+	err := s.db.QueryRowContext(ctx, countQuery, args...).Scan(&total)
+	if err != nil {
+		return nil, 0, fmt.Errorf("count hardware query: %w", err)
+	}
+
+	// Query with pagination.
+	queryArgs := make([]any, 0, len(args)+2)
+	queryArgs = append(queryArgs, args...)
+	queryArgs = append(queryArgs, q.Limit, q.Offset)
+
+	dataQuery := "SELECT " + //nolint:gosec // where uses parameterized placeholders only
+		"d.id, d.hostname, d.ip_addresses, d.mac_address, d.manufacturer, " +
+		"d.device_type, d.os, d.status, d.discovery_method, d.agent_id, " +
+		"d.first_seen, d.last_seen, d.notes, d.tags, d.custom_fields, " +
+		"d.location, d.category, d.primary_role, d.owner, " +
+		"d.classification_confidence, d.classification_source, d.classification_signals, " +
+		"d.parent_device_id, d.network_layer " +
+		"FROM recon_devices d " +
+		"JOIN recon_device_hardware h ON h.device_id = d.id " +
+		"WHERE " + whereClause + " ORDER BY d.last_seen DESC LIMIT ? OFFSET ?"
+
+	rows, err := s.db.QueryContext(ctx, dataQuery, queryArgs...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("query devices by hardware: %w", err)
+	}
+	defer rows.Close()
+
+	var devices []models.Device
+	for rows.Next() {
+		var d models.Device
+		var ipsJSON, tagsJSON, cfJSON string
+		var dt, status, method string
+		err := rows.Scan(
+			&d.ID, &d.Hostname, &ipsJSON, &d.MACAddress, &d.Manufacturer,
+			&dt, &d.OS, &status, &method, &d.AgentID,
+			&d.FirstSeen, &d.LastSeen, &d.Notes, &tagsJSON, &cfJSON,
+			&d.Location, &d.Category, &d.PrimaryRole, &d.Owner,
+			&d.ClassificationConfidence, &d.ClassificationSource, &d.ClassificationSignals,
+			&d.ParentDeviceID, &d.NetworkLayer)
+		if err != nil {
+			return nil, 0, fmt.Errorf("scan device row: %w", err)
+		}
+		d.DeviceType = models.DeviceType(dt)
+		d.Status = models.DeviceStatus(status)
+		d.DiscoveryMethod = models.DiscoveryMethod(method)
+		_ = json.Unmarshal([]byte(ipsJSON), &d.IPAddresses)
+		_ = json.Unmarshal([]byte(tagsJSON), &d.Tags)
+		_ = json.Unmarshal([]byte(cfJSON), &d.CustomFields)
+		devices = append(devices, d)
+	}
+	return devices, total, rows.Err()
+}
+
+// DeleteDeviceHardware removes the hardware profile for a device.
+func (s *ReconStore) DeleteDeviceHardware(ctx context.Context, deviceID string) error {
+	res, err := s.db.ExecContext(ctx,
+		"DELETE FROM recon_device_hardware WHERE device_id = ?", deviceID)
+	if err != nil {
+		return fmt.Errorf("delete device hardware: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}

--- a/internal/recon/hardware_store_test.go
+++ b/internal/recon/hardware_store_test.go
@@ -1,0 +1,1125 @@
+package recon
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/HerbHall/subnetree/pkg/models"
+)
+
+// ---------------------------------------------------------------------------
+// Hardware profile store tests
+// ---------------------------------------------------------------------------
+
+func TestUpsertDeviceHardware_CreateNew(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	// Create a parent device first (FK constraint).
+	device := &models.Device{
+		IPAddresses:     []string{"10.0.0.1"},
+		MACAddress:      "AA:BB:CC:DD:EE:01",
+		Status:          models.DeviceStatusOnline,
+		DiscoveryMethod: models.DiscoveryICMP,
+	}
+	if _, err := s.UpsertDevice(ctx, device); err != nil {
+		t.Fatalf("create device: %v", err)
+	}
+
+	hw := &models.DeviceHardware{
+		DeviceID:           device.ID,
+		Hostname:           "web-server-01",
+		OSName:             "Ubuntu 24.04",
+		OSVersion:          "24.04",
+		OSArch:             "amd64",
+		CPUModel:           "Intel Core i7-12700K",
+		CPUCores:           12,
+		CPUThreads:         20,
+		RAMTotalMB:         32768,
+		PlatformType:       "baremetal",
+		SystemManufacturer: "Dell Inc.",
+		CollectionSource:   "scout-linux",
+	}
+	if err := s.UpsertDeviceHardware(ctx, hw); err != nil {
+		t.Fatalf("UpsertDeviceHardware: %v", err)
+	}
+
+	got, err := s.GetDeviceHardware(ctx, device.ID)
+	if err != nil {
+		t.Fatalf("GetDeviceHardware: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected hardware, got nil")
+	}
+	if got.Hostname != "web-server-01" {
+		t.Errorf("Hostname = %q, want web-server-01", got.Hostname)
+	}
+	if got.CPUCores != 12 {
+		t.Errorf("CPUCores = %d, want 12", got.CPUCores)
+	}
+	if got.RAMTotalMB != 32768 {
+		t.Errorf("RAMTotalMB = %d, want 32768", got.RAMTotalMB)
+	}
+	if got.CollectionSource != "scout-linux" {
+		t.Errorf("CollectionSource = %q, want scout-linux", got.CollectionSource)
+	}
+	if got.CollectedAt == nil {
+		t.Error("expected non-nil CollectedAt")
+	}
+	if got.UpdatedAt == nil {
+		t.Error("expected non-nil UpdatedAt")
+	}
+}
+
+func TestUpsertDeviceHardware_UpdateExisting(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	device := &models.Device{
+		IPAddresses:     []string{"10.0.0.2"},
+		MACAddress:      "AA:BB:CC:DD:EE:02",
+		Status:          models.DeviceStatusOnline,
+		DiscoveryMethod: models.DiscoveryICMP,
+	}
+	if _, err := s.UpsertDevice(ctx, device); err != nil {
+		t.Fatalf("create device: %v", err)
+	}
+
+	// First insert.
+	hw := &models.DeviceHardware{
+		DeviceID:         device.ID,
+		OSName:           "Ubuntu 22.04",
+		CPUCores:         8,
+		RAMTotalMB:       16384,
+		CollectionSource: "scout-linux",
+	}
+	if err := s.UpsertDeviceHardware(ctx, hw); err != nil {
+		t.Fatalf("first UpsertDeviceHardware: %v", err)
+	}
+
+	// Update with new data.
+	hw2 := &models.DeviceHardware{
+		DeviceID:         device.ID,
+		OSName:           "Ubuntu 24.04",
+		CPUCores:         12,
+		RAMTotalMB:       32768,
+		CollectionSource: "scout-linux",
+	}
+	if err := s.UpsertDeviceHardware(ctx, hw2); err != nil {
+		t.Fatalf("second UpsertDeviceHardware: %v", err)
+	}
+
+	got, err := s.GetDeviceHardware(ctx, device.ID)
+	if err != nil {
+		t.Fatalf("GetDeviceHardware: %v", err)
+	}
+	if got.OSName != "Ubuntu 24.04" {
+		t.Errorf("OSName = %q, want Ubuntu 24.04", got.OSName)
+	}
+	if got.CPUCores != 12 {
+		t.Errorf("CPUCores = %d, want 12", got.CPUCores)
+	}
+	if got.RAMTotalMB != 32768 {
+		t.Errorf("RAMTotalMB = %d, want 32768", got.RAMTotalMB)
+	}
+}
+
+func TestUpsertDeviceHardware_ManualOverridePreserved(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	device := &models.Device{
+		IPAddresses:     []string{"10.0.0.3"},
+		MACAddress:      "AA:BB:CC:DD:EE:03",
+		Status:          models.DeviceStatusOnline,
+		DiscoveryMethod: models.DiscoveryICMP,
+	}
+	if _, err := s.UpsertDevice(ctx, device); err != nil {
+		t.Fatalf("create device: %v", err)
+	}
+
+	// Insert manual hardware data.
+	manual := &models.DeviceHardware{
+		DeviceID:         device.ID,
+		Hostname:         "manual-host",
+		OSName:           "FreeBSD 14",
+		CPUCores:         4,
+		RAMTotalMB:       8192,
+		PlatformType:     "baremetal",
+		CollectionSource: "manual",
+	}
+	if err := s.UpsertDeviceHardware(ctx, manual); err != nil {
+		t.Fatalf("insert manual hardware: %v", err)
+	}
+
+	// Auto-collected data should not overwrite manual fields.
+	auto := &models.DeviceHardware{
+		DeviceID:         device.ID,
+		Hostname:         "auto-host",
+		OSName:           "Linux 6.5",
+		CPUCores:         16,
+		RAMTotalMB:       65536,
+		PlatformType:     "vm",
+		Kernel:           "6.5.0-44-generic",
+		CollectionSource: "scout-linux",
+	}
+	if err := s.UpsertDeviceHardware(ctx, auto); err != nil {
+		t.Fatalf("upsert auto hardware: %v", err)
+	}
+
+	got, err := s.GetDeviceHardware(ctx, device.ID)
+	if err != nil {
+		t.Fatalf("GetDeviceHardware: %v", err)
+	}
+
+	// Manual fields should be preserved.
+	if got.Hostname != "manual-host" {
+		t.Errorf("Hostname = %q, want manual-host (manual override)", got.Hostname)
+	}
+	if got.OSName != "FreeBSD 14" {
+		t.Errorf("OSName = %q, want FreeBSD 14 (manual override)", got.OSName)
+	}
+	if got.CPUCores != 4 {
+		t.Errorf("CPUCores = %d, want 4 (manual override)", got.CPUCores)
+	}
+	if got.RAMTotalMB != 8192 {
+		t.Errorf("RAMTotalMB = %d, want 8192 (manual override)", got.RAMTotalMB)
+	}
+	if got.PlatformType != "baremetal" {
+		t.Errorf("PlatformType = %q, want baremetal (manual override)", got.PlatformType)
+	}
+	// Empty field should be filled by auto data.
+	if got.Kernel != "6.5.0-44-generic" {
+		t.Errorf("Kernel = %q, want 6.5.0-44-generic (auto-filled empty field)", got.Kernel)
+	}
+	// Source should remain manual.
+	if got.CollectionSource != "manual" {
+		t.Errorf("CollectionSource = %q, want manual", got.CollectionSource)
+	}
+}
+
+func TestUpsertDeviceHardware_ManualOverridesManual(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	device := &models.Device{
+		IPAddresses:     []string{"10.0.0.4"},
+		MACAddress:      "AA:BB:CC:DD:EE:04",
+		Status:          models.DeviceStatusOnline,
+		DiscoveryMethod: models.DiscoveryICMP,
+	}
+	if _, err := s.UpsertDevice(ctx, device); err != nil {
+		t.Fatalf("create device: %v", err)
+	}
+
+	// First manual insert.
+	hw1 := &models.DeviceHardware{
+		DeviceID:         device.ID,
+		Hostname:         "manual-v1",
+		RAMTotalMB:       8192,
+		CollectionSource: "manual",
+	}
+	if err := s.UpsertDeviceHardware(ctx, hw1); err != nil {
+		t.Fatalf("first manual insert: %v", err)
+	}
+
+	// Second manual insert should fully replace.
+	hw2 := &models.DeviceHardware{
+		DeviceID:         device.ID,
+		Hostname:         "manual-v2",
+		RAMTotalMB:       16384,
+		CollectionSource: "manual",
+	}
+	if err := s.UpsertDeviceHardware(ctx, hw2); err != nil {
+		t.Fatalf("second manual insert: %v", err)
+	}
+
+	got, err := s.GetDeviceHardware(ctx, device.ID)
+	if err != nil {
+		t.Fatalf("GetDeviceHardware: %v", err)
+	}
+	if got.Hostname != "manual-v2" {
+		t.Errorf("Hostname = %q, want manual-v2", got.Hostname)
+	}
+	if got.RAMTotalMB != 16384 {
+		t.Errorf("RAMTotalMB = %d, want 16384", got.RAMTotalMB)
+	}
+}
+
+func TestGetDeviceHardware_NotFound(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	got, err := s.GetDeviceHardware(ctx, "nonexistent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for missing hardware, got %+v", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Storage tests
+// ---------------------------------------------------------------------------
+
+func TestUpsertDeviceStorage_Create(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	device := &models.Device{
+		IPAddresses:     []string{"10.0.0.10"},
+		MACAddress:      "AA:BB:CC:DD:10:01",
+		Status:          models.DeviceStatusOnline,
+		DiscoveryMethod: models.DiscoveryICMP,
+	}
+	if _, err := s.UpsertDevice(ctx, device); err != nil {
+		t.Fatalf("create device: %v", err)
+	}
+
+	disks := []models.DeviceStorage{
+		{
+			DeviceID:         device.ID,
+			Name:             "Samsung 990 Pro",
+			DiskType:         "nvme",
+			Interface:        "pcie4",
+			CapacityGB:       2000,
+			Model:            "Samsung SSD 990 PRO",
+			Role:             "boot",
+			CollectionSource: "scout-linux",
+		},
+		{
+			DeviceID:         device.ID,
+			Name:             "WD Red 8TB",
+			DiskType:         "hdd",
+			Interface:        "sata",
+			CapacityGB:       8000,
+			Model:            "WDC WD80EFAX",
+			Role:             "data",
+			CollectionSource: "scout-linux",
+		},
+	}
+	if err := s.UpsertDeviceStorage(ctx, device.ID, disks); err != nil {
+		t.Fatalf("UpsertDeviceStorage: %v", err)
+	}
+
+	got, err := s.GetDeviceStorage(ctx, device.ID)
+	if err != nil {
+		t.Fatalf("GetDeviceStorage: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("storage count = %d, want 2", len(got))
+	}
+}
+
+func TestUpsertDeviceStorage_ReplaceNonManual(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	device := &models.Device{
+		IPAddresses:     []string{"10.0.0.11"},
+		MACAddress:      "AA:BB:CC:DD:10:02",
+		Status:          models.DeviceStatusOnline,
+		DiscoveryMethod: models.DiscoveryICMP,
+	}
+	if _, err := s.UpsertDevice(ctx, device); err != nil {
+		t.Fatalf("create device: %v", err)
+	}
+
+	// Insert initial auto-collected disks.
+	initial := []models.DeviceStorage{
+		{DeviceID: device.ID, Name: "Old Disk", DiskType: "hdd", CollectionSource: "scout-linux"},
+	}
+	if err := s.UpsertDeviceStorage(ctx, device.ID, initial); err != nil {
+		t.Fatalf("initial UpsertDeviceStorage: %v", err)
+	}
+
+	// Replace with new auto-collected disks.
+	replacement := []models.DeviceStorage{
+		{DeviceID: device.ID, Name: "New Disk 1", DiskType: "nvme", CollectionSource: "scout-linux"},
+		{DeviceID: device.ID, Name: "New Disk 2", DiskType: "ssd", CollectionSource: "scout-linux"},
+	}
+	if err := s.UpsertDeviceStorage(ctx, device.ID, replacement); err != nil {
+		t.Fatalf("replacement UpsertDeviceStorage: %v", err)
+	}
+
+	got, err := s.GetDeviceStorage(ctx, device.ID)
+	if err != nil {
+		t.Fatalf("GetDeviceStorage: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("storage count = %d, want 2 (old auto disk should be gone)", len(got))
+	}
+	names := map[string]bool{}
+	for _, d := range got {
+		names[d.Name] = true
+	}
+	if names["Old Disk"] {
+		t.Error("Old Disk should have been replaced")
+	}
+	if !names["New Disk 1"] || !names["New Disk 2"] {
+		t.Errorf("expected New Disk 1 and New Disk 2, got %v", names)
+	}
+}
+
+func TestUpsertDeviceStorage_PreservesManual(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	device := &models.Device{
+		IPAddresses:     []string{"10.0.0.12"},
+		MACAddress:      "AA:BB:CC:DD:10:03",
+		Status:          models.DeviceStatusOnline,
+		DiscoveryMethod: models.DiscoveryICMP,
+	}
+	if _, err := s.UpsertDevice(ctx, device); err != nil {
+		t.Fatalf("create device: %v", err)
+	}
+
+	// Insert a manual disk.
+	manual := []models.DeviceStorage{
+		{DeviceID: device.ID, Name: "Manual Disk", DiskType: "ssd", CollectionSource: "manual"},
+	}
+	if err := s.UpsertDeviceStorage(ctx, device.ID, manual); err != nil {
+		t.Fatalf("manual UpsertDeviceStorage: %v", err)
+	}
+
+	// Insert auto-collected disks (should not remove manual).
+	auto := []models.DeviceStorage{
+		{DeviceID: device.ID, Name: "Auto Disk", DiskType: "nvme", CollectionSource: "scout-linux"},
+	}
+	if err := s.UpsertDeviceStorage(ctx, device.ID, auto); err != nil {
+		t.Fatalf("auto UpsertDeviceStorage: %v", err)
+	}
+
+	got, err := s.GetDeviceStorage(ctx, device.ID)
+	if err != nil {
+		t.Fatalf("GetDeviceStorage: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("storage count = %d, want 2 (manual + auto)", len(got))
+	}
+}
+
+func TestGetDeviceStorage_NotFound(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	got, err := s.GetDeviceStorage(ctx, "nonexistent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty slice, got %d items", len(got))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GPU tests
+// ---------------------------------------------------------------------------
+
+func TestUpsertDeviceGPU_Create(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	device := &models.Device{
+		IPAddresses:     []string{"10.0.0.20"},
+		MACAddress:      "AA:BB:CC:DD:20:01",
+		Status:          models.DeviceStatusOnline,
+		DiscoveryMethod: models.DiscoveryICMP,
+	}
+	if _, err := s.UpsertDevice(ctx, device); err != nil {
+		t.Fatalf("create device: %v", err)
+	}
+
+	gpus := []models.DeviceGPU{
+		{
+			DeviceID:         device.ID,
+			Model:            "NVIDIA RTX 3090",
+			Vendor:           "nvidia",
+			VRAMMB:           24576,
+			DriverVersion:    "535.183.01",
+			CollectionSource: "scout-linux",
+		},
+	}
+	if err := s.UpsertDeviceGPU(ctx, device.ID, gpus); err != nil {
+		t.Fatalf("UpsertDeviceGPU: %v", err)
+	}
+
+	got, err := s.GetDeviceGPU(ctx, device.ID)
+	if err != nil {
+		t.Fatalf("GetDeviceGPU: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("gpu count = %d, want 1", len(got))
+	}
+	if got[0].Model != "NVIDIA RTX 3090" {
+		t.Errorf("Model = %q, want NVIDIA RTX 3090", got[0].Model)
+	}
+	if got[0].VRAMMB != 24576 {
+		t.Errorf("VRAMMB = %d, want 24576", got[0].VRAMMB)
+	}
+}
+
+func TestUpsertDeviceGPU_Replace(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	device := &models.Device{
+		IPAddresses:     []string{"10.0.0.21"},
+		MACAddress:      "AA:BB:CC:DD:20:02",
+		Status:          models.DeviceStatusOnline,
+		DiscoveryMethod: models.DiscoveryICMP,
+	}
+	if _, err := s.UpsertDevice(ctx, device); err != nil {
+		t.Fatalf("create device: %v", err)
+	}
+
+	// Insert initial GPU.
+	initial := []models.DeviceGPU{
+		{DeviceID: device.ID, Model: "Old GPU", Vendor: "amd", CollectionSource: "scout-linux"},
+	}
+	if err := s.UpsertDeviceGPU(ctx, device.ID, initial); err != nil {
+		t.Fatalf("initial UpsertDeviceGPU: %v", err)
+	}
+
+	// Replace with new GPU.
+	replacement := []models.DeviceGPU{
+		{DeviceID: device.ID, Model: "New GPU", Vendor: "nvidia", CollectionSource: "scout-linux"},
+	}
+	if err := s.UpsertDeviceGPU(ctx, device.ID, replacement); err != nil {
+		t.Fatalf("replacement UpsertDeviceGPU: %v", err)
+	}
+
+	got, err := s.GetDeviceGPU(ctx, device.ID)
+	if err != nil {
+		t.Fatalf("GetDeviceGPU: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("gpu count = %d, want 1", len(got))
+	}
+	if got[0].Model != "New GPU" {
+		t.Errorf("Model = %q, want New GPU", got[0].Model)
+	}
+}
+
+func TestGetDeviceGPU_NotFound(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	got, err := s.GetDeviceGPU(ctx, "nonexistent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty slice, got %d items", len(got))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Services tests
+// ---------------------------------------------------------------------------
+
+func TestUpsertDeviceServices_Create(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	device := &models.Device{
+		IPAddresses:     []string{"10.0.0.30"},
+		MACAddress:      "AA:BB:CC:DD:30:01",
+		Status:          models.DeviceStatusOnline,
+		DiscoveryMethod: models.DiscoveryICMP,
+	}
+	if _, err := s.UpsertDevice(ctx, device); err != nil {
+		t.Fatalf("create device: %v", err)
+	}
+
+	svcs := []models.DeviceService{
+		{
+			DeviceID:         device.ID,
+			Name:             "plex",
+			ServiceType:      "docker",
+			Port:             32400,
+			URL:              "http://10.0.0.30:32400",
+			Version:          "1.40.0",
+			Status:           "running",
+			CollectionSource: "scout-linux",
+		},
+		{
+			DeviceID:         device.ID,
+			Name:             "nginx",
+			ServiceType:      "systemd",
+			Port:             443,
+			Status:           "running",
+			CollectionSource: "scout-linux",
+		},
+	}
+	if err := s.UpsertDeviceServices(ctx, device.ID, svcs); err != nil {
+		t.Fatalf("UpsertDeviceServices: %v", err)
+	}
+
+	got, err := s.GetDeviceServices(ctx, device.ID)
+	if err != nil {
+		t.Fatalf("GetDeviceServices: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("service count = %d, want 2", len(got))
+	}
+}
+
+func TestUpsertDeviceServices_Replace(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	device := &models.Device{
+		IPAddresses:     []string{"10.0.0.31"},
+		MACAddress:      "AA:BB:CC:DD:30:02",
+		Status:          models.DeviceStatusOnline,
+		DiscoveryMethod: models.DiscoveryICMP,
+	}
+	if _, err := s.UpsertDevice(ctx, device); err != nil {
+		t.Fatalf("create device: %v", err)
+	}
+
+	initial := []models.DeviceService{
+		{DeviceID: device.ID, Name: "old-svc", CollectionSource: "scout-linux"},
+	}
+	if err := s.UpsertDeviceServices(ctx, device.ID, initial); err != nil {
+		t.Fatalf("initial UpsertDeviceServices: %v", err)
+	}
+
+	replacement := []models.DeviceService{
+		{DeviceID: device.ID, Name: "new-svc-1", CollectionSource: "scout-linux"},
+		{DeviceID: device.ID, Name: "new-svc-2", CollectionSource: "scout-linux"},
+	}
+	if err := s.UpsertDeviceServices(ctx, device.ID, replacement); err != nil {
+		t.Fatalf("replacement UpsertDeviceServices: %v", err)
+	}
+
+	got, err := s.GetDeviceServices(ctx, device.ID)
+	if err != nil {
+		t.Fatalf("GetDeviceServices: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("service count = %d, want 2", len(got))
+	}
+	names := map[string]bool{}
+	for _, svc := range got {
+		names[svc.Name] = true
+	}
+	if names["old-svc"] {
+		t.Error("old-svc should have been replaced")
+	}
+}
+
+func TestGetDeviceServices_NotFound(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	got, err := s.GetDeviceServices(ctx, "nonexistent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty slice, got %d items", len(got))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Hardware summary tests
+// ---------------------------------------------------------------------------
+
+func TestGetHardwareSummary_Empty(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	summary, err := s.GetHardwareSummary(ctx)
+	if err != nil {
+		t.Fatalf("GetHardwareSummary: %v", err)
+	}
+	if summary.TotalWithHardware != 0 {
+		t.Errorf("TotalWithHardware = %d, want 0", summary.TotalWithHardware)
+	}
+	if summary.TotalRAMMB != 0 {
+		t.Errorf("TotalRAMMB = %d, want 0", summary.TotalRAMMB)
+	}
+	if summary.TotalStorageGB != 0 {
+		t.Errorf("TotalStorageGB = %d, want 0", summary.TotalStorageGB)
+	}
+	if summary.TotalGPUs != 0 {
+		t.Errorf("TotalGPUs = %d, want 0", summary.TotalGPUs)
+	}
+}
+
+func TestGetHardwareSummary_WithData(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	// Create two devices with hardware profiles.
+	d1 := &models.Device{
+		IPAddresses: []string{"10.0.0.1"}, MACAddress: "AA:BB:CC:DD:50:01",
+		Status: models.DeviceStatusOnline, DiscoveryMethod: models.DiscoveryICMP,
+	}
+	d2 := &models.Device{
+		IPAddresses: []string{"10.0.0.2"}, MACAddress: "AA:BB:CC:DD:50:02",
+		Status: models.DeviceStatusOnline, DiscoveryMethod: models.DiscoveryICMP,
+	}
+	if _, err := s.UpsertDevice(ctx, d1); err != nil {
+		t.Fatalf("create d1: %v", err)
+	}
+	if _, err := s.UpsertDevice(ctx, d2); err != nil {
+		t.Fatalf("create d2: %v", err)
+	}
+
+	// Hardware profiles.
+	if err := s.UpsertDeviceHardware(ctx, &models.DeviceHardware{
+		DeviceID: d1.ID, OSName: "Ubuntu 24.04", CPUModel: "Intel i7", RAMTotalMB: 32768,
+		PlatformType: "baremetal", CollectionSource: "scout-linux",
+	}); err != nil {
+		t.Fatalf("hardware d1: %v", err)
+	}
+	if err := s.UpsertDeviceHardware(ctx, &models.DeviceHardware{
+		DeviceID: d2.ID, OSName: "Ubuntu 24.04", CPUModel: "AMD Ryzen 9", RAMTotalMB: 65536,
+		PlatformType: "baremetal", CollectionSource: "scout-linux",
+	}); err != nil {
+		t.Fatalf("hardware d2: %v", err)
+	}
+
+	// Storage.
+	if err := s.UpsertDeviceStorage(ctx, d1.ID, []models.DeviceStorage{
+		{DeviceID: d1.ID, CapacityGB: 2000, CollectionSource: "scout-linux"},
+	}); err != nil {
+		t.Fatalf("storage d1: %v", err)
+	}
+	if err := s.UpsertDeviceStorage(ctx, d2.ID, []models.DeviceStorage{
+		{DeviceID: d2.ID, CapacityGB: 4000, CollectionSource: "scout-linux"},
+		{DeviceID: d2.ID, CapacityGB: 8000, CollectionSource: "scout-linux"},
+	}); err != nil {
+		t.Fatalf("storage d2: %v", err)
+	}
+
+	// GPU on d1 only.
+	if err := s.UpsertDeviceGPU(ctx, d1.ID, []models.DeviceGPU{
+		{DeviceID: d1.ID, Model: "RTX 3090", Vendor: "nvidia", VRAMMB: 24576, CollectionSource: "scout-linux"},
+	}); err != nil {
+		t.Fatalf("gpu d1: %v", err)
+	}
+
+	summary, err := s.GetHardwareSummary(ctx)
+	if err != nil {
+		t.Fatalf("GetHardwareSummary: %v", err)
+	}
+	if summary.TotalWithHardware != 2 {
+		t.Errorf("TotalWithHardware = %d, want 2", summary.TotalWithHardware)
+	}
+	if summary.TotalRAMMB != 98304 { // 32768 + 65536
+		t.Errorf("TotalRAMMB = %d, want 98304", summary.TotalRAMMB)
+	}
+	if summary.TotalStorageGB != 14000 { // 2000 + 4000 + 8000
+		t.Errorf("TotalStorageGB = %d, want 14000", summary.TotalStorageGB)
+	}
+	if summary.TotalGPUs != 1 {
+		t.Errorf("TotalGPUs = %d, want 1", summary.TotalGPUs)
+	}
+	if summary.ByOS["Ubuntu 24.04"] != 2 {
+		t.Errorf("ByOS[Ubuntu 24.04] = %d, want 2", summary.ByOS["Ubuntu 24.04"])
+	}
+	if summary.ByCPUModel["Intel i7"] != 1 {
+		t.Errorf("ByCPUModel[Intel i7] = %d, want 1", summary.ByCPUModel["Intel i7"])
+	}
+	if summary.ByPlatformType["baremetal"] != 2 {
+		t.Errorf("ByPlatformType[baremetal] = %d, want 2", summary.ByPlatformType["baremetal"])
+	}
+	if summary.ByGPUVendor["nvidia"] != 1 {
+		t.Errorf("ByGPUVendor[nvidia] = %d, want 1", summary.ByGPUVendor["nvidia"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Query devices by hardware tests
+// ---------------------------------------------------------------------------
+
+func TestQueryDevicesByHardware_FilterByRAM(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	d1 := &models.Device{
+		IPAddresses: []string{"10.0.0.1"}, MACAddress: "AA:BB:CC:DD:60:01",
+		Status: models.DeviceStatusOnline, DiscoveryMethod: models.DiscoveryICMP,
+	}
+	d2 := &models.Device{
+		IPAddresses: []string{"10.0.0.2"}, MACAddress: "AA:BB:CC:DD:60:02",
+		Status: models.DeviceStatusOnline, DiscoveryMethod: models.DiscoveryICMP,
+	}
+	if _, err := s.UpsertDevice(ctx, d1); err != nil {
+		t.Fatalf("create d1: %v", err)
+	}
+	if _, err := s.UpsertDevice(ctx, d2); err != nil {
+		t.Fatalf("create d2: %v", err)
+	}
+
+	if err := s.UpsertDeviceHardware(ctx, &models.DeviceHardware{
+		DeviceID: d1.ID, RAMTotalMB: 8192, CollectionSource: "scout",
+	}); err != nil {
+		t.Fatalf("hw d1: %v", err)
+	}
+	if err := s.UpsertDeviceHardware(ctx, &models.DeviceHardware{
+		DeviceID: d2.ID, RAMTotalMB: 65536, CollectionSource: "scout",
+	}); err != nil {
+		t.Fatalf("hw d2: %v", err)
+	}
+
+	// Query for devices with >= 32768 MB RAM.
+	devices, total, err := s.QueryDevicesByHardware(ctx, models.HardwareQuery{MinRAMMB: 32768})
+	if err != nil {
+		t.Fatalf("QueryDevicesByHardware: %v", err)
+	}
+	if total != 1 {
+		t.Errorf("total = %d, want 1", total)
+	}
+	if len(devices) != 1 {
+		t.Fatalf("count = %d, want 1", len(devices))
+	}
+	if devices[0].ID != d2.ID {
+		t.Errorf("expected d2, got %s", devices[0].ID)
+	}
+}
+
+func TestQueryDevicesByHardware_FilterByOSAndCPU(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	d1 := &models.Device{
+		IPAddresses: []string{"10.0.0.1"}, MACAddress: "AA:BB:CC:DD:61:01",
+		Status: models.DeviceStatusOnline, DiscoveryMethod: models.DiscoveryICMP,
+	}
+	d2 := &models.Device{
+		IPAddresses: []string{"10.0.0.2"}, MACAddress: "AA:BB:CC:DD:61:02",
+		Status: models.DeviceStatusOnline, DiscoveryMethod: models.DiscoveryICMP,
+	}
+	if _, err := s.UpsertDevice(ctx, d1); err != nil {
+		t.Fatalf("create d1: %v", err)
+	}
+	if _, err := s.UpsertDevice(ctx, d2); err != nil {
+		t.Fatalf("create d2: %v", err)
+	}
+
+	if err := s.UpsertDeviceHardware(ctx, &models.DeviceHardware{
+		DeviceID: d1.ID, OSName: "Ubuntu 24.04", CPUModel: "Intel Core i7", CollectionSource: "scout",
+	}); err != nil {
+		t.Fatalf("hw d1: %v", err)
+	}
+	if err := s.UpsertDeviceHardware(ctx, &models.DeviceHardware{
+		DeviceID: d2.ID, OSName: "Windows 11", CPUModel: "AMD Ryzen 9", CollectionSource: "scout",
+	}); err != nil {
+		t.Fatalf("hw d2: %v", err)
+	}
+
+	// Filter by OS.
+	devices, total, err := s.QueryDevicesByHardware(ctx, models.HardwareQuery{OSName: "Ubuntu"})
+	if err != nil {
+		t.Fatalf("QueryDevicesByHardware OS: %v", err)
+	}
+	if total != 1 {
+		t.Errorf("total = %d, want 1", total)
+	}
+	if len(devices) != 1 || devices[0].ID != d1.ID {
+		t.Errorf("expected d1 for Ubuntu filter")
+	}
+
+	// Filter by CPU.
+	devices, total, err = s.QueryDevicesByHardware(ctx, models.HardwareQuery{CPUModel: "Ryzen"})
+	if err != nil {
+		t.Fatalf("QueryDevicesByHardware CPU: %v", err)
+	}
+	if total != 1 {
+		t.Errorf("total = %d, want 1", total)
+	}
+	if len(devices) != 1 || devices[0].ID != d2.ID {
+		t.Errorf("expected d2 for Ryzen filter")
+	}
+}
+
+func TestQueryDevicesByHardware_FilterByPlatformType(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	d1 := &models.Device{
+		IPAddresses: []string{"10.0.0.1"}, MACAddress: "AA:BB:CC:DD:62:01",
+		Status: models.DeviceStatusOnline, DiscoveryMethod: models.DiscoveryICMP,
+	}
+	d2 := &models.Device{
+		IPAddresses: []string{"10.0.0.2"}, MACAddress: "AA:BB:CC:DD:62:02",
+		Status: models.DeviceStatusOnline, DiscoveryMethod: models.DiscoveryICMP,
+	}
+	if _, err := s.UpsertDevice(ctx, d1); err != nil {
+		t.Fatalf("create d1: %v", err)
+	}
+	if _, err := s.UpsertDevice(ctx, d2); err != nil {
+		t.Fatalf("create d2: %v", err)
+	}
+
+	if err := s.UpsertDeviceHardware(ctx, &models.DeviceHardware{
+		DeviceID: d1.ID, PlatformType: "baremetal", CollectionSource: "scout",
+	}); err != nil {
+		t.Fatalf("hw d1: %v", err)
+	}
+	if err := s.UpsertDeviceHardware(ctx, &models.DeviceHardware{
+		DeviceID: d2.ID, PlatformType: "vm", CollectionSource: "scout",
+	}); err != nil {
+		t.Fatalf("hw d2: %v", err)
+	}
+
+	devices, total, err := s.QueryDevicesByHardware(ctx, models.HardwareQuery{PlatformType: "vm"})
+	if err != nil {
+		t.Fatalf("QueryDevicesByHardware: %v", err)
+	}
+	if total != 1 {
+		t.Errorf("total = %d, want 1", total)
+	}
+	if len(devices) != 1 || devices[0].ID != d2.ID {
+		t.Errorf("expected d2 for vm filter")
+	}
+}
+
+func TestQueryDevicesByHardware_FilterByGPU(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	d1 := &models.Device{
+		IPAddresses: []string{"10.0.0.1"}, MACAddress: "AA:BB:CC:DD:63:01",
+		Status: models.DeviceStatusOnline, DiscoveryMethod: models.DiscoveryICMP,
+	}
+	d2 := &models.Device{
+		IPAddresses: []string{"10.0.0.2"}, MACAddress: "AA:BB:CC:DD:63:02",
+		Status: models.DeviceStatusOnline, DiscoveryMethod: models.DiscoveryICMP,
+	}
+	if _, err := s.UpsertDevice(ctx, d1); err != nil {
+		t.Fatalf("create d1: %v", err)
+	}
+	if _, err := s.UpsertDevice(ctx, d2); err != nil {
+		t.Fatalf("create d2: %v", err)
+	}
+
+	if err := s.UpsertDeviceHardware(ctx, &models.DeviceHardware{
+		DeviceID: d1.ID, CollectionSource: "scout",
+	}); err != nil {
+		t.Fatalf("hw d1: %v", err)
+	}
+	if err := s.UpsertDeviceHardware(ctx, &models.DeviceHardware{
+		DeviceID: d2.ID, CollectionSource: "scout",
+	}); err != nil {
+		t.Fatalf("hw d2: %v", err)
+	}
+
+	// Add GPU to d1 only.
+	if err := s.UpsertDeviceGPU(ctx, d1.ID, []models.DeviceGPU{
+		{DeviceID: d1.ID, Model: "RTX 3090", Vendor: "nvidia", CollectionSource: "scout"},
+	}); err != nil {
+		t.Fatalf("gpu d1: %v", err)
+	}
+
+	// Filter has_gpu = true.
+	hasGPU := true
+	devices, total, err := s.QueryDevicesByHardware(ctx, models.HardwareQuery{HasGPU: &hasGPU})
+	if err != nil {
+		t.Fatalf("QueryDevicesByHardware has_gpu=true: %v", err)
+	}
+	if total != 1 {
+		t.Errorf("total = %d, want 1", total)
+	}
+	if len(devices) != 1 || devices[0].ID != d1.ID {
+		t.Errorf("expected d1 for has_gpu=true")
+	}
+
+	// Filter has_gpu = false.
+	noGPU := false
+	devices, total, err = s.QueryDevicesByHardware(ctx, models.HardwareQuery{HasGPU: &noGPU})
+	if err != nil {
+		t.Fatalf("QueryDevicesByHardware has_gpu=false: %v", err)
+	}
+	if total != 1 {
+		t.Errorf("total = %d, want 1", total)
+	}
+	if len(devices) != 1 || devices[0].ID != d2.ID {
+		t.Errorf("expected d2 for has_gpu=false")
+	}
+
+	// Filter by GPU vendor.
+	devices, total, err = s.QueryDevicesByHardware(ctx, models.HardwareQuery{GPUVendor: "nvidia"})
+	if err != nil {
+		t.Fatalf("QueryDevicesByHardware gpu_vendor: %v", err)
+	}
+	if total != 1 {
+		t.Errorf("total = %d, want 1", total)
+	}
+	if len(devices) != 1 || devices[0].ID != d1.ID {
+		t.Errorf("expected d1 for nvidia filter")
+	}
+}
+
+func TestQueryDevicesByHardware_Pagination(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	// Create 3 devices with hardware.
+	for i := 0; i < 3; i++ {
+		d := &models.Device{
+			IPAddresses:     []string{fmt.Sprintf("10.0.0.%d", i+1)},
+			MACAddress:      fmt.Sprintf("AA:BB:CC:DD:64:%02X", i),
+			Status:          models.DeviceStatusOnline,
+			DiscoveryMethod: models.DiscoveryICMP,
+		}
+		if _, err := s.UpsertDevice(ctx, d); err != nil {
+			t.Fatalf("create device %d: %v", i, err)
+		}
+		if err := s.UpsertDeviceHardware(ctx, &models.DeviceHardware{
+			DeviceID: d.ID, RAMTotalMB: (i + 1) * 8192, CollectionSource: "scout",
+		}); err != nil {
+			t.Fatalf("hardware %d: %v", i, err)
+		}
+	}
+
+	// Page 1.
+	devices, total, err := s.QueryDevicesByHardware(ctx, models.HardwareQuery{Limit: 2, Offset: 0})
+	if err != nil {
+		t.Fatalf("QueryDevicesByHardware page 1: %v", err)
+	}
+	if total != 3 {
+		t.Errorf("total = %d, want 3", total)
+	}
+	if len(devices) != 2 {
+		t.Errorf("page 1 count = %d, want 2", len(devices))
+	}
+
+	// Page 2.
+	devices, _, err = s.QueryDevicesByHardware(ctx, models.HardwareQuery{Limit: 2, Offset: 2})
+	if err != nil {
+		t.Fatalf("QueryDevicesByHardware page 2: %v", err)
+	}
+	if len(devices) != 1 {
+		t.Errorf("page 2 count = %d, want 1", len(devices))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Delete and cascade tests
+// ---------------------------------------------------------------------------
+
+func TestDeleteDeviceHardware(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	device := &models.Device{
+		IPAddresses:     []string{"10.0.0.40"},
+		MACAddress:      "AA:BB:CC:DD:40:01",
+		Status:          models.DeviceStatusOnline,
+		DiscoveryMethod: models.DiscoveryICMP,
+	}
+	if _, err := s.UpsertDevice(ctx, device); err != nil {
+		t.Fatalf("create device: %v", err)
+	}
+	if err := s.UpsertDeviceHardware(ctx, &models.DeviceHardware{
+		DeviceID: device.ID, OSName: "Ubuntu", CollectionSource: "scout",
+	}); err != nil {
+		t.Fatalf("insert hardware: %v", err)
+	}
+
+	if err := s.DeleteDeviceHardware(ctx, device.ID); err != nil {
+		t.Fatalf("DeleteDeviceHardware: %v", err)
+	}
+
+	got, err := s.GetDeviceHardware(ctx, device.ID)
+	if err != nil {
+		t.Fatalf("GetDeviceHardware after delete: %v", err)
+	}
+	if got != nil {
+		t.Error("expected nil after delete")
+	}
+}
+
+func TestDeleteDeviceHardware_NotFound(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	err := s.DeleteDeviceHardware(ctx, "nonexistent")
+	if err == nil {
+		t.Error("expected error for nonexistent hardware")
+	}
+}
+
+func TestCascadeDeleteDevice_RemovesAllHardware(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	device := &models.Device{
+		IPAddresses:     []string{"10.0.0.50"},
+		MACAddress:      "AA:BB:CC:DD:50:99",
+		Status:          models.DeviceStatusOnline,
+		DiscoveryMethod: models.DiscoveryICMP,
+	}
+	if _, err := s.UpsertDevice(ctx, device); err != nil {
+		t.Fatalf("create device: %v", err)
+	}
+
+	// Add hardware, storage, GPU, and services.
+	if err := s.UpsertDeviceHardware(ctx, &models.DeviceHardware{
+		DeviceID: device.ID, OSName: "Ubuntu", CollectionSource: "scout",
+	}); err != nil {
+		t.Fatalf("insert hardware: %v", err)
+	}
+	if err := s.UpsertDeviceStorage(ctx, device.ID, []models.DeviceStorage{
+		{DeviceID: device.ID, Name: "Disk 1", CollectionSource: "scout"},
+	}); err != nil {
+		t.Fatalf("insert storage: %v", err)
+	}
+	if err := s.UpsertDeviceGPU(ctx, device.ID, []models.DeviceGPU{
+		{DeviceID: device.ID, Model: "GPU 1", Vendor: "nvidia", CollectionSource: "scout"},
+	}); err != nil {
+		t.Fatalf("insert gpu: %v", err)
+	}
+	if err := s.UpsertDeviceServices(ctx, device.ID, []models.DeviceService{
+		{DeviceID: device.ID, Name: "svc-1", CollectionSource: "scout"},
+	}); err != nil {
+		t.Fatalf("insert services: %v", err)
+	}
+
+	// Delete the parent device -- CASCADE should remove all children.
+	if err := s.DeleteDevice(ctx, device.ID); err != nil {
+		t.Fatalf("DeleteDevice: %v", err)
+	}
+
+	// Verify all hardware tables are empty for this device.
+	hw, err := s.GetDeviceHardware(ctx, device.ID)
+	if err != nil {
+		t.Fatalf("GetDeviceHardware: %v", err)
+	}
+	if hw != nil {
+		t.Error("hardware should be cascaded")
+	}
+
+	storage, err := s.GetDeviceStorage(ctx, device.ID)
+	if err != nil {
+		t.Fatalf("GetDeviceStorage: %v", err)
+	}
+	if len(storage) != 0 {
+		t.Errorf("storage count = %d, want 0 (cascaded)", len(storage))
+	}
+
+	gpus, err := s.GetDeviceGPU(ctx, device.ID)
+	if err != nil {
+		t.Fatalf("GetDeviceGPU: %v", err)
+	}
+	if len(gpus) != 0 {
+		t.Errorf("gpu count = %d, want 0 (cascaded)", len(gpus))
+	}
+
+	svcs, err := s.GetDeviceServices(ctx, device.ID)
+	if err != nil {
+		t.Fatalf("GetDeviceServices: %v", err)
+	}
+	if len(svcs) != 0 {
+		t.Errorf("service count = %d, want 0 (cascaded)", len(svcs))
+	}
+}

--- a/internal/recon/migrations.go
+++ b/internal/recon/migrations.go
@@ -236,5 +236,87 @@ func migrations() []plugin.Migration {
 				return nil
 			},
 		},
+		{
+			Version:     10,
+			Description: "create hardware asset profile tables (hardware, storage, gpu, services)",
+			Up: func(tx *sql.Tx) error {
+				stmts := []string{
+					`CREATE TABLE recon_device_hardware (
+						device_id           TEXT PRIMARY KEY REFERENCES recon_devices(id) ON DELETE CASCADE,
+						hostname            TEXT NOT NULL DEFAULT '',
+						fqdn                TEXT NOT NULL DEFAULT '',
+						os_name             TEXT NOT NULL DEFAULT '',
+						os_version          TEXT NOT NULL DEFAULT '',
+						os_arch             TEXT NOT NULL DEFAULT '',
+						kernel              TEXT NOT NULL DEFAULT '',
+						cpu_model           TEXT NOT NULL DEFAULT '',
+						cpu_cores           INTEGER NOT NULL DEFAULT 0,
+						cpu_threads         INTEGER NOT NULL DEFAULT 0,
+						cpu_arch            TEXT NOT NULL DEFAULT '',
+						ram_total_mb        INTEGER NOT NULL DEFAULT 0,
+						ram_type            TEXT NOT NULL DEFAULT '',
+						ram_slots_used      INTEGER NOT NULL DEFAULT 0,
+						ram_slots_total     INTEGER NOT NULL DEFAULT 0,
+						platform_type       TEXT NOT NULL DEFAULT '',
+						hypervisor          TEXT NOT NULL DEFAULT '',
+						vm_host_id          TEXT NOT NULL DEFAULT '',
+						system_manufacturer TEXT NOT NULL DEFAULT '',
+						system_model        TEXT NOT NULL DEFAULT '',
+						serial_number       TEXT NOT NULL DEFAULT '',
+						bios_version        TEXT NOT NULL DEFAULT '',
+						collection_source   TEXT NOT NULL DEFAULT '',
+						collected_at        DATETIME,
+						updated_at          DATETIME
+					)`,
+					`CREATE INDEX idx_recon_device_hardware_cpu ON recon_device_hardware(cpu_model)`,
+					`CREATE INDEX idx_recon_device_hardware_os ON recon_device_hardware(os_name)`,
+					`CREATE INDEX idx_recon_device_hardware_platform ON recon_device_hardware(platform_type)`,
+					`CREATE TABLE recon_device_storage (
+						id                TEXT PRIMARY KEY,
+						device_id         TEXT NOT NULL REFERENCES recon_devices(id) ON DELETE CASCADE,
+						name              TEXT NOT NULL DEFAULT '',
+						disk_type         TEXT NOT NULL DEFAULT '',
+						interface         TEXT NOT NULL DEFAULT '',
+						capacity_gb       INTEGER NOT NULL DEFAULT 0,
+						model             TEXT NOT NULL DEFAULT '',
+						role              TEXT NOT NULL DEFAULT '',
+						collection_source TEXT NOT NULL DEFAULT '',
+						collected_at      DATETIME
+					)`,
+					`CREATE INDEX idx_recon_device_storage_device ON recon_device_storage(device_id)`,
+					`CREATE TABLE recon_device_gpu (
+						id                TEXT PRIMARY KEY,
+						device_id         TEXT NOT NULL REFERENCES recon_devices(id) ON DELETE CASCADE,
+						model             TEXT NOT NULL DEFAULT '',
+						vendor            TEXT NOT NULL DEFAULT '',
+						vram_mb           INTEGER NOT NULL DEFAULT 0,
+						driver_version    TEXT NOT NULL DEFAULT '',
+						collection_source TEXT NOT NULL DEFAULT '',
+						collected_at      DATETIME
+					)`,
+					`CREATE INDEX idx_recon_device_gpu_device ON recon_device_gpu(device_id)`,
+					`CREATE TABLE recon_device_services (
+						id                TEXT PRIMARY KEY,
+						device_id         TEXT NOT NULL REFERENCES recon_devices(id) ON DELETE CASCADE,
+						name              TEXT NOT NULL DEFAULT '',
+						service_type      TEXT NOT NULL DEFAULT '',
+						port              INTEGER NOT NULL DEFAULT 0,
+						url               TEXT NOT NULL DEFAULT '',
+						version           TEXT NOT NULL DEFAULT '',
+						status            TEXT NOT NULL DEFAULT '',
+						collection_source TEXT NOT NULL DEFAULT '',
+						collected_at      DATETIME
+					)`,
+					`CREATE INDEX idx_recon_device_services_device ON recon_device_services(device_id)`,
+					`CREATE INDEX idx_recon_device_services_name ON recon_device_services(name)`,
+				}
+				for _, stmt := range stmts {
+					if _, err := tx.Exec(stmt); err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+		},
 	}
 }

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -57,3 +57,57 @@ func WithLastSeen(t time.Time) func(*models.Device) {
 func WithDeviceType(dt models.DeviceType) func(*models.Device) {
 	return func(d *models.Device) { d.DeviceType = dt }
 }
+
+// NewDeviceHardware returns a DeviceHardware with sensible defaults.
+func NewDeviceHardware(deviceID string, opts ...func(*models.DeviceHardware)) models.DeviceHardware {
+	hw := models.DeviceHardware{
+		DeviceID:           deviceID,
+		Hostname:           "test-device",
+		OSName:             "Ubuntu 24.04",
+		OSVersion:          "24.04",
+		OSArch:             "amd64",
+		CPUModel:           "Intel Core i7-12700K",
+		CPUCores:           12,
+		CPUThreads:         20,
+		RAMTotalMB:         32768,
+		PlatformType:       "baremetal",
+		SystemManufacturer: "Dell Inc.",
+		CollectionSource:   "scout-linux",
+	}
+	for _, opt := range opts {
+		opt(&hw)
+	}
+	return hw
+}
+
+// WithCPU sets the CPU model, cores, and threads on a DeviceHardware.
+func WithCPU(model string, cores, threads int) func(*models.DeviceHardware) {
+	return func(hw *models.DeviceHardware) {
+		hw.CPUModel = model
+		hw.CPUCores = cores
+		hw.CPUThreads = threads
+	}
+}
+
+// WithRAM sets the total RAM in MB on a DeviceHardware.
+func WithRAM(totalMB int) func(*models.DeviceHardware) {
+	return func(hw *models.DeviceHardware) { hw.RAMTotalMB = totalMB }
+}
+
+// WithOSInfo sets the OS name and version on a DeviceHardware.
+func WithOSInfo(name, version string) func(*models.DeviceHardware) {
+	return func(hw *models.DeviceHardware) {
+		hw.OSName = name
+		hw.OSVersion = version
+	}
+}
+
+// WithPlatformType sets the platform type on a DeviceHardware.
+func WithPlatformType(pt string) func(*models.DeviceHardware) {
+	return func(hw *models.DeviceHardware) { hw.PlatformType = pt }
+}
+
+// WithCollectionSource sets the collection source on a DeviceHardware.
+func WithCollectionSource(src string) func(*models.DeviceHardware) {
+	return func(hw *models.DeviceHardware) { hw.CollectionSource = src }
+}

--- a/pkg/models/hardware.go
+++ b/pkg/models/hardware.go
@@ -1,0 +1,97 @@
+package models
+
+import "time"
+
+// DeviceHardware represents the hardware profile of a device.
+type DeviceHardware struct {
+	DeviceID           string     `json:"device_id" example:"550e8400-e29b-41d4-a716-446655440000"`
+	Hostname           string     `json:"hostname,omitempty" example:"web-server-01"`
+	FQDN               string     `json:"fqdn,omitempty" example:"web-server-01.local"`
+	OSName             string     `json:"os_name,omitempty" example:"Ubuntu 24.04"`
+	OSVersion          string     `json:"os_version,omitempty" example:"24.04"`
+	OSArch             string     `json:"os_arch,omitempty" example:"amd64"`
+	Kernel             string     `json:"kernel,omitempty" example:"6.5.0-44-generic"`
+	CPUModel           string     `json:"cpu_model,omitempty" example:"Intel Core i9-10900K"`
+	CPUCores           int        `json:"cpu_cores,omitempty" example:"10"`
+	CPUThreads         int        `json:"cpu_threads,omitempty" example:"20"`
+	CPUArch            string     `json:"cpu_arch,omitempty" example:"x86_64"`
+	RAMTotalMB         int        `json:"ram_total_mb,omitempty" example:"32768"`
+	RAMType            string     `json:"ram_type,omitempty" example:"DDR4"`
+	RAMSlotsUsed       int        `json:"ram_slots_used,omitempty" example:"2"`
+	RAMSlotsTotal      int        `json:"ram_slots_total,omitempty" example:"4"`
+	PlatformType       string     `json:"platform_type,omitempty" example:"baremetal"`
+	Hypervisor         string     `json:"hypervisor,omitempty" example:"proxmox"`
+	VMHostID           string     `json:"vm_host_id,omitempty"`
+	SystemManufacturer string     `json:"system_manufacturer,omitempty" example:"Dell Inc."`
+	SystemModel        string     `json:"system_model,omitempty" example:"PowerEdge R730"`
+	SerialNumber       string     `json:"serial_number,omitempty" example:"ABC123"`
+	BIOSVersion        string     `json:"bios_version,omitempty" example:"2.17.0"`
+	CollectionSource   string     `json:"collection_source,omitempty" example:"scout-wmi"`
+	CollectedAt        *time.Time `json:"collected_at,omitempty"`
+	UpdatedAt          *time.Time `json:"updated_at,omitempty"`
+}
+
+// DeviceStorage represents a storage device attached to a device.
+type DeviceStorage struct {
+	ID               string     `json:"id"`
+	DeviceID         string     `json:"device_id"`
+	Name             string     `json:"name,omitempty" example:"Samsung 990 Pro 4TB"`
+	DiskType         string     `json:"disk_type,omitempty" example:"nvme"`
+	Interface        string     `json:"interface,omitempty" example:"pcie4"`
+	CapacityGB       int        `json:"capacity_gb,omitempty" example:"4000"`
+	Model            string     `json:"model,omitempty" example:"Samsung SSD 990 PRO"`
+	Role             string     `json:"role,omitempty" example:"data"`
+	CollectionSource string     `json:"collection_source,omitempty" example:"scout-linux"`
+	CollectedAt      *time.Time `json:"collected_at,omitempty"`
+}
+
+// DeviceGPU represents a GPU in a device.
+type DeviceGPU struct {
+	ID               string     `json:"id"`
+	DeviceID         string     `json:"device_id"`
+	Model            string     `json:"model,omitempty" example:"NVIDIA RTX 3090 Ti"`
+	Vendor           string     `json:"vendor,omitempty" example:"nvidia"`
+	VRAMMB           int        `json:"vram_mb,omitempty" example:"24576"`
+	DriverVersion    string     `json:"driver_version,omitempty" example:"535.183.01"`
+	CollectionSource string     `json:"collection_source,omitempty" example:"scout-linux"`
+	CollectedAt      *time.Time `json:"collected_at,omitempty"`
+}
+
+// DeviceService represents a running service on a device.
+type DeviceService struct {
+	ID               string     `json:"id"`
+	DeviceID         string     `json:"device_id"`
+	Name             string     `json:"name,omitempty" example:"plex"`
+	ServiceType      string     `json:"service_type,omitempty" example:"docker"`
+	Port             int        `json:"port,omitempty" example:"32400"`
+	URL              string     `json:"url,omitempty" example:"http://192.168.1.10:32400"`
+	Version          string     `json:"version,omitempty" example:"1.40.0"`
+	Status           string     `json:"status,omitempty" example:"running"`
+	CollectionSource string     `json:"collection_source,omitempty" example:"scout-linux"`
+	CollectedAt      *time.Time `json:"collected_at,omitempty"`
+}
+
+// HardwareSummary provides fleet-wide aggregate hardware statistics.
+type HardwareSummary struct {
+	TotalWithHardware int            `json:"total_with_hardware"`
+	TotalRAMMB        int64          `json:"total_ram_mb"`
+	TotalStorageGB    int64          `json:"total_storage_gb"`
+	TotalGPUs         int            `json:"total_gpus"`
+	ByOS              map[string]int `json:"by_os"`
+	ByCPUModel        map[string]int `json:"by_cpu_model"`
+	ByPlatformType    map[string]int `json:"by_platform_type"`
+	ByGPUVendor       map[string]int `json:"by_gpu_vendor"`
+}
+
+// HardwareQuery defines filters for hardware-based device queries.
+type HardwareQuery struct {
+	MinRAMMB     int    `json:"min_ram_mb,omitempty"`
+	MaxRAMMB     int    `json:"max_ram_mb,omitempty"`
+	CPUModel     string `json:"cpu_model,omitempty"`
+	OSName       string `json:"os_name,omitempty"`
+	PlatformType string `json:"platform_type,omitempty"`
+	GPUVendor    string `json:"gpu_vendor,omitempty"`
+	HasGPU       *bool  `json:"has_gpu,omitempty"`
+	Limit        int    `json:"limit,omitempty"`
+	Offset       int    `json:"offset,omitempty"`
+}


### PR DESCRIPTION
## Summary

- Add migration v10 with 4 normalized tables for structured device inventory
- Implement 11 store methods with manual override protection
- Add fleet-wide aggregate queries and hardware-based device filtering
- 25 table-driven tests, all passing

### New Tables

| Table | Relationship | Purpose |
|-------|-------------|---------|
| `recon_device_hardware` | 1:1 with devices | CPU, RAM, OS, platform, BIOS, manufacturer |
| `recon_device_storage` | 1:many | Disks with type, interface, capacity, role |
| `recon_device_gpu` | 1:many | GPUs with VRAM, driver version |
| `recon_device_services` | 1:many | Running services with type, port, status |

### Manual Override Logic

Auto-collected data never overwrites fields set by manual override (`collection_source = "manual"`). When existing record is manual and incoming is auto-collected, only empty/zero fields are filled.

### Phase 1 of 3

This is the data layer for #437. Phase 2 adds REST API handlers + event bridge from dispatch. Phase 3 adds frontend hardware tab + seed data.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/recon/...` -- 25 new tests pass
- [x] `GOOS=linux GOARCH=amd64 go build ./...` -- cross-compile clean
- [ ] CI passes

Closes #437 (partially -- schema and store layer complete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)