### PR TITLE
feat: Inno Setup installer for Scout agent on Windows

### DIFF
--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -1,0 +1,81 @@
+name: Build Windows Installer
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  build-installer:
+    name: Build Scout Installer
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Get release version
+        id: tag
+        shell: bash
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Download Scout Windows binary from release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p installer/inno/bin
+
+          # GoReleaser produces a bare binary named scout_windows_amd64.exe
+          # via the scout-binary archive config
+          gh release download "$GITHUB_REF_NAME" \
+            --pattern 'scout_windows_amd64.exe' \
+            --dir installer/inno/bin/ || true
+
+          # If bare binary wasn't found, try downloading the zip archive
+          # and extracting scout.exe from it
+          if [ ! -f installer/inno/bin/scout_windows_amd64.exe ]; then
+            echo "Bare binary not found, trying zip archive..."
+            gh release download "$GITHUB_REF_NAME" \
+              --pattern "scout_${{ steps.tag.outputs.version }}_windows_amd64.zip" \
+              --dir /tmp/
+            unzip -o "/tmp/scout_${{ steps.tag.outputs.version }}_windows_amd64.zip" \
+              -d installer/inno/bin/
+          fi
+
+          # Normalize to scout.exe (the name the .iss script expects)
+          if [ -f installer/inno/bin/scout_windows_amd64.exe ]; then
+            mv installer/inno/bin/scout_windows_amd64.exe installer/inno/bin/scout.exe
+          fi
+
+          # Verify the binary exists
+          if [ ! -f installer/inno/bin/scout.exe ]; then
+            echo "ERROR: scout.exe not found after download"
+            ls -la installer/inno/bin/
+            exit 1
+          fi
+
+          echo "Scout binary ready:"
+          ls -la installer/inno/bin/scout.exe
+
+      - name: Install Inno Setup
+        shell: powershell
+        run: |
+          choco install innosetup -y --no-progress
+          echo "C:\Program Files (x86)\Inno Setup 6" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+
+      - name: Build installer
+        shell: cmd
+        env:
+          SCOUT_VERSION: ${{ steps.tag.outputs.version }}
+        run: iscc installer\inno\subnetree-scout.iss
+
+      - name: Upload installer to release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "$GITHUB_REF_NAME" \
+            installer/inno/output/SubNetreeScout-*.exe \
+            --clobber

--- a/installer/inno/README.md
+++ b/installer/inno/README.md
@@ -1,0 +1,50 @@
+# SubNetree Scout Windows Installer
+
+Builds a Windows installer for the Scout agent using [Inno Setup 6](https://jrsoftware.org/isinfo.php).
+
+## Prerequisites
+
+- [Inno Setup 6](https://jrsoftware.org/isdl.php) installed on Windows
+- Scout binary built for Windows AMD64
+
+## Local Build
+
+1. Build Scout:
+
+   ```bash
+   go build -o installer/inno/bin/scout.exe ./cmd/scout/
+   ```
+
+2. Set version and compile:
+
+   ```cmd
+   set SCOUT_VERSION=1.0.0
+   iscc installer\inno\subnetree-scout.iss
+   ```
+
+3. Output: `installer/inno/output/SubNetreeScout-1.0.0-setup.exe`
+
+## CI Build
+
+The installer is built automatically by the `build-installer.yml` workflow
+when a release is published. It downloads the Scout Windows binary from the
+release assets and packages it into the installer.
+
+## What the Installer Does
+
+- Installs `scout.exe` to `C:\Program Files\SubNetree\Scout\`
+- Creates Start Menu shortcuts
+- Optionally adds the install directory to the system PATH
+- Shows the BSL 1.1 license during installation
+- Registers in Windows Add/Remove Programs for clean uninstall
+- Removes the PATH entry on uninstall
+
+## Installer Details
+
+| Property | Value |
+|----------|-------|
+| Minimum OS | Windows 10 |
+| Architecture | x64 only |
+| Privileges | Admin required |
+| Compression | LZMA (solid) |
+| Output filename | `SubNetreeScout-{version}-setup.exe` |

--- a/installer/inno/subnetree-scout.iss
+++ b/installer/inno/subnetree-scout.iss
@@ -1,0 +1,108 @@
+; SubNetree Scout Agent Installer
+; Inno Setup 6+ script
+;
+; Build: iscc installer\inno\subnetree-scout.iss
+; Requires SCOUT_VERSION env var (defaults to 0.0.0-dev)
+
+#define MyAppName "SubNetree Scout Agent"
+#define MyAppVersion GetEnv('SCOUT_VERSION')
+#if MyAppVersion == ""
+  #define MyAppVersion "0.0.0-dev"
+#endif
+#define MyAppPublisher "SubNetree"
+#define MyAppURL "https://github.com/HerbHall/subnetree"
+#define MyAppExeName "scout.exe"
+
+[Setup]
+AppId={{5E8F9C2A-7B3D-4A1E-B6F0-8D2C3E4A5B6C}
+AppName={#MyAppName}
+AppVersion={#MyAppVersion}
+AppVerName={#MyAppName} {#MyAppVersion}
+AppPublisher={#MyAppPublisher}
+AppPublisherURL={#MyAppURL}
+AppSupportURL={#MyAppURL}/issues
+DefaultDirName={autopf}\SubNetree\Scout
+DefaultGroupName=SubNetree
+LicenseFile=..\..\LICENSE
+OutputDir=output
+OutputBaseFilename=SubNetreeScout-{#MyAppVersion}-setup
+Compression=lzma
+SolidCompression=yes
+WizardStyle=modern
+MinVersion=10.0
+PrivilegesRequired=admin
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+UninstallDisplayIcon={app}\{#MyAppExeName}
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "addtopath"; Description: "Add Scout to system PATH"; GroupDescription: "Additional options:"
+
+[Files]
+Source: "bin\scout.exe"; DestDir: "{app}"; Flags: ignoreversion
+
+[Icons]
+Name: "{group}\SubNetree Scout"; Filename: "{app}\{#MyAppExeName}"
+Name: "{group}\Uninstall SubNetree Scout"; Filename: "{uninstallexe}"
+
+[Registry]
+Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; \
+    ValueType: expandsz; ValueName: "Path"; ValueData: "{olddata};{app}"; \
+    Tasks: addtopath; Check: NeedsAddPath(ExpandConstant('{app}'))
+
+[UninstallDelete]
+Type: dirifempty; Name: "{app}"
+Type: dirifempty; Name: "{autopf}\SubNetree"
+
+[Code]
+function NeedsAddPath(Param: string): Boolean;
+var
+  OrigPath: string;
+begin
+  if not RegQueryStringValue(HKLM,
+    'SYSTEM\CurrentControlSet\Control\Session Manager\Environment',
+    'Path', OrigPath)
+  then begin
+    Result := True;
+    exit;
+  end;
+  { Check if the path is already present (case-insensitive) }
+  Result := Pos(';' + Uppercase(Param) + ';', ';' + Uppercase(OrigPath) + ';') = 0;
+end;
+
+procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+var
+  OrigPath: string;
+  AppDir: string;
+  P: Integer;
+begin
+  if CurUninstallStep = usPostUninstall then
+  begin
+    AppDir := ExpandConstant('{app}');
+    if RegQueryStringValue(HKLM,
+      'SYSTEM\CurrentControlSet\Control\Session Manager\Environment',
+      'Path', OrigPath)
+    then begin
+      { Remove ;{app} from PATH }
+      P := Pos(';' + Uppercase(AppDir), Uppercase(OrigPath));
+      if P <> 0 then
+      begin
+        Delete(OrigPath, P, Length(';' + AppDir));
+        RegWriteStringValue(HKLM,
+          'SYSTEM\CurrentControlSet\Control\Session Manager\Environment',
+          'Path', OrigPath);
+      end;
+      { Also check if it starts with {app}; }
+      if Pos(Uppercase(AppDir) + ';', Uppercase(OrigPath)) = 1 then
+      begin
+        Delete(OrigPath, 1, Length(AppDir) + 1);
+        RegWriteStringValue(HKLM,
+          'SYSTEM\CurrentControlSet\Control\Session Manager\Environment',
+          'Path', OrigPath);
+      end;
+    end;
+  end;
+end;


### PR DESCRIPTION
## Summary
- Inno Setup 6 script for Windows Scout installer (`installer/inno/`)
- CI workflow triggered on `release:published` to build and upload `.exe` to release assets
- Installs to Program Files, manages PATH, clean uninstall support
- Windows 10+ x64 required

Closes #431

## Test plan
- [ ] Verify Inno Setup script compiles locally with `iscc`
- [ ] Verify CI workflow triggers on release and uploads artifact
- [ ] Verify installer creates correct directory structure and PATH entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)