### PR TITLE
feat: hardware profile UI and seed data (#437)

### DIFF
--- a/web/src/api/hardware.ts
+++ b/web/src/api/hardware.ts
@@ -1,0 +1,116 @@
+import { api } from './client'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface DeviceHardware {
+  device_id: string
+  hostname?: string
+  fqdn?: string
+  os_name?: string
+  os_version?: string
+  os_arch?: string
+  kernel?: string
+  cpu_model?: string
+  cpu_cores?: number
+  cpu_threads?: number
+  cpu_arch?: string
+  ram_total_mb?: number
+  ram_type?: string
+  ram_slots_used?: number
+  ram_slots_total?: number
+  platform_type?: string
+  hypervisor?: string
+  vm_host_id?: string
+  system_manufacturer?: string
+  system_model?: string
+  serial_number?: string
+  bios_version?: string
+  collection_source?: string
+  collected_at?: string
+  updated_at?: string
+}
+
+export interface DeviceStorage {
+  id: string
+  device_id: string
+  name?: string
+  disk_type?: string
+  interface?: string
+  capacity_gb?: number
+  model?: string
+  role?: string
+  collection_source?: string
+  collected_at?: string
+}
+
+export interface DeviceGPU {
+  id: string
+  device_id: string
+  model?: string
+  vendor?: string
+  vram_mb?: number
+  driver_version?: string
+  collection_source?: string
+  collected_at?: string
+}
+
+export interface DeviceService {
+  id: string
+  device_id: string
+  name?: string
+  service_type?: string
+  port?: number
+  url?: string
+  version?: string
+  status?: string
+  collection_source?: string
+  collected_at?: string
+}
+
+export interface DeviceHardwareResponse {
+  hardware: DeviceHardware | null
+  storage: DeviceStorage[]
+  gpus: DeviceGPU[]
+  services: DeviceService[]
+}
+
+export interface HardwareSummary {
+  total_with_hardware: number
+  total_ram_mb: number
+  total_storage_gb: number
+  total_gpus: number
+  by_os: Record<string, number>
+  by_cpu_model: Record<string, number>
+  by_platform_type: Record<string, number>
+  by_gpu_vendor: Record<string, number>
+}
+
+// ---------------------------------------------------------------------------
+// API functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch the full hardware profile for a device (hardware, storage, GPUs, services).
+ */
+export async function getDeviceHardware(id: string): Promise<DeviceHardwareResponse> {
+  return api.get<DeviceHardwareResponse>(`/recon/devices/${id}/hardware`)
+}
+
+/**
+ * Update (or create) a device's hardware profile manually.
+ */
+export async function updateDeviceHardware(
+  id: string,
+  data: Partial<DeviceHardware>,
+): Promise<DeviceHardware> {
+  return api.put<DeviceHardware>(`/recon/devices/${id}/hardware`, data)
+}
+
+/**
+ * Fetch fleet-wide aggregate hardware statistics.
+ */
+export async function getHardwareSummary(): Promise<HardwareSummary> {
+  return api.get<HardwareSummary>('/recon/inventory/hardware-summary')
+}


### PR DESCRIPTION
## Summary

- Add Hardware Profile section to device detail page showing system info, CPU, memory, storage, GPU, and detected services
- Collection source badges (e.g., "scout-linux", "manual") show data provenance on each field
- Frontend API client (`web/src/api/hardware.ts`) with TypeScript interfaces matching backend models
- Seed 5 demo devices with realistic hardware profiles (proxmox-host, docker-host, gaming-pc, synology-nas, macbook-pro)

This is Phase 3 (final) of #437. Phase 1 (schema+store, PR #441) and Phase 2 (API+event bridge, PR #442) are already merged.

Closes #437

## Test plan

- [ ] `go build ./...` passes
- [ ] `npx tsc --noEmit` passes
- [ ] `npx eslint` clean on modified files
- [ ] Seed data creates hardware profiles for demo devices
- [ ] Device detail page shows Hardware Profile section when data exists
- [ ] Section is hidden when no hardware data exists
- [ ] Collection source badge displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)