### PR TITLE
feat: enhance Scout installer with service registration

### DIFF
--- a/installer/inno/subnetree-scout.iss
+++ b/installer/inno/subnetree-scout.iss
@@ -40,18 +40,39 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Tasks]
 Name: "addtopath"; Description: "Add Scout to system PATH"; GroupDescription: "Additional options:"
+Name: "registerservice"; Description: "Register as Windows service (recommended)"; GroupDescription: "Service options:"; Flags: checkedonce
 
 [Files]
 Source: "bin\scout.exe"; DestDir: "{app}"; Flags: ignoreversion
 
 [Icons]
-Name: "{group}\SubNetree Scout"; Filename: "{app}\{#MyAppExeName}"
+Name: "{group}\SubNetree Scout"; Filename: "{app}\{#MyAppExeName}"; Parameters: "run"
+Name: "{group}\Scout Service Status"; Filename: "sc.exe"; Parameters: "query SubNetreeScout"; \
+    Comment: "Check Scout service status"
+Name: "{group}\Open SubNetree Dashboard"; Filename: "http://localhost:8080"; \
+    Comment: "Open SubNetree web dashboard"
+Name: "{group}\Scout Configuration"; Filename: "{app}"; \
+    Comment: "Open Scout installation directory"
 Name: "{group}\Uninstall SubNetree Scout"; Filename: "{uninstallexe}"
 
 [Registry]
 Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; \
     ValueType: expandsz; ValueName: "Path"; ValueData: "{olddata};{app}"; \
     Tasks: addtopath; Check: NeedsAddPath(ExpandConstant('{app}'))
+
+[Run]
+; Register and start the Windows service after installation
+Filename: "{app}\{#MyAppExeName}"; Parameters: "install --server localhost:9090"; \
+    StatusMsg: "Registering Windows service..."; \
+    Flags: runhidden waituntilterminated; Tasks: registerservice
+Filename: "sc.exe"; Parameters: "start SubNetreeScout"; \
+    StatusMsg: "Starting Scout service..."; \
+    Flags: runhidden waituntilterminated; Tasks: registerservice
+
+[UninstallRun]
+; Stop and unregister the Windows service before uninstall
+Filename: "{app}\{#MyAppExeName}"; Parameters: "uninstall"; \
+    Flags: runhidden waituntilterminated; RunOnceId: "UninstallScoutService"
 
 [UninstallDelete]
 Type: dirifempty; Name: "{app}"
@@ -73,14 +94,36 @@ begin
   Result := Pos(';' + Uppercase(Param) + ';', ';' + Uppercase(OrigPath) + ';') = 0;
 end;
 
+function IsServiceInstalled(): Boolean;
+var
+  ResultCode: Integer;
+begin
+  Result := Exec('sc.exe', 'query SubNetreeScout', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) and (ResultCode = 0);
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+begin
+  if CurStep = ssPostInstall then
+  begin
+    { Log service registration status }
+    Log('Post-install: service registration task selected = ' + BoolToStr(IsTaskSelected('registerservice')));
+  end;
+end;
+
 procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
 var
   OrigPath: string;
   AppDir: string;
   P: Integer;
+  ResultCode: Integer;
 begin
   if CurUninstallStep = usPostUninstall then
   begin
+    { Stop service before uninstall if running }
+    Exec('sc.exe', 'stop SubNetreeScout', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+    { Small delay to let service stop }
+    Sleep(2000);
+
     AppDir := ExpandConstant('{app}');
     if RegQueryStringValue(HKLM,
       'SYSTEM\CurrentControlSet\Control\Session Manager\Environment',


### PR DESCRIPTION
## Summary

- Add service registration task in Inno Setup installer (checked by default)
- Post-install: runs `scout install` and `sc start SubNetreeScout` to register and start the service
- Pre-uninstall: stops and deregisters the service automatically
- Enhanced Start Menu entries: Scout runner, service status check, dashboard URL, config directory
- Added `IsServiceInstalled()` Pascal Script check and post-install logging

Closes #429

## Test plan

- [ ] Build installer with `iscc installer\inno\subnetree-scout.iss`
- [ ] Install: service registration checkbox defaults to checked
- [ ] After install: `sc query SubNetreeScout` shows Running
- [ ] Start Menu has 5 entries (Scout, Status, Dashboard, Config, Uninstall)
- [ ] Uninstall: service is stopped and deregistered before file removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)