### PR TITLE
feat: hardware asset profile API and event bridge

### DIFF
--- a/api/swagger/docs.go
+++ b/api/swagger/docs.go
@@ -2660,6 +2660,95 @@ const docTemplate = `{
                 }
             }
         },
+        "/recon/devices/query/hardware": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns devices matching hardware filters like RAM, CPU model, OS, platform type, and GPU.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "recon"
+                ],
+                "summary": "Query devices by hardware",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Minimum RAM in MB",
+                        "name": "min_ram_mb",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum RAM in MB",
+                        "name": "max_ram_mb",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "CPU model substring match",
+                        "name": "cpu_model",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "OS name substring match",
+                        "name": "os_name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Platform type (baremetal, vm, container, lxc)",
+                        "name": "platform_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "GPU vendor filter (nvidia, amd, intel)",
+                        "name": "gpu_vendor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Filter devices with/without GPU",
+                        "name": "has_gpu",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 50,
+                        "description": "Max results",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 0,
+                        "description": "Offset",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_recon.HardwareQueryResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    }
+                }
+            }
+        },
         "/recon/devices/{id}": {
             "get": {
                 "security": [
@@ -2812,6 +2901,157 @@ const docTemplate = `{
                 }
             }
         },
+        "/recon/devices/{id}/gpu": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns all GPUs installed in a device.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "recon"
+                ],
+                "summary": "Get device GPUs",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Device ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.DeviceGPU"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    }
+                }
+            }
+        },
+        "/recon/devices/{id}/hardware": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the full hardware profile including storage, GPUs, and services for a device.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "recon"
+                ],
+                "summary": "Get device hardware profile",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Device ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_recon.DeviceHardwareResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Manually creates or updates a device's hardware profile. Sets collection_source to \"manual\".",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "recon"
+                ],
+                "summary": "Update device hardware profile",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Device ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Hardware profile",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.DeviceHardware"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.DeviceHardware"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    }
+                }
+            }
+        },
         "/recon/devices/{id}/history": {
             "get": {
                 "security": [
@@ -2906,6 +3146,104 @@ const docTemplate = `{
                             "type": "array",
                             "items": {
                                 "$ref": "#/definitions/internal_recon.DeviceScanEvent"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    }
+                }
+            }
+        },
+        "/recon/devices/{id}/services": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns all running services on a device.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "recon"
+                ],
+                "summary": "Get device services",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Device ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.DeviceService"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    }
+                }
+            }
+        },
+        "/recon/devices/{id}/storage": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns all storage devices attached to a device.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "recon"
+                ],
+                "summary": "Get device storage",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Device ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.DeviceStorage"
                             }
                         }
                     },
@@ -3118,6 +3456,37 @@ const docTemplate = `{
                             "items": {
                                 "$ref": "#/definitions/internal_recon.DeviceTreeNode"
                             }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    }
+                }
+            }
+        },
+        "/recon/inventory/hardware-summary": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns aggregate hardware statistics across all devices with hardware profiles.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "recon"
+                ],
+                "summary": "Hardware inventory summary",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.HardwareSummary"
                         }
                     },
                     "500": {
@@ -5338,6 +5707,184 @@ const docTemplate = `{
                 }
             }
         },
+        "github_com_HerbHall_subnetree_pkg_models.DeviceGPU": {
+            "type": "object",
+            "properties": {
+                "collected_at": {
+                    "type": "string"
+                },
+                "collection_source": {
+                    "type": "string",
+                    "example": "scout-linux"
+                },
+                "device_id": {
+                    "type": "string"
+                },
+                "driver_version": {
+                    "type": "string",
+                    "example": "535.183.01"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "model": {
+                    "type": "string",
+                    "example": "NVIDIA RTX 3090 Ti"
+                },
+                "vendor": {
+                    "type": "string",
+                    "example": "nvidia"
+                },
+                "vram_mb": {
+                    "type": "integer",
+                    "example": 24576
+                }
+            }
+        },
+        "github_com_HerbHall_subnetree_pkg_models.DeviceHardware": {
+            "type": "object",
+            "properties": {
+                "bios_version": {
+                    "type": "string",
+                    "example": "2.17.0"
+                },
+                "collected_at": {
+                    "type": "string"
+                },
+                "collection_source": {
+                    "type": "string",
+                    "example": "scout-wmi"
+                },
+                "cpu_arch": {
+                    "type": "string",
+                    "example": "x86_64"
+                },
+                "cpu_cores": {
+                    "type": "integer",
+                    "example": 10
+                },
+                "cpu_model": {
+                    "type": "string",
+                    "example": "Intel Core i9-10900K"
+                },
+                "cpu_threads": {
+                    "type": "integer",
+                    "example": 20
+                },
+                "device_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "fqdn": {
+                    "type": "string",
+                    "example": "web-server-01.local"
+                },
+                "hostname": {
+                    "type": "string",
+                    "example": "web-server-01"
+                },
+                "hypervisor": {
+                    "type": "string",
+                    "example": "proxmox"
+                },
+                "kernel": {
+                    "type": "string",
+                    "example": "6.5.0-44-generic"
+                },
+                "os_arch": {
+                    "type": "string",
+                    "example": "amd64"
+                },
+                "os_name": {
+                    "type": "string",
+                    "example": "Ubuntu 24.04"
+                },
+                "os_version": {
+                    "type": "string",
+                    "example": "24.04"
+                },
+                "platform_type": {
+                    "type": "string",
+                    "example": "baremetal"
+                },
+                "ram_slots_total": {
+                    "type": "integer",
+                    "example": 4
+                },
+                "ram_slots_used": {
+                    "type": "integer",
+                    "example": 2
+                },
+                "ram_total_mb": {
+                    "type": "integer",
+                    "example": 32768
+                },
+                "ram_type": {
+                    "type": "string",
+                    "example": "DDR4"
+                },
+                "serial_number": {
+                    "type": "string",
+                    "example": "ABC123"
+                },
+                "system_manufacturer": {
+                    "type": "string",
+                    "example": "Dell Inc."
+                },
+                "system_model": {
+                    "type": "string",
+                    "example": "PowerEdge R730"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "vm_host_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_HerbHall_subnetree_pkg_models.DeviceService": {
+            "type": "object",
+            "properties": {
+                "collected_at": {
+                    "type": "string"
+                },
+                "collection_source": {
+                    "type": "string",
+                    "example": "scout-linux"
+                },
+                "device_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "plex"
+                },
+                "port": {
+                    "type": "integer",
+                    "example": 32400
+                },
+                "service_type": {
+                    "type": "string",
+                    "example": "docker"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "running"
+                },
+                "url": {
+                    "type": "string",
+                    "example": "http://192.168.1.10:32400"
+                },
+                "version": {
+                    "type": "string",
+                    "example": "1.40.0"
+                }
+            }
+        },
         "github_com_HerbHall_subnetree_pkg_models.DeviceStatus": {
             "type": "string",
             "enum": [
@@ -5352,6 +5899,48 @@ const docTemplate = `{
                 "DeviceStatusDegraded",
                 "DeviceStatusUnknown"
             ]
+        },
+        "github_com_HerbHall_subnetree_pkg_models.DeviceStorage": {
+            "type": "object",
+            "properties": {
+                "capacity_gb": {
+                    "type": "integer",
+                    "example": 4000
+                },
+                "collected_at": {
+                    "type": "string"
+                },
+                "collection_source": {
+                    "type": "string",
+                    "example": "scout-linux"
+                },
+                "device_id": {
+                    "type": "string"
+                },
+                "disk_type": {
+                    "type": "string",
+                    "example": "nvme"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "interface": {
+                    "type": "string",
+                    "example": "pcie4"
+                },
+                "model": {
+                    "type": "string",
+                    "example": "Samsung SSD 990 PRO"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "Samsung 990 Pro 4TB"
+                },
+                "role": {
+                    "type": "string",
+                    "example": "data"
+                }
+            }
         },
         "github_com_HerbHall_subnetree_pkg_models.DeviceType": {
             "type": "string",
@@ -5449,6 +6038,47 @@ const docTemplate = `{
                     "items": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "github_com_HerbHall_subnetree_pkg_models.HardwareSummary": {
+            "type": "object",
+            "properties": {
+                "by_cpu_model": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer"
+                    }
+                },
+                "by_gpu_vendor": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer"
+                    }
+                },
+                "by_os": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer"
+                    }
+                },
+                "by_platform_type": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer"
+                    }
+                },
+                "total_gpus": {
+                    "type": "integer"
+                },
+                "total_ram_mb": {
+                    "type": "integer"
+                },
+                "total_storage_gb": {
+                    "type": "integer"
+                },
+                "total_with_hardware": {
+                    "type": "integer"
                 }
             }
         },
@@ -6303,6 +6933,32 @@ const docTemplate = `{
                 }
             }
         },
+        "internal_recon.DeviceHardwareResponse": {
+            "type": "object",
+            "properties": {
+                "gpus": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.DeviceGPU"
+                    }
+                },
+                "hardware": {
+                    "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.DeviceHardware"
+                },
+                "services": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.DeviceService"
+                    }
+                },
+                "storage": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.DeviceStorage"
+                    }
+                }
+            }
+        },
         "internal_recon.DeviceListResponse": {
             "type": "object",
             "properties": {
@@ -6524,6 +7180,26 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "port": {
+                    "type": "integer"
+                }
+            }
+        },
+        "internal_recon.HardwareQueryResponse": {
+            "type": "object",
+            "properties": {
+                "devices": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.Device"
+                    }
+                },
+                "limit": {
+                    "type": "integer"
+                },
+                "offset": {
+                    "type": "integer"
+                },
+                "total": {
                     "type": "integer"
                 }
             }

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -2653,6 +2653,95 @@
                 }
             }
         },
+        "/recon/devices/query/hardware": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns devices matching hardware filters like RAM, CPU model, OS, platform type, and GPU.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "recon"
+                ],
+                "summary": "Query devices by hardware",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Minimum RAM in MB",
+                        "name": "min_ram_mb",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum RAM in MB",
+                        "name": "max_ram_mb",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "CPU model substring match",
+                        "name": "cpu_model",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "OS name substring match",
+                        "name": "os_name",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Platform type (baremetal, vm, container, lxc)",
+                        "name": "platform_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "GPU vendor filter (nvidia, amd, intel)",
+                        "name": "gpu_vendor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Filter devices with/without GPU",
+                        "name": "has_gpu",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 50,
+                        "description": "Max results",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 0,
+                        "description": "Offset",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_recon.HardwareQueryResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    }
+                }
+            }
+        },
         "/recon/devices/{id}": {
             "get": {
                 "security": [
@@ -2805,6 +2894,157 @@
                 }
             }
         },
+        "/recon/devices/{id}/gpu": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns all GPUs installed in a device.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "recon"
+                ],
+                "summary": "Get device GPUs",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Device ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.DeviceGPU"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    }
+                }
+            }
+        },
+        "/recon/devices/{id}/hardware": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the full hardware profile including storage, GPUs, and services for a device.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "recon"
+                ],
+                "summary": "Get device hardware profile",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Device ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_recon.DeviceHardwareResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Manually creates or updates a device's hardware profile. Sets collection_source to \"manual\".",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "recon"
+                ],
+                "summary": "Update device hardware profile",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Device ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Hardware profile",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.DeviceHardware"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.DeviceHardware"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    }
+                }
+            }
+        },
         "/recon/devices/{id}/history": {
             "get": {
                 "security": [
@@ -2899,6 +3139,104 @@
                             "type": "array",
                             "items": {
                                 "$ref": "#/definitions/internal_recon.DeviceScanEvent"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    }
+                }
+            }
+        },
+        "/recon/devices/{id}/services": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns all running services on a device.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "recon"
+                ],
+                "summary": "Get device services",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Device ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.DeviceService"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    }
+                }
+            }
+        },
+        "/recon/devices/{id}/storage": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns all storage devices attached to a device.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "recon"
+                ],
+                "summary": "Get device storage",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Device ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.DeviceStorage"
                             }
                         }
                     },
@@ -3111,6 +3449,37 @@
                             "items": {
                                 "$ref": "#/definitions/internal_recon.DeviceTreeNode"
                             }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    }
+                }
+            }
+        },
+        "/recon/inventory/hardware-summary": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns aggregate hardware statistics across all devices with hardware profiles.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "recon"
+                ],
+                "summary": "Hardware inventory summary",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.HardwareSummary"
                         }
                     },
                     "500": {
@@ -5331,6 +5700,184 @@
                 }
             }
         },
+        "github_com_HerbHall_subnetree_pkg_models.DeviceGPU": {
+            "type": "object",
+            "properties": {
+                "collected_at": {
+                    "type": "string"
+                },
+                "collection_source": {
+                    "type": "string",
+                    "example": "scout-linux"
+                },
+                "device_id": {
+                    "type": "string"
+                },
+                "driver_version": {
+                    "type": "string",
+                    "example": "535.183.01"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "model": {
+                    "type": "string",
+                    "example": "NVIDIA RTX 3090 Ti"
+                },
+                "vendor": {
+                    "type": "string",
+                    "example": "nvidia"
+                },
+                "vram_mb": {
+                    "type": "integer",
+                    "example": 24576
+                }
+            }
+        },
+        "github_com_HerbHall_subnetree_pkg_models.DeviceHardware": {
+            "type": "object",
+            "properties": {
+                "bios_version": {
+                    "type": "string",
+                    "example": "2.17.0"
+                },
+                "collected_at": {
+                    "type": "string"
+                },
+                "collection_source": {
+                    "type": "string",
+                    "example": "scout-wmi"
+                },
+                "cpu_arch": {
+                    "type": "string",
+                    "example": "x86_64"
+                },
+                "cpu_cores": {
+                    "type": "integer",
+                    "example": 10
+                },
+                "cpu_model": {
+                    "type": "string",
+                    "example": "Intel Core i9-10900K"
+                },
+                "cpu_threads": {
+                    "type": "integer",
+                    "example": 20
+                },
+                "device_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "fqdn": {
+                    "type": "string",
+                    "example": "web-server-01.local"
+                },
+                "hostname": {
+                    "type": "string",
+                    "example": "web-server-01"
+                },
+                "hypervisor": {
+                    "type": "string",
+                    "example": "proxmox"
+                },
+                "kernel": {
+                    "type": "string",
+                    "example": "6.5.0-44-generic"
+                },
+                "os_arch": {
+                    "type": "string",
+                    "example": "amd64"
+                },
+                "os_name": {
+                    "type": "string",
+                    "example": "Ubuntu 24.04"
+                },
+                "os_version": {
+                    "type": "string",
+                    "example": "24.04"
+                },
+                "platform_type": {
+                    "type": "string",
+                    "example": "baremetal"
+                },
+                "ram_slots_total": {
+                    "type": "integer",
+                    "example": 4
+                },
+                "ram_slots_used": {
+                    "type": "integer",
+                    "example": 2
+                },
+                "ram_total_mb": {
+                    "type": "integer",
+                    "example": 32768
+                },
+                "ram_type": {
+                    "type": "string",
+                    "example": "DDR4"
+                },
+                "serial_number": {
+                    "type": "string",
+                    "example": "ABC123"
+                },
+                "system_manufacturer": {
+                    "type": "string",
+                    "example": "Dell Inc."
+                },
+                "system_model": {
+                    "type": "string",
+                    "example": "PowerEdge R730"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "vm_host_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_HerbHall_subnetree_pkg_models.DeviceService": {
+            "type": "object",
+            "properties": {
+                "collected_at": {
+                    "type": "string"
+                },
+                "collection_source": {
+                    "type": "string",
+                    "example": "scout-linux"
+                },
+                "device_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "plex"
+                },
+                "port": {
+                    "type": "integer",
+                    "example": 32400
+                },
+                "service_type": {
+                    "type": "string",
+                    "example": "docker"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "running"
+                },
+                "url": {
+                    "type": "string",
+                    "example": "http://192.168.1.10:32400"
+                },
+                "version": {
+                    "type": "string",
+                    "example": "1.40.0"
+                }
+            }
+        },
         "github_com_HerbHall_subnetree_pkg_models.DeviceStatus": {
             "type": "string",
             "enum": [
@@ -5345,6 +5892,48 @@
                 "DeviceStatusDegraded",
                 "DeviceStatusUnknown"
             ]
+        },
+        "github_com_HerbHall_subnetree_pkg_models.DeviceStorage": {
+            "type": "object",
+            "properties": {
+                "capacity_gb": {
+                    "type": "integer",
+                    "example": 4000
+                },
+                "collected_at": {
+                    "type": "string"
+                },
+                "collection_source": {
+                    "type": "string",
+                    "example": "scout-linux"
+                },
+                "device_id": {
+                    "type": "string"
+                },
+                "disk_type": {
+                    "type": "string",
+                    "example": "nvme"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "interface": {
+                    "type": "string",
+                    "example": "pcie4"
+                },
+                "model": {
+                    "type": "string",
+                    "example": "Samsung SSD 990 PRO"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "Samsung 990 Pro 4TB"
+                },
+                "role": {
+                    "type": "string",
+                    "example": "data"
+                }
+            }
         },
         "github_com_HerbHall_subnetree_pkg_models.DeviceType": {
             "type": "string",
@@ -5442,6 +6031,47 @@
                     "items": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "github_com_HerbHall_subnetree_pkg_models.HardwareSummary": {
+            "type": "object",
+            "properties": {
+                "by_cpu_model": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer"
+                    }
+                },
+                "by_gpu_vendor": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer"
+                    }
+                },
+                "by_os": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer"
+                    }
+                },
+                "by_platform_type": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer"
+                    }
+                },
+                "total_gpus": {
+                    "type": "integer"
+                },
+                "total_ram_mb": {
+                    "type": "integer"
+                },
+                "total_storage_gb": {
+                    "type": "integer"
+                },
+                "total_with_hardware": {
+                    "type": "integer"
                 }
             }
         },
@@ -6296,6 +6926,32 @@
                 }
             }
         },
+        "internal_recon.DeviceHardwareResponse": {
+            "type": "object",
+            "properties": {
+                "gpus": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.DeviceGPU"
+                    }
+                },
+                "hardware": {
+                    "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.DeviceHardware"
+                },
+                "services": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.DeviceService"
+                    }
+                },
+                "storage": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.DeviceStorage"
+                    }
+                }
+            }
+        },
         "internal_recon.DeviceListResponse": {
             "type": "object",
             "properties": {
@@ -6517,6 +7173,26 @@
                     "type": "boolean"
                 },
                 "port": {
+                    "type": "integer"
+                }
+            }
+        },
+        "internal_recon.HardwareQueryResponse": {
+            "type": "object",
+            "properties": {
+                "devices": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.Device"
+                    }
+                },
+                "limit": {
+                    "type": "integer"
+                },
+                "offset": {
+                    "type": "integer"
+                },
+                "total": {
                     "type": "integer"
                 }
             }

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -393,6 +393,135 @@ definitions:
           type: string
         type: array
     type: object
+  github_com_HerbHall_subnetree_pkg_models.DeviceGPU:
+    properties:
+      collected_at:
+        type: string
+      collection_source:
+        example: scout-linux
+        type: string
+      device_id:
+        type: string
+      driver_version:
+        example: 535.183.01
+        type: string
+      id:
+        type: string
+      model:
+        example: NVIDIA RTX 3090 Ti
+        type: string
+      vendor:
+        example: nvidia
+        type: string
+      vram_mb:
+        example: 24576
+        type: integer
+    type: object
+  github_com_HerbHall_subnetree_pkg_models.DeviceHardware:
+    properties:
+      bios_version:
+        example: 2.17.0
+        type: string
+      collected_at:
+        type: string
+      collection_source:
+        example: scout-wmi
+        type: string
+      cpu_arch:
+        example: x86_64
+        type: string
+      cpu_cores:
+        example: 10
+        type: integer
+      cpu_model:
+        example: Intel Core i9-10900K
+        type: string
+      cpu_threads:
+        example: 20
+        type: integer
+      device_id:
+        example: 550e8400-e29b-41d4-a716-446655440000
+        type: string
+      fqdn:
+        example: web-server-01.local
+        type: string
+      hostname:
+        example: web-server-01
+        type: string
+      hypervisor:
+        example: proxmox
+        type: string
+      kernel:
+        example: 6.5.0-44-generic
+        type: string
+      os_arch:
+        example: amd64
+        type: string
+      os_name:
+        example: Ubuntu 24.04
+        type: string
+      os_version:
+        example: "24.04"
+        type: string
+      platform_type:
+        example: baremetal
+        type: string
+      ram_slots_total:
+        example: 4
+        type: integer
+      ram_slots_used:
+        example: 2
+        type: integer
+      ram_total_mb:
+        example: 32768
+        type: integer
+      ram_type:
+        example: DDR4
+        type: string
+      serial_number:
+        example: ABC123
+        type: string
+      system_manufacturer:
+        example: Dell Inc.
+        type: string
+      system_model:
+        example: PowerEdge R730
+        type: string
+      updated_at:
+        type: string
+      vm_host_id:
+        type: string
+    type: object
+  github_com_HerbHall_subnetree_pkg_models.DeviceService:
+    properties:
+      collected_at:
+        type: string
+      collection_source:
+        example: scout-linux
+        type: string
+      device_id:
+        type: string
+      id:
+        type: string
+      name:
+        example: plex
+        type: string
+      port:
+        example: 32400
+        type: integer
+      service_type:
+        example: docker
+        type: string
+      status:
+        example: running
+        type: string
+      url:
+        example: http://192.168.1.10:32400
+        type: string
+      version:
+        example: 1.40.0
+        type: string
+    type: object
   github_com_HerbHall_subnetree_pkg_models.DeviceStatus:
     enum:
     - online
@@ -405,6 +534,36 @@ definitions:
     - DeviceStatusOffline
     - DeviceStatusDegraded
     - DeviceStatusUnknown
+  github_com_HerbHall_subnetree_pkg_models.DeviceStorage:
+    properties:
+      capacity_gb:
+        example: 4000
+        type: integer
+      collected_at:
+        type: string
+      collection_source:
+        example: scout-linux
+        type: string
+      device_id:
+        type: string
+      disk_type:
+        example: nvme
+        type: string
+      id:
+        type: string
+      interface:
+        example: pcie4
+        type: string
+      model:
+        example: Samsung SSD 990 PRO
+        type: string
+      name:
+        example: Samsung 990 Pro 4TB
+        type: string
+      role:
+        example: data
+        type: string
+    type: object
   github_com_HerbHall_subnetree_pkg_models.DeviceType:
     enum:
     - server
@@ -485,6 +644,33 @@ definitions:
         items:
           type: string
         type: array
+    type: object
+  github_com_HerbHall_subnetree_pkg_models.HardwareSummary:
+    properties:
+      by_cpu_model:
+        additionalProperties:
+          type: integer
+        type: object
+      by_gpu_vendor:
+        additionalProperties:
+          type: integer
+        type: object
+      by_os:
+        additionalProperties:
+          type: integer
+        type: object
+      by_platform_type:
+        additionalProperties:
+          type: integer
+        type: object
+      total_gpus:
+        type: integer
+      total_ram_mb:
+        type: integer
+      total_storage_gb:
+        type: integer
+      total_with_hardware:
+        type: integer
     type: object
   github_com_HerbHall_subnetree_pkg_models.ScanMetrics:
     properties:
@@ -1059,6 +1245,23 @@ definitions:
           type: string
         type: array
     type: object
+  internal_recon.DeviceHardwareResponse:
+    properties:
+      gpus:
+        items:
+          $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_models.DeviceGPU'
+        type: array
+      hardware:
+        $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_models.DeviceHardware'
+      services:
+        items:
+          $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_models.DeviceService'
+        type: array
+      storage:
+        items:
+          $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_models.DeviceStorage'
+        type: array
+    type: object
   internal_recon.DeviceListResponse:
     properties:
       devices:
@@ -1206,6 +1409,19 @@ definitions:
       open:
         type: boolean
       port:
+        type: integer
+    type: object
+  internal_recon.HardwareQueryResponse:
+    properties:
+      devices:
+        items:
+          $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_models.Device'
+        type: array
+      limit:
+        type: integer
+      offset:
+        type: integer
+      total:
         type: integer
     type: object
   internal_recon.HealthScoreFactor:
@@ -3394,6 +3610,104 @@ paths:
       summary: Update device
       tags:
       - recon
+  /recon/devices/{id}/gpu:
+    get:
+      description: Returns all GPUs installed in a device.
+      parameters:
+      - description: Device ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_models.DeviceGPU'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem'
+      security:
+      - BearerAuth: []
+      summary: Get device GPUs
+      tags:
+      - recon
+  /recon/devices/{id}/hardware:
+    get:
+      description: Returns the full hardware profile including storage, GPUs, and
+        services for a device.
+      parameters:
+      - description: Device ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/internal_recon.DeviceHardwareResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem'
+      security:
+      - BearerAuth: []
+      summary: Get device hardware profile
+      tags:
+      - recon
+    put:
+      consumes:
+      - application/json
+      description: Manually creates or updates a device's hardware profile. Sets collection_source
+        to "manual".
+      parameters:
+      - description: Device ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Hardware profile
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_models.DeviceHardware'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_models.DeviceHardware'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem'
+      security:
+      - BearerAuth: []
+      summary: Update device hardware profile
+      tags:
+      - recon
   /recon/devices/{id}/history:
     get:
       description: Returns the status change timeline for a device.
@@ -3464,6 +3778,68 @@ paths:
       security:
       - BearerAuth: []
       summary: Device scan history
+      tags:
+      - recon
+  /recon/devices/{id}/services:
+    get:
+      description: Returns all running services on a device.
+      parameters:
+      - description: Device ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_models.DeviceService'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem'
+      security:
+      - BearerAuth: []
+      summary: Get device services
+      tags:
+      - recon
+  /recon/devices/{id}/storage:
+    get:
+      description: Returns all storage devices attached to a device.
+      parameters:
+      - description: Device ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_models.DeviceStorage'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem'
+      security:
+      - BearerAuth: []
+      summary: Get device storage
       tags:
       - recon
   /recon/devices/bulk:
@@ -3547,6 +3923,65 @@ paths:
       security:
       - BearerAuth: []
       summary: Import devices from CSV
+      tags:
+      - recon
+  /recon/devices/query/hardware:
+    get:
+      description: Returns devices matching hardware filters like RAM, CPU model,
+        OS, platform type, and GPU.
+      parameters:
+      - description: Minimum RAM in MB
+        in: query
+        name: min_ram_mb
+        type: integer
+      - description: Maximum RAM in MB
+        in: query
+        name: max_ram_mb
+        type: integer
+      - description: CPU model substring match
+        in: query
+        name: cpu_model
+        type: string
+      - description: OS name substring match
+        in: query
+        name: os_name
+        type: string
+      - description: Platform type (baremetal, vm, container, lxc)
+        in: query
+        name: platform_type
+        type: string
+      - description: GPU vendor filter (nvidia, amd, intel)
+        in: query
+        name: gpu_vendor
+        type: string
+      - description: Filter devices with/without GPU
+        in: query
+        name: has_gpu
+        type: boolean
+      - default: 50
+        description: Max results
+        in: query
+        name: limit
+        type: integer
+      - default: 0
+        description: Offset
+        in: query
+        name: offset
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/internal_recon.HardwareQueryResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem'
+      security:
+      - BearerAuth: []
+      summary: Query devices by hardware
       tags:
       - recon
   /recon/diag/dns:
@@ -3679,6 +4114,26 @@ paths:
       security:
       - BearerAuth: []
       summary: Get network hierarchy
+      tags:
+      - recon
+  /recon/inventory/hardware-summary:
+    get:
+      description: Returns aggregate hardware statistics across all devices with hardware
+        profiles.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_models.HardwareSummary'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem'
+      security:
+      - BearerAuth: []
+      summary: Hardware inventory summary
       tags:
       - recon
   /recon/inventory/summary:

--- a/internal/recon/events.go
+++ b/internal/recon/events.go
@@ -14,7 +14,8 @@ const (
 	TopicScanStarted      = "recon.scan.started"
 	TopicScanCompleted    = "recon.scan.completed"
 	TopicScanProgress     = "recon.scan.progress"
-	TopicServiceMoved     = "recon.service.moved"
+	TopicServiceMoved            = "recon.service.moved"
+	TopicDeviceHardwareUpdated   = "recon.device.hardware.updated"
 )
 
 // DeviceLostEvent is the payload for TopicDeviceLost events.
@@ -40,4 +41,10 @@ type ScanProgressEvent struct {
 // ServiceMovedEvent is the payload for TopicServiceMoved events.
 type ServiceMovedEvent struct {
 	Movement ServiceMovement `json:"movement"`
+}
+
+// DeviceHardwareUpdatedEvent is the payload for TopicDeviceHardwareUpdated events.
+type DeviceHardwareUpdatedEvent struct {
+	DeviceID         string `json:"device_id"`
+	CollectionSource string `json:"collection_source"`
 }

--- a/internal/recon/hardware_bridge.go
+++ b/internal/recon/hardware_bridge.go
@@ -1,0 +1,299 @@
+package recon
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/HerbHall/subnetree/pkg/models"
+	"github.com/HerbHall/subnetree/pkg/plugin"
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+)
+
+// ProfileSource provides raw hardware profiles from the agent system.
+// Defined here (consumer-side interface) to avoid coupling recon -> dispatch.
+type ProfileSource interface {
+	GetAgent(ctx context.Context, agentID string) (*AgentInfo, error)
+	GetHardwareProfile(ctx context.Context, agentID string) (*HardwareProfileData, error)
+	GetServices(ctx context.Context, agentID string) ([]*ServiceData, error)
+}
+
+// AgentInfo is the minimal agent data needed for profile bridging.
+type AgentInfo struct {
+	ID       string
+	DeviceID string
+	Platform string
+	Hostname string
+}
+
+// HardwareProfileData holds the raw hardware profile from Scout agents.
+type HardwareProfileData struct {
+	CPUModel           string
+	CPUCores           int32
+	CPUThreads         int32
+	RAMBytes           int64
+	BIOSVersion        string
+	SystemManufacturer string
+	SystemModel        string
+	SerialNumber       string
+	Disks              []DiskData
+	GPUs               []GPUData
+}
+
+// DiskData represents a storage disk from the Scout agent profile.
+type DiskData struct {
+	Name      string
+	SizeBytes int64
+	DiskType  string
+	Model     string
+}
+
+// GPUData represents a GPU from the Scout agent profile.
+type GPUData struct {
+	Model         string
+	VRAMBytes     int64
+	DriverVersion string
+}
+
+// ServiceData represents a running service from the Scout agent profile.
+type ServiceData struct {
+	Name        string
+	DisplayName string
+	Status      string
+	StartType   string
+	CPUPercent  float64
+	MemoryBytes int64
+	Ports       []int32
+}
+
+// handleDeviceProfiled bridges dispatch's TopicDeviceProfiled event to recon's
+// normalized hardware tables. It maps raw proto-style profile data into the
+// models.DeviceHardware, DeviceStorage, DeviceGPU, and DeviceService records.
+func (m *Module) handleDeviceProfiled(ctx context.Context, evt plugin.Event) {
+	// Extract agent_id from event payload (map[string]string).
+	payload, ok := evt.Payload.(map[string]string)
+	if !ok {
+		m.logger.Warn("unexpected payload type for device profiled event")
+		return
+	}
+	agentID := payload["agent_id"]
+	if agentID == "" {
+		m.logger.Warn("device profiled event missing agent_id")
+		return
+	}
+
+	if m.profileSource == nil {
+		m.logger.Debug("profile source not configured, skipping hardware bridge")
+		return
+	}
+
+	// Look up agent to get device_id.
+	agent, err := m.profileSource.GetAgent(ctx, agentID)
+	if err != nil {
+		m.logger.Error("failed to get agent for hardware bridge",
+			zap.String("agent_id", agentID),
+			zap.Error(err),
+		)
+		return
+	}
+	if agent == nil {
+		m.logger.Warn("agent not found for hardware bridge", zap.String("agent_id", agentID))
+		return
+	}
+	if agent.DeviceID == "" {
+		m.logger.Warn("agent has no device_id, skipping hardware bridge",
+			zap.String("agent_id", agentID),
+		)
+		return
+	}
+
+	// Determine collection source based on agent platform.
+	source := collectionSourceForPlatform(agent.Platform)
+
+	// Fetch raw hardware profile.
+	rawHW, err := m.profileSource.GetHardwareProfile(ctx, agentID)
+	if err != nil {
+		m.logger.Error("failed to get hardware profile for bridge",
+			zap.String("agent_id", agentID),
+			zap.Error(err),
+		)
+		return
+	}
+
+	now := time.Now().UTC()
+
+	// Map raw hardware to models.DeviceHardware.
+	if rawHW != nil {
+		hw := &models.DeviceHardware{
+			DeviceID:           agent.DeviceID,
+			Hostname:           agent.Hostname,
+			CPUModel:           rawHW.CPUModel,
+			CPUCores:           int(rawHW.CPUCores),
+			CPUThreads:         int(rawHW.CPUThreads),
+			RAMTotalMB:         int(rawHW.RAMBytes / (1024 * 1024)),
+			BIOSVersion:        rawHW.BIOSVersion,
+			SystemManufacturer: rawHW.SystemManufacturer,
+			SystemModel:        rawHW.SystemModel,
+			SerialNumber:       rawHW.SerialNumber,
+			CollectionSource:   source,
+			CollectedAt:        &now,
+		}
+		if err := m.store.UpsertDeviceHardware(ctx, hw); err != nil {
+			m.logger.Error("failed to upsert device hardware from bridge",
+				zap.String("device_id", agent.DeviceID),
+				zap.Error(err),
+			)
+		}
+
+		// Map disks to models.DeviceStorage.
+		if len(rawHW.Disks) > 0 {
+			storage := make([]models.DeviceStorage, len(rawHW.Disks))
+			for i, d := range rawHW.Disks {
+				storage[i] = models.DeviceStorage{
+					ID:               uuid.New().String(),
+					DeviceID:         agent.DeviceID,
+					Name:             d.Name,
+					DiskType:         d.DiskType,
+					CapacityGB:       int(d.SizeBytes / (1024 * 1024 * 1024)),
+					Model:            d.Model,
+					CollectionSource: source,
+					CollectedAt:      &now,
+				}
+			}
+			if err := m.store.UpsertDeviceStorage(ctx, agent.DeviceID, storage); err != nil {
+				m.logger.Error("failed to upsert device storage from bridge",
+					zap.String("device_id", agent.DeviceID),
+					zap.Error(err),
+				)
+			}
+		}
+
+		// Map GPUs to models.DeviceGPU.
+		if len(rawHW.GPUs) > 0 {
+			gpus := make([]models.DeviceGPU, len(rawHW.GPUs))
+			for i, g := range rawHW.GPUs {
+				gpus[i] = models.DeviceGPU{
+					ID:               uuid.New().String(),
+					DeviceID:         agent.DeviceID,
+					Model:            g.Model,
+					Vendor:           detectGPUVendor(g.Model),
+					VRAMMB:           int(g.VRAMBytes / (1024 * 1024)),
+					DriverVersion:    g.DriverVersion,
+					CollectionSource: source,
+					CollectedAt:      &now,
+				}
+			}
+			if err := m.store.UpsertDeviceGPU(ctx, agent.DeviceID, gpus); err != nil {
+				m.logger.Error("failed to upsert device GPUs from bridge",
+					zap.String("device_id", agent.DeviceID),
+					zap.Error(err),
+				)
+			}
+		}
+	}
+
+	// Fetch and map services.
+	rawSvcs, err := m.profileSource.GetServices(ctx, agentID)
+	if err != nil {
+		m.logger.Error("failed to get services for bridge",
+			zap.String("agent_id", agentID),
+			zap.Error(err),
+		)
+	} else if len(rawSvcs) > 0 {
+		svcs := make([]models.DeviceService, len(rawSvcs))
+		for i, s := range rawSvcs {
+			// Use the first port if available.
+			port := 0
+			if len(s.Ports) > 0 {
+				port = int(s.Ports[0])
+			}
+
+			svcName := s.Name
+			if s.DisplayName != "" {
+				svcName = s.DisplayName
+			}
+
+			svcs[i] = models.DeviceService{
+				ID:               uuid.New().String(),
+				DeviceID:         agent.DeviceID,
+				Name:             svcName,
+				ServiceType:      serviceTypeFromStatus(s.StartType),
+				Port:             port,
+				Status:           s.Status,
+				CollectionSource: source,
+				CollectedAt:      &now,
+			}
+		}
+		if err := m.store.UpsertDeviceServices(ctx, agent.DeviceID, svcs); err != nil {
+			m.logger.Error("failed to upsert device services from bridge",
+				zap.String("device_id", agent.DeviceID),
+				zap.Error(err),
+			)
+		}
+	}
+
+	// Publish recon.device.hardware.updated event.
+	m.publishEvent(ctx, TopicDeviceHardwareUpdated, DeviceHardwareUpdatedEvent{
+		DeviceID:         agent.DeviceID,
+		CollectionSource: source,
+	})
+
+	m.logger.Info("hardware profile bridged",
+		zap.String("agent_id", agentID),
+		zap.String("device_id", agent.DeviceID),
+		zap.String("source", source),
+	)
+}
+
+// collectionSourceForPlatform returns the collection source identifier
+// based on the Scout agent's reported platform.
+func collectionSourceForPlatform(platform string) string {
+	p := strings.ToLower(platform)
+	switch {
+	case strings.Contains(p, "windows"):
+		return "scout-wmi"
+	case strings.Contains(p, "linux"):
+		return "scout-linux"
+	case strings.Contains(p, "darwin") || strings.Contains(p, "macos"):
+		return "scout-macos"
+	default:
+		return fmt.Sprintf("scout-%s", p)
+	}
+}
+
+// detectGPUVendor infers the GPU vendor from the model string.
+func detectGPUVendor(model string) string {
+	lower := strings.ToLower(model)
+	switch {
+	case strings.Contains(lower, "nvidia") ||
+		strings.Contains(lower, "geforce") ||
+		strings.Contains(lower, "rtx") ||
+		strings.Contains(lower, "gtx"):
+		return "nvidia"
+	case strings.Contains(lower, "amd") ||
+		strings.Contains(lower, "radeon"):
+		return "amd"
+	case strings.Contains(lower, "intel") ||
+		strings.Contains(lower, "arc") ||
+		strings.Contains(lower, "iris"):
+		return "intel"
+	default:
+		return "unknown"
+	}
+}
+
+// serviceTypeFromStatus maps the agent start_type to a service type label.
+func serviceTypeFromStatus(startType string) string {
+	switch strings.ToLower(startType) {
+	case "auto":
+		return "system"
+	case "manual":
+		return "manual"
+	case "disabled":
+		return "disabled"
+	default:
+		return "other"
+	}
+}

--- a/internal/recon/hardware_handlers.go
+++ b/internal/recon/hardware_handlers.go
@@ -1,0 +1,317 @@
+package recon
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/HerbHall/subnetree/pkg/models"
+	"go.uber.org/zap"
+)
+
+// DeviceHardwareResponse is the composite response for GET /devices/{id}/hardware.
+type DeviceHardwareResponse struct {
+	Hardware *models.DeviceHardware `json:"hardware"`
+	Storage  []models.DeviceStorage `json:"storage"`
+	GPUs     []models.DeviceGPU     `json:"gpus"`
+	Services []models.DeviceService `json:"services"`
+}
+
+// HardwareQueryResponse is the paginated response for GET /devices/query/hardware.
+type HardwareQueryResponse struct {
+	Devices []models.Device `json:"devices"`
+	Total   int             `json:"total"`
+	Limit   int             `json:"limit"`
+	Offset  int             `json:"offset"`
+}
+
+// handleGetDeviceHardware returns the full hardware profile for a device.
+//
+//	@Summary		Get device hardware profile
+//	@Description	Returns the full hardware profile including storage, GPUs, and services for a device.
+//	@Tags			recon
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			id	path		string	true	"Device ID"
+//	@Success		200	{object}	DeviceHardwareResponse
+//	@Failure		400	{object}	models.APIProblem
+//	@Failure		500	{object}	models.APIProblem
+//	@Router			/recon/devices/{id}/hardware [get]
+func (m *Module) handleGetDeviceHardware(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "device ID is required")
+		return
+	}
+
+	ctx := r.Context()
+
+	hw, err := m.store.GetDeviceHardware(ctx, id)
+	if err != nil {
+		m.logger.Error("failed to get device hardware", zap.String("device_id", id), zap.Error(err))
+		writeError(w, http.StatusInternalServerError, "failed to get device hardware")
+		return
+	}
+
+	storage, err := m.store.GetDeviceStorage(ctx, id)
+	if err != nil {
+		m.logger.Error("failed to get device storage", zap.String("device_id", id), zap.Error(err))
+		writeError(w, http.StatusInternalServerError, "failed to get device storage")
+		return
+	}
+
+	gpus, err := m.store.GetDeviceGPU(ctx, id)
+	if err != nil {
+		m.logger.Error("failed to get device GPUs", zap.String("device_id", id), zap.Error(err))
+		writeError(w, http.StatusInternalServerError, "failed to get device GPUs")
+		return
+	}
+
+	svcs, err := m.store.GetDeviceServices(ctx, id)
+	if err != nil {
+		m.logger.Error("failed to get device services", zap.String("device_id", id), zap.Error(err))
+		writeError(w, http.StatusInternalServerError, "failed to get device services")
+		return
+	}
+
+	if storage == nil {
+		storage = []models.DeviceStorage{}
+	}
+	if gpus == nil {
+		gpus = []models.DeviceGPU{}
+	}
+	if svcs == nil {
+		svcs = []models.DeviceService{}
+	}
+
+	writeJSON(w, http.StatusOK, DeviceHardwareResponse{
+		Hardware: hw,
+		Storage:  storage,
+		GPUs:     gpus,
+		Services: svcs,
+	})
+}
+
+// handleUpdateDeviceHardware manually updates the hardware profile for a device.
+//
+//	@Summary		Update device hardware profile
+//	@Description	Manually creates or updates a device's hardware profile. Sets collection_source to "manual".
+//	@Tags			recon
+//	@Accept			json
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			id		path		string					true	"Device ID"
+//	@Param			request	body		models.DeviceHardware	true	"Hardware profile"
+//	@Success		200		{object}	models.DeviceHardware
+//	@Failure		400		{object}	models.APIProblem
+//	@Failure		500		{object}	models.APIProblem
+//	@Router			/recon/devices/{id}/hardware [put]
+func (m *Module) handleUpdateDeviceHardware(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "device ID is required")
+		return
+	}
+
+	var hw models.DeviceHardware
+	if err := json.NewDecoder(r.Body).Decode(&hw); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+	hw.DeviceID = id
+	hw.CollectionSource = "manual"
+	now := time.Now().UTC()
+	hw.CollectedAt = &now
+
+	if err := m.store.UpsertDeviceHardware(r.Context(), &hw); err != nil {
+		m.logger.Error("failed to upsert device hardware", zap.String("device_id", id), zap.Error(err))
+		writeError(w, http.StatusInternalServerError, "failed to update device hardware")
+		return
+	}
+
+	// Re-read the stored record to return the full state.
+	stored, err := m.store.GetDeviceHardware(r.Context(), id)
+	if err != nil {
+		m.logger.Error("failed to read updated hardware", zap.String("device_id", id), zap.Error(err))
+		writeError(w, http.StatusInternalServerError, "failed to read updated hardware")
+		return
+	}
+	writeJSON(w, http.StatusOK, stored)
+}
+
+// handleGetDeviceStorage returns storage devices for a device.
+//
+//	@Summary		Get device storage
+//	@Description	Returns all storage devices attached to a device.
+//	@Tags			recon
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			id	path		string	true	"Device ID"
+//	@Success		200	{array}		models.DeviceStorage
+//	@Failure		400	{object}	models.APIProblem
+//	@Failure		500	{object}	models.APIProblem
+//	@Router			/recon/devices/{id}/storage [get]
+func (m *Module) handleGetDeviceStorage(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "device ID is required")
+		return
+	}
+
+	storage, err := m.store.GetDeviceStorage(r.Context(), id)
+	if err != nil {
+		m.logger.Error("failed to get device storage", zap.String("device_id", id), zap.Error(err))
+		writeError(w, http.StatusInternalServerError, "failed to get device storage")
+		return
+	}
+	if storage == nil {
+		storage = []models.DeviceStorage{}
+	}
+	writeJSON(w, http.StatusOK, storage)
+}
+
+// handleGetDeviceGPU returns GPUs for a device.
+//
+//	@Summary		Get device GPUs
+//	@Description	Returns all GPUs installed in a device.
+//	@Tags			recon
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			id	path		string	true	"Device ID"
+//	@Success		200	{array}		models.DeviceGPU
+//	@Failure		400	{object}	models.APIProblem
+//	@Failure		500	{object}	models.APIProblem
+//	@Router			/recon/devices/{id}/gpu [get]
+func (m *Module) handleGetDeviceGPU(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "device ID is required")
+		return
+	}
+
+	gpus, err := m.store.GetDeviceGPU(r.Context(), id)
+	if err != nil {
+		m.logger.Error("failed to get device GPUs", zap.String("device_id", id), zap.Error(err))
+		writeError(w, http.StatusInternalServerError, "failed to get device GPUs")
+		return
+	}
+	if gpus == nil {
+		gpus = []models.DeviceGPU{}
+	}
+	writeJSON(w, http.StatusOK, gpus)
+}
+
+// handleGetDeviceServices returns running services for a device.
+//
+//	@Summary		Get device services
+//	@Description	Returns all running services on a device.
+//	@Tags			recon
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			id	path		string	true	"Device ID"
+//	@Success		200	{array}		models.DeviceService
+//	@Failure		400	{object}	models.APIProblem
+//	@Failure		500	{object}	models.APIProblem
+//	@Router			/recon/devices/{id}/services [get]
+func (m *Module) handleGetDeviceServices(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "device ID is required")
+		return
+	}
+
+	svcs, err := m.store.GetDeviceServices(r.Context(), id)
+	if err != nil {
+		m.logger.Error("failed to get device services", zap.String("device_id", id), zap.Error(err))
+		writeError(w, http.StatusInternalServerError, "failed to get device services")
+		return
+	}
+	if svcs == nil {
+		svcs = []models.DeviceService{}
+	}
+	writeJSON(w, http.StatusOK, svcs)
+}
+
+// handleHardwareSummary returns fleet-wide aggregate hardware statistics.
+//
+//	@Summary		Hardware inventory summary
+//	@Description	Returns aggregate hardware statistics across all devices with hardware profiles.
+//	@Tags			recon
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Success		200	{object}	models.HardwareSummary
+//	@Failure		500	{object}	models.APIProblem
+//	@Router			/recon/inventory/hardware-summary [get]
+func (m *Module) handleHardwareSummary(w http.ResponseWriter, r *http.Request) {
+	summary, err := m.store.GetHardwareSummary(r.Context())
+	if err != nil {
+		m.logger.Error("failed to get hardware summary", zap.Error(err))
+		writeError(w, http.StatusInternalServerError, "failed to get hardware summary")
+		return
+	}
+	writeJSON(w, http.StatusOK, summary)
+}
+
+// handleQueryDevicesByHardware filters devices by hardware specifications.
+//
+//	@Summary		Query devices by hardware
+//	@Description	Returns devices matching hardware filters like RAM, CPU model, OS, platform type, and GPU.
+//	@Tags			recon
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			min_ram_mb		query		int		false	"Minimum RAM in MB"
+//	@Param			max_ram_mb		query		int		false	"Maximum RAM in MB"
+//	@Param			cpu_model		query		string	false	"CPU model substring match"
+//	@Param			os_name			query		string	false	"OS name substring match"
+//	@Param			platform_type	query		string	false	"Platform type (baremetal, vm, container, lxc)"
+//	@Param			gpu_vendor		query		string	false	"GPU vendor filter (nvidia, amd, intel)"
+//	@Param			has_gpu			query		bool	false	"Filter devices with/without GPU"
+//	@Param			limit			query		int		false	"Max results"	default(50)
+//	@Param			offset			query		int		false	"Offset"		default(0)
+//	@Success		200				{object}	HardwareQueryResponse
+//	@Failure		500				{object}	models.APIProblem
+//	@Router			/recon/devices/query/hardware [get]
+func (m *Module) handleQueryDevicesByHardware(w http.ResponseWriter, r *http.Request) {
+	q := models.HardwareQuery{
+		MinRAMMB:     queryInt(r, "min_ram_mb", 0),
+		MaxRAMMB:     queryInt(r, "max_ram_mb", 0),
+		CPUModel:     r.URL.Query().Get("cpu_model"),
+		OSName:       r.URL.Query().Get("os_name"),
+		PlatformType: r.URL.Query().Get("platform_type"),
+		GPUVendor:    r.URL.Query().Get("gpu_vendor"),
+		Limit:        queryInt(r, "limit", 50),
+		Offset:       queryInt(r, "offset", 0),
+	}
+
+	// Parse has_gpu bool parameter.
+	if hasGPUStr := r.URL.Query().Get("has_gpu"); hasGPUStr != "" {
+		val, err := strconv.ParseBool(hasGPUStr)
+		if err == nil {
+			q.HasGPU = &val
+		}
+	}
+
+	// Normalize gpu_vendor to lowercase.
+	if q.GPUVendor != "" {
+		q.GPUVendor = strings.ToLower(q.GPUVendor)
+	}
+
+	devices, total, err := m.store.QueryDevicesByHardware(r.Context(), q)
+	if err != nil {
+		m.logger.Error("failed to query devices by hardware", zap.Error(err))
+		writeError(w, http.StatusInternalServerError, "failed to query devices by hardware")
+		return
+	}
+	if devices == nil {
+		devices = []models.Device{}
+	}
+	writeJSON(w, http.StatusOK, HardwareQueryResponse{
+		Devices: devices,
+		Total:   total,
+		Limit:   q.Limit,
+		Offset:  q.Offset,
+	})
+}


### PR DESCRIPTION
## Summary

Phase 2 of #437 (Hardware Asset Profiles). Adds REST API endpoints and the dispatch-to-recon event bridge for hardware inventory data.

- **7 REST endpoints**: GET/PUT device hardware, storage, GPU, services; fleet hardware summary; hardware-based device query
- **Event bridge**: Subscribes to `dispatch.device.profiled` events, maps Scout agent proto data to normalized recon tables via `ProfileSource` consumer-side interface
- **Composition root adapter**: `profileSourceAdapter` in main.go bridges dispatch store to recon module (follows existing `tokenAdapter`, `serviceSourceAdapter` patterns)
- **Swagger regenerated**: All new endpoints documented with proper annotations

### New Files
- `internal/recon/hardware_handlers.go` -- 7 REST handlers with swagger annotations
- `internal/recon/hardware_bridge.go` -- ProfileSource interface, event handler, proto-to-model mapping

### Modified Files
- `internal/recon/recon.go` -- EventSubscriber interface, 7 new routes, SetProfileSource
- `internal/recon/events.go` -- TopicDeviceHardwareUpdated event
- `cmd/subnetree/main.go` -- profileSourceAdapter + wiring
- `api/swagger/*` -- Regenerated

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/recon/...` passes (25 Phase 1 store tests)
- [x] `GOOS=linux GOARCH=amd64 go build ./...` cross-compile passes
- [x] Swagger regenerated without drift
- [ ] CI checks (build, lint, test, E2E, frontend, swagger drift)

Depends on: PR #441 (merged)
Next: Phase 3 (frontend hardware tab + seed data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)