### PR TITLE
feat: WiFi hotspot client enumeration for AP-mode servers

### DIFF
--- a/api/swagger/docs.go
+++ b/api/swagger/docs.go
@@ -4504,6 +4504,48 @@ const docTemplate = `{
                 }
             }
         },
+        "/recon/wifi/clients": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns devices connected to the server's WiFi AP/hotspot with signal data",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "recon"
+                ],
+                "summary": "List WiFi hotspot clients",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Filter by AP device ID",
+                        "name": "ap_device_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/internal_recon.WiFiClientSnapshot"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    }
+                }
+            }
+        },
         "/settings/interfaces": {
             "get": {
                 "description": "Get a list of all network interfaces available on the server.",
@@ -7961,6 +8003,47 @@ const docTemplate = `{
                     "items": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "internal_recon.WiFiClientSnapshot": {
+            "type": "object",
+            "properties": {
+                "ap_bssid": {
+                    "type": "string"
+                },
+                "ap_ssid": {
+                    "type": "string"
+                },
+                "collected_at": {
+                    "type": "string"
+                },
+                "connected_sec": {
+                    "type": "integer"
+                },
+                "device_id": {
+                    "type": "string"
+                },
+                "inactive_sec": {
+                    "type": "integer"
+                },
+                "rx_bitrate_bps": {
+                    "type": "integer"
+                },
+                "rx_bytes": {
+                    "type": "integer"
+                },
+                "signal_avg_dbm": {
+                    "type": "integer"
+                },
+                "signal_dbm": {
+                    "type": "integer"
+                },
+                "tx_bitrate_bps": {
+                    "type": "integer"
+                },
+                "tx_bytes": {
+                    "type": "integer"
                 }
             }
         },

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -4497,6 +4497,48 @@
                 }
             }
         },
+        "/recon/wifi/clients": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns devices connected to the server's WiFi AP/hotspot with signal data",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "recon"
+                ],
+                "summary": "List WiFi hotspot clients",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Filter by AP device ID",
+                        "name": "ap_device_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/internal_recon.WiFiClientSnapshot"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem"
+                        }
+                    }
+                }
+            }
+        },
         "/settings/interfaces": {
             "get": {
                 "description": "Get a list of all network interfaces available on the server.",
@@ -7954,6 +7996,47 @@
                     "items": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "internal_recon.WiFiClientSnapshot": {
+            "type": "object",
+            "properties": {
+                "ap_bssid": {
+                    "type": "string"
+                },
+                "ap_ssid": {
+                    "type": "string"
+                },
+                "collected_at": {
+                    "type": "string"
+                },
+                "connected_sec": {
+                    "type": "integer"
+                },
+                "device_id": {
+                    "type": "string"
+                },
+                "inactive_sec": {
+                    "type": "integer"
+                },
+                "rx_bitrate_bps": {
+                    "type": "integer"
+                },
+                "rx_bytes": {
+                    "type": "integer"
+                },
+                "signal_avg_dbm": {
+                    "type": "integer"
+                },
+                "signal_dbm": {
+                    "type": "integer"
+                },
+                "tx_bitrate_bps": {
+                    "type": "integer"
+                },
+                "tx_bytes": {
+                    "type": "integer"
                 }
             }
         },

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -1798,6 +1798,33 @@ definitions:
           type: string
         type: array
     type: object
+  internal_recon.WiFiClientSnapshot:
+    properties:
+      ap_bssid:
+        type: string
+      ap_ssid:
+        type: string
+      collected_at:
+        type: string
+      connected_sec:
+        type: integer
+      device_id:
+        type: string
+      inactive_sec:
+        type: integer
+      rx_bitrate_bps:
+        type: integer
+      rx_bytes:
+        type: integer
+      signal_avg_dbm:
+        type: integer
+      signal_dbm:
+        type: integer
+      tx_bitrate_bps:
+        type: integer
+      tx_bytes:
+        type: integer
+    type: object
   internal_server.HealthResponse:
     properties:
       service:
@@ -4855,6 +4882,33 @@ paths:
       security:
       - BearerAuth: []
       summary: Run traceroute
+      tags:
+      - recon
+  /recon/wifi/clients:
+    get:
+      description: Returns devices connected to the server's WiFi AP/hotspot with
+        signal data
+      parameters:
+      - description: Filter by AP device ID
+        in: query
+        name: ap_device_id
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/internal_recon.WiFiClientSnapshot'
+            type: array
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/github_com_HerbHall_subnetree_pkg_models.APIProblem'
+      security:
+      - BearerAuth: []
+      summary: List WiFi hotspot clients
       tags:
       - recon
   /settings/interfaces:

--- a/internal/recon/migrations.go
+++ b/internal/recon/migrations.go
@@ -351,5 +351,26 @@ func migrations() []plugin.Migration {
 				return err
 			},
 		},
+		{
+			Version:     13,
+			Description: "create recon_wifi_clients table for WiFi AP client snapshots",
+			Up: func(tx *sql.Tx) error {
+				_, err := tx.Exec(`CREATE TABLE IF NOT EXISTS recon_wifi_clients (
+					device_id      TEXT PRIMARY KEY REFERENCES recon_devices(id) ON DELETE CASCADE,
+					signal_dbm     INTEGER NOT NULL DEFAULT 0,
+					signal_avg_dbm INTEGER NOT NULL DEFAULT 0,
+					connected_sec  INTEGER NOT NULL DEFAULT 0,
+					inactive_sec   INTEGER NOT NULL DEFAULT 0,
+					rx_bitrate_bps INTEGER NOT NULL DEFAULT 0,
+					tx_bitrate_bps INTEGER NOT NULL DEFAULT 0,
+					rx_bytes       INTEGER NOT NULL DEFAULT 0,
+					tx_bytes       INTEGER NOT NULL DEFAULT 0,
+					ap_bssid       TEXT NOT NULL DEFAULT '',
+					ap_ssid        TEXT NOT NULL DEFAULT '',
+					collected_at   DATETIME NOT NULL
+				)`)
+				return err
+			},
+		},
 	}
 }

--- a/internal/recon/wifi_ap_enumerator.go
+++ b/internal/recon/wifi_ap_enumerator.go
@@ -1,0 +1,29 @@
+package recon
+
+import (
+	"context"
+	"time"
+)
+
+// APClientEnumerator enumerates clients associated with the server's own
+// WiFi access point or hotspot interface.
+type APClientEnumerator interface {
+	Available() bool
+	Enumerate(ctx context.Context) ([]APClientInfo, error)
+}
+
+// APClientInfo represents a client station associated with the server's AP.
+type APClientInfo struct {
+	MACAddress    string        // Client MAC address
+	Signal        int           // dBm (negative, e.g., -65)
+	SignalAverage int           // dBm average
+	Connected     time.Duration // Time since association
+	Inactive      time.Duration // Time since last activity
+	RxBitrate     int           // bits/sec
+	TxBitrate     int           // bits/sec
+	RxBytes       int
+	TxBytes       int
+	InterfaceName string // AP interface name (e.g., "wlan0")
+	APBSSID       string // MAC address of the AP interface
+	APSSID        string // SSID of the AP network
+}

--- a/internal/recon/wifi_ap_enumerator_linux.go
+++ b/internal/recon/wifi_ap_enumerator_linux.go
@@ -1,0 +1,272 @@
+//go:build linux
+
+package recon
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/mdlayher/wifi"
+	"go.uber.org/zap"
+)
+
+type linuxAPClientEnumerator struct {
+	logger *zap.Logger
+}
+
+// NewAPClientEnumerator returns a Linux APClientEnumerator backed by nl80211.
+func NewAPClientEnumerator(logger *zap.Logger) APClientEnumerator {
+	return &linuxAPClientEnumerator{logger: logger}
+}
+
+// Available returns true if at least one WiFi interface is in AP mode.
+func (e *linuxAPClientEnumerator) Available() bool {
+	c, err := wifi.New()
+	if err != nil {
+		e.logger.Debug("wifi client unavailable for AP enumeration", zap.Error(err))
+		return false
+	}
+	defer c.Close()
+
+	ifaces, err := c.Interfaces()
+	if err != nil {
+		e.logger.Debug("failed to enumerate wifi interfaces for AP check", zap.Error(err))
+		return false
+	}
+
+	for _, ifi := range ifaces {
+		if ifi.Type == wifi.InterfaceTypeAP {
+			return true
+		}
+	}
+
+	// Fallback: check for hostapd control sockets.
+	entries, err := os.ReadDir("/var/run/hostapd")
+	if err == nil && len(entries) > 0 {
+		return true
+	}
+
+	return false
+}
+
+// Enumerate returns all client stations associated with AP-mode interfaces.
+// Falls back to hostapd control socket parsing if nl80211 fails.
+func (e *linuxAPClientEnumerator) Enumerate(ctx context.Context) ([]APClientInfo, error) {
+	clients, err := e.enumerateNL80211(ctx)
+	if err != nil {
+		e.logger.Debug("nl80211 AP enumeration failed, trying hostapd fallback", zap.Error(err))
+		return e.enumerateHostapd(ctx)
+	}
+	return clients, nil
+}
+
+// enumerateNL80211 uses the mdlayher/wifi library to enumerate AP clients.
+func (e *linuxAPClientEnumerator) enumerateNL80211(_ context.Context) ([]APClientInfo, error) {
+	c, err := wifi.New()
+	if err != nil {
+		return nil, fmt.Errorf("open wifi client: %w", err)
+	}
+	defer c.Close()
+
+	ifaces, err := c.Interfaces()
+	if err != nil {
+		return nil, fmt.Errorf("enumerate wifi interfaces: %w", err)
+	}
+
+	var clients []APClientInfo
+	for _, ifi := range ifaces {
+		if ifi.Type != wifi.InterfaceTypeAP {
+			continue
+		}
+
+		stations, sErr := c.StationInfo(ifi)
+		if sErr != nil {
+			e.logger.Warn("failed to get station info for AP interface",
+				zap.String("interface", ifi.Name),
+				zap.Error(sErr))
+			continue
+		}
+
+		apBSSID := ""
+		if ifi.HardwareAddr != nil {
+			apBSSID = ifi.HardwareAddr.String()
+		}
+
+		for _, sta := range stations {
+			client := APClientInfo{
+				Signal:        int(sta.Signal / 100), // mBm to dBm
+				SignalAverage: int(sta.SignalAverage),
+				Connected:     sta.Connected,
+				Inactive:      sta.Inactive,
+				RxBitrate:     sta.ReceiveBitrate,
+				TxBitrate:     sta.TransmitBitrate,
+				RxBytes:       int(sta.ReceivedBytes),
+				TxBytes:       int(sta.TransmittedBytes),
+				InterfaceName: ifi.Name,
+				APBSSID:       apBSSID,
+			}
+			if sta.HardwareAddr != nil {
+				client.MACAddress = sta.HardwareAddr.String()
+			}
+			clients = append(clients, client)
+		}
+	}
+
+	return clients, nil
+}
+
+// enumerateHostapd parses the hostapd control socket to enumerate clients.
+// This is a fallback for systems where nl80211 station info requires root.
+func (e *linuxAPClientEnumerator) enumerateHostapd(_ context.Context) ([]APClientInfo, error) {
+	entries, err := os.ReadDir("/var/run/hostapd")
+	if err != nil {
+		return nil, fmt.Errorf("read hostapd directory: %w", err)
+	}
+
+	var clients []APClientInfo
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		ifaceName := entry.Name()
+		socketPath := "/var/run/hostapd/" + ifaceName
+
+		ifaceClients, parseErr := e.parseHostapdSocket(socketPath, ifaceName)
+		if parseErr != nil {
+			e.logger.Debug("failed to parse hostapd socket",
+				zap.String("socket", socketPath),
+				zap.Error(parseErr))
+			continue
+		}
+		clients = append(clients, ifaceClients...)
+	}
+
+	return clients, nil
+}
+
+// parseHostapdSocket connects to a hostapd control socket and enumerates stations.
+func (e *linuxAPClientEnumerator) parseHostapdSocket(socketPath, ifaceName string) ([]APClientInfo, error) {
+	// Create a temporary local socket for receiving replies.
+	localPath := fmt.Sprintf("/tmp/subnetree_hostapd_%s_%d", ifaceName, time.Now().UnixNano())
+	defer os.Remove(localPath)
+
+	localAddr := &net.UnixAddr{Name: localPath, Net: "unixgram"}
+	remoteAddr := &net.UnixAddr{Name: socketPath, Net: "unixgram"}
+
+	conn, err := net.DialUnix("unixgram", localAddr, remoteAddr)
+	if err != nil {
+		return nil, fmt.Errorf("connect to hostapd: %w", err)
+	}
+	defer conn.Close()
+
+	// Set read timeout.
+	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		return nil, fmt.Errorf("set deadline: %w", err)
+	}
+
+	// Send STA-FIRST to get the first station.
+	if _, err := conn.Write([]byte("STA-FIRST")); err != nil {
+		return nil, fmt.Errorf("send STA-FIRST: %w", err)
+	}
+
+	var clients []APClientInfo
+	buf := make([]byte, 4096)
+
+	for {
+		n, readErr := conn.Read(buf)
+		if readErr != nil {
+			break
+		}
+
+		response := string(buf[:n])
+		if response == "" || response == "FAIL" {
+			break
+		}
+
+		client := e.parseStationResponse(response, ifaceName)
+		if client.MACAddress != "" {
+			clients = append(clients, client)
+		}
+
+		// Request next station.
+		if _, err := conn.Write([]byte("STA-NEXT " + client.MACAddress)); err != nil {
+			break
+		}
+	}
+
+	return clients, nil
+}
+
+// parseStationResponse parses a hostapd STA response into an APClientInfo.
+func (e *linuxAPClientEnumerator) parseStationResponse(response, ifaceName string) APClientInfo {
+	client := APClientInfo{
+		InterfaceName: ifaceName,
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(response))
+	lineNum := 0
+	for scanner.Scan() {
+		line := scanner.Text()
+		lineNum++
+
+		// First line is the MAC address.
+		if lineNum == 1 {
+			mac := strings.TrimSpace(line)
+			if _, parseErr := net.ParseMAC(mac); parseErr == nil {
+				client.MACAddress = mac
+			}
+			continue
+		}
+
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		val := strings.TrimSpace(parts[1])
+
+		switch key {
+		case "signal":
+			if v, err := strconv.Atoi(val); err == nil {
+				client.Signal = v
+			}
+		case "signal_avg":
+			if v, err := strconv.Atoi(val); err == nil {
+				client.SignalAverage = v
+			}
+		case "connected_time":
+			if v, err := strconv.ParseInt(val, 10, 64); err == nil {
+				client.Connected = time.Duration(v) * time.Second
+			}
+		case "inactive_msec":
+			if v, err := strconv.ParseInt(val, 10, 64); err == nil {
+				client.Inactive = time.Duration(v) * time.Millisecond
+			}
+		case "rx_bytes":
+			if v, err := strconv.Atoi(val); err == nil {
+				client.RxBytes = v
+			}
+		case "tx_bytes":
+			if v, err := strconv.Atoi(val); err == nil {
+				client.TxBytes = v
+			}
+		case "rx_rate_info":
+			if v, err := strconv.Atoi(val); err == nil {
+				client.RxBitrate = v * 100 // hostapd reports in 100kbps
+			}
+		case "tx_rate_info":
+			if v, err := strconv.Atoi(val); err == nil {
+				client.TxBitrate = v * 100
+			}
+		}
+	}
+
+	return client
+}

--- a/internal/recon/wifi_ap_enumerator_stub.go
+++ b/internal/recon/wifi_ap_enumerator_stub.go
@@ -1,0 +1,22 @@
+//go:build !linux && !windows
+
+package recon
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+)
+
+type stubAPClientEnumerator struct{}
+
+// NewAPClientEnumerator returns a stub APClientEnumerator for unsupported platforms.
+func NewAPClientEnumerator(_ *zap.Logger) APClientEnumerator {
+	return &stubAPClientEnumerator{}
+}
+
+func (s *stubAPClientEnumerator) Available() bool { return false }
+
+func (s *stubAPClientEnumerator) Enumerate(_ context.Context) ([]APClientInfo, error) {
+	return nil, nil
+}

--- a/internal/recon/wifi_ap_enumerator_test.go
+++ b/internal/recon/wifi_ap_enumerator_test.go
@@ -1,0 +1,78 @@
+package recon
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// Compile-time interface guard for the mock enumerator.
+var _ APClientEnumerator = (*mockAPClientEnumerator)(nil)
+
+type mockAPClientEnumerator struct {
+	available bool
+	clients   []APClientInfo
+	err       error
+}
+
+func (m *mockAPClientEnumerator) Available() bool { return m.available }
+
+func (m *mockAPClientEnumerator) Enumerate(_ context.Context) ([]APClientInfo, error) {
+	return m.clients, m.err
+}
+
+func TestAPClientInfo_Construction(t *testing.T) {
+	info := APClientInfo{
+		MACAddress:    "aa:bb:cc:dd:ee:ff",
+		Signal:        -65,
+		SignalAverage: -67,
+		Connected:     2 * time.Hour,
+		Inactive:      500 * time.Millisecond,
+		RxBitrate:     300_000_000,
+		TxBitrate:     200_000_000,
+		RxBytes:       1024 * 1024,
+		TxBytes:       512 * 1024,
+		InterfaceName: "wlan0",
+		APBSSID:       "00:11:22:33:44:55",
+		APSSID:        "TestNetwork",
+	}
+
+	if info.MACAddress != "aa:bb:cc:dd:ee:ff" {
+		t.Errorf("MACAddress = %q, want %q", info.MACAddress, "aa:bb:cc:dd:ee:ff")
+	}
+	if info.Signal != -65 {
+		t.Errorf("Signal = %d, want -65", info.Signal)
+	}
+	if info.Connected != 2*time.Hour {
+		t.Errorf("Connected = %v, want 2h", info.Connected)
+	}
+	if info.APBSSID != "00:11:22:33:44:55" {
+		t.Errorf("APBSSID = %q, want %q", info.APBSSID, "00:11:22:33:44:55")
+	}
+	if info.APSSID != "TestNetwork" {
+		t.Errorf("APSSID = %q, want %q", info.APSSID, "TestNetwork")
+	}
+}
+
+func TestMockAPClientEnumerator_Available(t *testing.T) {
+	e := &mockAPClientEnumerator{available: false}
+	if e.Available() {
+		t.Error("expected Available() = false")
+	}
+
+	e.available = true
+	if !e.Available() {
+		t.Error("expected Available() = true")
+	}
+}
+
+func TestMockAPClientEnumerator_Enumerate_Empty(t *testing.T) {
+	e := &mockAPClientEnumerator{available: true}
+	clients, err := e.Enumerate(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if clients != nil {
+		t.Errorf("expected nil clients, got %d", len(clients))
+	}
+}

--- a/internal/recon/wifi_ap_enumerator_windows.go
+++ b/internal/recon/wifi_ap_enumerator_windows.go
@@ -1,0 +1,124 @@
+//go:build windows
+
+package recon
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"go.uber.org/zap"
+)
+
+type windowsAPClientEnumerator struct {
+	logger *zap.Logger
+}
+
+// NewAPClientEnumerator returns a Windows APClientEnumerator that uses netsh
+// and ARP table parsing for Mobile Hotspot / Hosted Network enumeration.
+func NewAPClientEnumerator(logger *zap.Logger) APClientEnumerator {
+	return &windowsAPClientEnumerator{logger: logger}
+}
+
+// Available returns true if a Windows hosted network or mobile hotspot is active.
+func (e *windowsAPClientEnumerator) Available() bool {
+	out, err := exec.Command("netsh", "wlan", "show", "hostednetwork").Output()
+	if err != nil {
+		e.logger.Debug("netsh hostednetwork check failed", zap.Error(err))
+		return false
+	}
+	return strings.Contains(string(out), "Status") &&
+		strings.Contains(string(out), "Started")
+}
+
+// Enumerate returns clients connected to the Windows hotspot by cross-referencing
+// the hosted network config with the ARP table for the hotspot subnet.
+func (e *windowsAPClientEnumerator) Enumerate(ctx context.Context) ([]APClientInfo, error) {
+	// Parse hosted network info for BSSID and SSID.
+	apBSSID, apSSID, parseErr := e.parseHostedNetwork(ctx)
+	if parseErr != nil {
+		return nil, fmt.Errorf("parse hosted network: %w", parseErr)
+	}
+
+	// Windows ICS (Internet Connection Sharing) typically assigns the
+	// hotspot interface 192.168.137.1 with subnet 192.168.137.0/24.
+	hotspotPrefix := "192.168.137."
+
+	// Read ARP table and filter to hotspot subnet.
+	arpOut, err := exec.CommandContext(ctx, "arp", "-a").Output()
+	if err != nil {
+		return nil, fmt.Errorf("read ARP table: %w", err)
+	}
+
+	var clients []APClientInfo
+	scanner := bufio.NewScanner(strings.NewReader(string(arpOut)))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+
+		ip := fields[0]
+		mac := fields[1]
+
+		// Only include entries from the hotspot subnet.
+		if !strings.HasPrefix(ip, hotspotPrefix) {
+			continue
+		}
+
+		// Skip the gateway itself and broadcast entries.
+		if ip == "192.168.137.1" || ip == "192.168.137.255" {
+			continue
+		}
+
+		// Normalise MAC format from Windows (xx-xx-xx-xx-xx-xx) to standard.
+		mac = strings.ReplaceAll(mac, "-", ":")
+		if mac == "ff:ff:ff:ff:ff:ff" {
+			continue
+		}
+
+		clients = append(clients, APClientInfo{
+			MACAddress: mac,
+			APBSSID:    apBSSID,
+			APSSID:     apSSID,
+		})
+	}
+
+	return clients, nil
+}
+
+// parseHostedNetwork extracts the BSSID and SSID from netsh output.
+func (e *windowsAPClientEnumerator) parseHostedNetwork(ctx context.Context) (bssid, ssid string, err error) {
+	out, cmdErr := exec.CommandContext(ctx, "netsh", "wlan", "show", "hostednetwork").Output()
+	if cmdErr != nil {
+		return "", "", fmt.Errorf("netsh: %w", cmdErr)
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(string(out)))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		if strings.HasPrefix(line, "BSSID") {
+			parts := strings.SplitN(line, ":", 2)
+			if len(parts) == 2 {
+				bssid = strings.TrimSpace(parts[1])
+				bssid = strings.ReplaceAll(bssid, "-", ":")
+			}
+		}
+		if strings.HasPrefix(line, "SSID name") || strings.HasPrefix(line, "SSID") {
+			parts := strings.SplitN(line, ":", 2)
+			if len(parts) == 2 {
+				ssid = strings.Trim(strings.TrimSpace(parts[1]), "\"")
+			}
+		}
+	}
+
+	return bssid, ssid, nil
+}

--- a/internal/recon/wifi_ap_handlers.go
+++ b/internal/recon/wifi_ap_handlers.go
@@ -1,0 +1,35 @@
+package recon
+
+import (
+	"net/http"
+
+	// models is imported for swagger annotation resolution (models.APIProblem).
+	_ "github.com/HerbHall/subnetree/pkg/models"
+	"go.uber.org/zap"
+)
+
+// handleListWiFiClients returns WiFi clients connected to the server's AP/hotspot.
+//
+//	@Summary		List WiFi hotspot clients
+//	@Description	Returns devices connected to the server's WiFi AP/hotspot with signal data
+//	@Tags			recon
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			ap_device_id	query		string	false	"Filter by AP device ID"
+//	@Success		200				{array}		WiFiClientSnapshot
+//	@Failure		500				{object}	models.APIProblem
+//	@Router			/recon/wifi/clients [get]
+func (m *Module) handleListWiFiClients(w http.ResponseWriter, r *http.Request) {
+	apDeviceID := r.URL.Query().Get("ap_device_id")
+
+	clients, err := m.store.ListWiFiClients(r.Context(), apDeviceID)
+	if err != nil {
+		m.logger.Error("failed to list wifi clients", zap.Error(err))
+		writeError(w, http.StatusInternalServerError, "failed to list wifi clients")
+		return
+	}
+	if clients == nil {
+		clients = []WiFiClientSnapshot{}
+	}
+	writeJSON(w, http.StatusOK, clients)
+}

--- a/internal/recon/wifi_ap_store.go
+++ b/internal/recon/wifi_ap_store.go
@@ -1,0 +1,111 @@
+package recon
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// WiFiClientSnapshot represents a WiFi client's signal and traffic data.
+type WiFiClientSnapshot struct {
+	DeviceID     string    `json:"device_id"`
+	SignalDBm    int       `json:"signal_dbm"`
+	SignalAvgDBm int       `json:"signal_avg_dbm"`
+	ConnectedSec int64     `json:"connected_sec"`
+	InactiveSec  int64     `json:"inactive_sec"`
+	RxBitrate    int       `json:"rx_bitrate_bps"`
+	TxBitrate    int       `json:"tx_bitrate_bps"`
+	RxBytes      int       `json:"rx_bytes"`
+	TxBytes      int       `json:"tx_bytes"`
+	APBSSID      string    `json:"ap_bssid"`
+	APSSID       string    `json:"ap_ssid"`
+	CollectedAt  time.Time `json:"collected_at"`
+}
+
+// UpsertWiFiClient inserts or replaces a WiFi client snapshot.
+func (s *ReconStore) UpsertWiFiClient(ctx context.Context, snap *WiFiClientSnapshot) error {
+	_, err := s.db.ExecContext(ctx, `INSERT OR REPLACE INTO recon_wifi_clients (
+		device_id, signal_dbm, signal_avg_dbm,
+		connected_sec, inactive_sec,
+		rx_bitrate_bps, tx_bitrate_bps,
+		rx_bytes, tx_bytes,
+		ap_bssid, ap_ssid, collected_at
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		snap.DeviceID, snap.SignalDBm, snap.SignalAvgDBm,
+		snap.ConnectedSec, snap.InactiveSec,
+		snap.RxBitrate, snap.TxBitrate,
+		snap.RxBytes, snap.TxBytes,
+		snap.APBSSID, snap.APSSID, snap.CollectedAt)
+	if err != nil {
+		return fmt.Errorf("upsert wifi client: %w", err)
+	}
+	return nil
+}
+
+// GetWiFiClient returns the WiFi client snapshot for a specific device.
+// Returns nil, nil if not found.
+func (s *ReconStore) GetWiFiClient(ctx context.Context, deviceID string) (*WiFiClientSnapshot, error) {
+	var snap WiFiClientSnapshot
+	err := s.db.QueryRowContext(ctx, `SELECT
+		device_id, signal_dbm, signal_avg_dbm,
+		connected_sec, inactive_sec,
+		rx_bitrate_bps, tx_bitrate_bps,
+		rx_bytes, tx_bytes,
+		ap_bssid, ap_ssid, collected_at
+		FROM recon_wifi_clients WHERE device_id = ?`, deviceID).Scan(
+		&snap.DeviceID, &snap.SignalDBm, &snap.SignalAvgDBm,
+		&snap.ConnectedSec, &snap.InactiveSec,
+		&snap.RxBitrate, &snap.TxBitrate,
+		&snap.RxBytes, &snap.TxBytes,
+		&snap.APBSSID, &snap.APSSID, &snap.CollectedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get wifi client: %w", err)
+	}
+	return &snap, nil
+}
+
+// ListWiFiClients returns WiFi client snapshots. If apDeviceID is non-empty,
+// only clients whose parent device matches the AP are returned.
+func (s *ReconStore) ListWiFiClients(ctx context.Context, apDeviceID string) ([]WiFiClientSnapshot, error) {
+	query := `SELECT
+		wc.device_id, wc.signal_dbm, wc.signal_avg_dbm,
+		wc.connected_sec, wc.inactive_sec,
+		wc.rx_bitrate_bps, wc.tx_bitrate_bps,
+		wc.rx_bytes, wc.tx_bytes,
+		wc.ap_bssid, wc.ap_ssid, wc.collected_at
+		FROM recon_wifi_clients wc`
+
+	var args []any
+	if apDeviceID != "" {
+		query += ` JOIN recon_devices d ON d.id = wc.device_id
+			WHERE d.parent_device_id = ?`
+		args = append(args, apDeviceID)
+	}
+	query += " ORDER BY wc.device_id"
+
+	rows, err := s.db.QueryContext(ctx, query, args...) //nolint:gosec // query uses parameterized placeholders only
+	if err != nil {
+		return nil, fmt.Errorf("list wifi clients: %w", err)
+	}
+	defer rows.Close()
+
+	var result []WiFiClientSnapshot
+	for rows.Next() {
+		var snap WiFiClientSnapshot
+		if err := rows.Scan(
+			&snap.DeviceID, &snap.SignalDBm, &snap.SignalAvgDBm,
+			&snap.ConnectedSec, &snap.InactiveSec,
+			&snap.RxBitrate, &snap.TxBitrate,
+			&snap.RxBytes, &snap.TxBytes,
+			&snap.APBSSID, &snap.APSSID, &snap.CollectedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan wifi client row: %w", err)
+		}
+		result = append(result, snap)
+	}
+	return result, rows.Err()
+}

--- a/internal/recon/wifi_ap_store_test.go
+++ b/internal/recon/wifi_ap_store_test.go
@@ -1,0 +1,259 @@
+package recon
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/HerbHall/subnetree/pkg/models"
+)
+
+func TestUpsertWiFiClient_RoundTrip(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	// Create a parent AP device and a client device (FK requirement).
+	ap := &models.Device{
+		ID:              "ap-1",
+		Hostname:        "test-ap",
+		MACAddress:      "00:11:22:33:44:55",
+		DeviceType:      models.DeviceTypeAccessPoint,
+		Status:          models.DeviceStatusOnline,
+		DiscoveryMethod: models.DiscoveryWiFi,
+		FirstSeen:       time.Now(),
+		LastSeen:        time.Now(),
+	}
+	if _, err := s.UpsertDevice(ctx, ap); err != nil {
+		t.Fatalf("upsert AP: %v", err)
+	}
+
+	client := &models.Device{
+		ID:              "client-1",
+		Hostname:        "my-phone",
+		MACAddress:      "aa:bb:cc:dd:ee:ff",
+		DeviceType:      models.DeviceTypePhone,
+		Status:          models.DeviceStatusOnline,
+		DiscoveryMethod: models.DiscoveryWiFi,
+		ParentDeviceID:  "ap-1",
+		FirstSeen:       time.Now(),
+		LastSeen:        time.Now(),
+	}
+	if _, err := s.UpsertDevice(ctx, client); err != nil {
+		t.Fatalf("upsert client: %v", err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	snap := &WiFiClientSnapshot{
+		DeviceID:     "client-1",
+		SignalDBm:    -65,
+		SignalAvgDBm: -67,
+		ConnectedSec: 7200,
+		InactiveSec:  5,
+		RxBitrate:    300_000_000,
+		TxBitrate:    200_000_000,
+		RxBytes:      1_048_576,
+		TxBytes:      524_288,
+		APBSSID:      "00:11:22:33:44:55",
+		APSSID:       "TestNetwork",
+		CollectedAt:  now,
+	}
+
+	// Upsert.
+	if err := s.UpsertWiFiClient(ctx, snap); err != nil {
+		t.Fatalf("UpsertWiFiClient: %v", err)
+	}
+
+	// Get it back.
+	got, err := s.GetWiFiClient(ctx, "client-1")
+	if err != nil {
+		t.Fatalf("GetWiFiClient: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil snapshot")
+	}
+	if got.SignalDBm != -65 {
+		t.Errorf("SignalDBm = %d, want -65", got.SignalDBm)
+	}
+	if got.SignalAvgDBm != -67 {
+		t.Errorf("SignalAvgDBm = %d, want -67", got.SignalAvgDBm)
+	}
+	if got.ConnectedSec != 7200 {
+		t.Errorf("ConnectedSec = %d, want 7200", got.ConnectedSec)
+	}
+	if got.RxBitrate != 300_000_000 {
+		t.Errorf("RxBitrate = %d, want 300000000", got.RxBitrate)
+	}
+	if got.TxBitrate != 200_000_000 {
+		t.Errorf("TxBitrate = %d, want 200000000", got.TxBitrate)
+	}
+	if got.RxBytes != 1_048_576 {
+		t.Errorf("RxBytes = %d, want 1048576", got.RxBytes)
+	}
+	if got.APBSSID != "00:11:22:33:44:55" {
+		t.Errorf("APBSSID = %q, want %q", got.APBSSID, "00:11:22:33:44:55")
+	}
+	if got.APSSID != "TestNetwork" {
+		t.Errorf("APSSID = %q, want %q", got.APSSID, "TestNetwork")
+	}
+}
+
+func TestUpsertWiFiClient_ReplaceOnConflict(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	dev := &models.Device{
+		ID:              "client-1",
+		Hostname:        "test-device",
+		DeviceType:      models.DeviceTypePhone,
+		Status:          models.DeviceStatusOnline,
+		DiscoveryMethod: models.DiscoveryWiFi,
+		FirstSeen:       time.Now(),
+		LastSeen:        time.Now(),
+	}
+	if _, err := s.UpsertDevice(ctx, dev); err != nil {
+		t.Fatalf("upsert device: %v", err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	snap := &WiFiClientSnapshot{
+		DeviceID:    "client-1",
+		SignalDBm:   -55,
+		CollectedAt: now,
+	}
+	if err := s.UpsertWiFiClient(ctx, snap); err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+
+	// Upsert again with different signal.
+	snap.SignalDBm = -72
+	if err := s.UpsertWiFiClient(ctx, snap); err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+
+	got, err := s.GetWiFiClient(ctx, "client-1")
+	if err != nil {
+		t.Fatalf("get after update: %v", err)
+	}
+	if got.SignalDBm != -72 {
+		t.Errorf("SignalDBm after update = %d, want -72", got.SignalDBm)
+	}
+}
+
+func TestListWiFiClients_All(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	// Create two devices with wifi client snapshots.
+	for _, d := range []struct {
+		id, mac string
+	}{
+		{"c-1", "aa:bb:cc:11:11:11"},
+		{"c-2", "aa:bb:cc:22:22:22"},
+	} {
+		dev := &models.Device{
+			ID:              d.id,
+			MACAddress:      d.mac,
+			DeviceType:      models.DeviceTypePhone,
+			Status:          models.DeviceStatusOnline,
+			DiscoveryMethod: models.DiscoveryWiFi,
+			FirstSeen:       now,
+			LastSeen:        now,
+		}
+		if _, err := s.UpsertDevice(ctx, dev); err != nil {
+			t.Fatalf("upsert %s: %v", d.id, err)
+		}
+		snap := &WiFiClientSnapshot{
+			DeviceID:    d.id,
+			SignalDBm:   -60,
+			CollectedAt: now,
+		}
+		if err := s.UpsertWiFiClient(ctx, snap); err != nil {
+			t.Fatalf("upsert snap %s: %v", d.id, err)
+		}
+	}
+
+	// List all.
+	all, err := s.ListWiFiClients(ctx, "")
+	if err != nil {
+		t.Fatalf("ListWiFiClients (all): %v", err)
+	}
+	if len(all) != 2 {
+		t.Errorf("all count = %d, want 2", len(all))
+	}
+}
+
+func TestListWiFiClients_FilterByAP(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	// Create AP device.
+	ap := &models.Device{
+		ID:              "ap-1",
+		Hostname:        "test-ap",
+		DeviceType:      models.DeviceTypeAccessPoint,
+		Status:          models.DeviceStatusOnline,
+		DiscoveryMethod: models.DiscoveryWiFi,
+		FirstSeen:       now,
+		LastSeen:        now,
+	}
+	if _, err := s.UpsertDevice(ctx, ap); err != nil {
+		t.Fatalf("upsert AP: %v", err)
+	}
+
+	// Create two clients: one under the AP, one not.
+	for _, d := range []struct {
+		id, mac, parent string
+	}{
+		{"c-1", "aa:bb:cc:11:11:11", "ap-1"},
+		{"c-2", "aa:bb:cc:22:22:22", ""},
+	} {
+		dev := &models.Device{
+			ID:              d.id,
+			MACAddress:      d.mac,
+			DeviceType:      models.DeviceTypePhone,
+			Status:          models.DeviceStatusOnline,
+			DiscoveryMethod: models.DiscoveryWiFi,
+			ParentDeviceID:  d.parent,
+			FirstSeen:       now,
+			LastSeen:        now,
+		}
+		if _, err := s.UpsertDevice(ctx, dev); err != nil {
+			t.Fatalf("upsert %s: %v", d.id, err)
+		}
+		snap := &WiFiClientSnapshot{
+			DeviceID:    d.id,
+			SignalDBm:   -60,
+			CollectedAt: now,
+		}
+		if err := s.UpsertWiFiClient(ctx, snap); err != nil {
+			t.Fatalf("upsert snap %s: %v", d.id, err)
+		}
+	}
+
+	// Filter by AP.
+	filtered, err := s.ListWiFiClients(ctx, "ap-1")
+	if err != nil {
+		t.Fatalf("ListWiFiClients (filtered): %v", err)
+	}
+	if len(filtered) != 1 {
+		t.Errorf("filtered count = %d, want 1", len(filtered))
+	}
+	if len(filtered) == 1 && filtered[0].DeviceID != "c-1" {
+		t.Errorf("filtered device = %q, want %q", filtered[0].DeviceID, "c-1")
+	}
+}
+
+func TestGetWiFiClient_NotFound(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	got, err := s.GetWiFiClient(ctx, "nonexistent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Error("expected nil for nonexistent device")
+	}
+}

--- a/internal/recon/wifi_ap_sync.go
+++ b/internal/recon/wifi_ap_sync.go
@@ -1,0 +1,230 @@
+package recon
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/HerbHall/subnetree/pkg/models"
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+)
+
+// WiFiAPSyncer synchronises WiFi AP clients as child devices in the recon store
+// and collects their signal/traffic snapshots.
+type WiFiAPSyncer struct {
+	store  *ReconStore
+	oui    OUIResolver
+	logger *zap.Logger
+}
+
+// NewWiFiAPSyncer creates a new WiFiAPSyncer.
+func NewWiFiAPSyncer(store *ReconStore, oui OUIResolver, logger *zap.Logger) *WiFiAPSyncer {
+	return &WiFiAPSyncer{store: store, oui: oui, logger: logger}
+}
+
+// WiFiAPSyncResult summarises the outcome of a WiFi AP sync operation.
+type WiFiAPSyncResult struct {
+	APsChecked   int `json:"aps_checked"`
+	ClientsFound int `json:"clients_found"`
+	Created      int `json:"created"`
+	Updated      int `json:"updated"`
+}
+
+// Sync enumerates AP clients and upserts them as child devices under the
+// corresponding AP device.
+func (s *WiFiAPSyncer) Sync(ctx context.Context, enumerator APClientEnumerator) (result *WiFiAPSyncResult, err error) {
+	result = &WiFiAPSyncResult{}
+
+	if !enumerator.Available() {
+		return result, nil
+	}
+
+	clients, enumErr := enumerator.Enumerate(ctx)
+	if enumErr != nil {
+		return nil, fmt.Errorf("enumerate AP clients: %w", enumErr)
+	}
+	result.ClientsFound = len(clients)
+
+	now := time.Now().UTC()
+
+	// Group clients by AP BSSID so we can track seen devices per AP.
+	type apGroup struct {
+		apDeviceID string
+		apSSID     string
+		clients    []APClientInfo
+	}
+	groups := make(map[string]*apGroup)
+
+	for i := range clients {
+		bssid := clients[i].APBSSID
+		if bssid == "" {
+			continue
+		}
+
+		g, ok := groups[bssid]
+		if !ok {
+			g = &apGroup{apSSID: clients[i].APSSID}
+			groups[bssid] = g
+		}
+		g.clients = append(g.clients, clients[i])
+	}
+
+	result.APsChecked = len(groups)
+
+	for bssid, g := range groups {
+		// Find or create the AP device.
+		apDevice, apErr := s.store.GetDeviceByMAC(ctx, bssid)
+		if apErr != nil && !errors.Is(apErr, sql.ErrNoRows) {
+			s.logger.Error("failed to look up AP device by MAC",
+				zap.String("bssid", bssid), zap.Error(apErr))
+			continue
+		}
+		if apDevice == nil {
+			// Create a new AP device.
+			apDevice = &models.Device{
+				ID:              uuid.New().String(),
+				Hostname:        g.apSSID,
+				MACAddress:      bssid,
+				DeviceType:      models.DeviceTypeAccessPoint,
+				Status:          models.DeviceStatusOnline,
+				DiscoveryMethod: models.DiscoveryWiFi,
+				ConnectionType:  models.ConnectionWiFi,
+				NetworkLayer:    models.NetworkLayerAccess,
+				FirstSeen:       now,
+				LastSeen:        now,
+			}
+			if s.oui != nil {
+				apDevice.Manufacturer = s.oui.Lookup(bssid)
+			}
+			if _, uErr := s.store.UpsertDevice(ctx, apDevice); uErr != nil {
+				s.logger.Error("failed to create AP device",
+					zap.String("bssid", bssid), zap.Error(uErr))
+				continue
+			}
+		}
+		g.apDeviceID = apDevice.ID
+
+		seenDeviceIDs := make(map[string]bool)
+
+		for j := range g.clients {
+			client := &g.clients[j]
+			if client.MACAddress == "" {
+				continue
+			}
+
+			deviceID, created, syncErr := s.upsertClientDevice(ctx, client, apDevice.ID, now)
+			if syncErr != nil {
+				s.logger.Error("upsert wifi client device",
+					zap.String("mac", client.MACAddress), zap.Error(syncErr))
+				continue
+			}
+			seenDeviceIDs[deviceID] = true
+
+			if created {
+				result.Created++
+			} else {
+				result.Updated++
+			}
+
+			// Upsert signal snapshot.
+			snap := &WiFiClientSnapshot{
+				DeviceID:     deviceID,
+				SignalDBm:    client.Signal,
+				SignalAvgDBm: client.SignalAverage,
+				ConnectedSec: int64(client.Connected.Seconds()),
+				InactiveSec:  int64(client.Inactive.Seconds()),
+				RxBitrate:    client.RxBitrate,
+				TxBitrate:    client.TxBitrate,
+				RxBytes:      client.RxBytes,
+				TxBytes:      client.TxBytes,
+				APBSSID:      client.APBSSID,
+				APSSID:       client.APSSID,
+				CollectedAt:  now,
+			}
+			if snapErr := s.store.UpsertWiFiClient(ctx, snap); snapErr != nil {
+				s.logger.Error("upsert wifi client snapshot",
+					zap.String("device_id", deviceID), zap.Error(snapErr))
+			}
+		}
+
+		// Mark unseen wifi children under this AP as offline.
+		if markErr := s.markUnseen(ctx, apDevice.ID, seenDeviceIDs); markErr != nil {
+			s.logger.Warn("failed to mark unseen wifi devices offline", zap.Error(markErr))
+		}
+	}
+
+	return result, nil
+}
+
+// upsertClientDevice creates or updates a child device record for a WiFi client.
+// Returns the device ID, whether it was newly created, and any error.
+func (s *WiFiAPSyncer) upsertClientDevice(
+	ctx context.Context, client *APClientInfo, apDeviceID string, now time.Time,
+) (deviceID string, created bool, err error) {
+	existing, lErr := s.store.GetDeviceByMAC(ctx, client.MACAddress)
+	if lErr != nil && !errors.Is(lErr, sql.ErrNoRows) {
+		return "", false, fmt.Errorf("find existing device: %w", lErr)
+	}
+
+	if existing != nil {
+		// Update status and last_seen.
+		if uErr := s.store.UpdateDeviceStatus(ctx, existing.ID, models.DeviceStatusOnline, now); uErr != nil {
+			return "", false, fmt.Errorf("update device status: %w", uErr)
+		}
+		// Ensure connection type is wifi.
+		if existing.ConnectionType != models.ConnectionWiFi {
+			if cErr := s.store.UpdateDeviceConnectionType(ctx, existing.ID, models.ConnectionWiFi); cErr != nil {
+				s.logger.Warn("failed to update connection type to wifi",
+					zap.String("device_id", existing.ID), zap.Error(cErr))
+			}
+		}
+		return existing.ID, false, nil
+	}
+
+	// Create new device.
+	manufacturer := ""
+	if s.oui != nil {
+		manufacturer = s.oui.Lookup(client.MACAddress)
+	}
+
+	dev := &models.Device{
+		ID:                       uuid.New().String(),
+		MACAddress:               client.MACAddress,
+		Manufacturer:             manufacturer,
+		DeviceType:               models.DeviceTypeUnknown,
+		Status:                   models.DeviceStatusOnline,
+		DiscoveryMethod:          models.DiscoveryWiFi,
+		ConnectionType:           models.ConnectionWiFi,
+		ParentDeviceID:           apDeviceID,
+		NetworkLayer:             models.NetworkLayerEndpoint,
+		ClassificationConfidence: 100,
+		ClassificationSource:     "wifi_ap",
+		FirstSeen:                now,
+		LastSeen:                 now,
+	}
+	if _, uErr := s.store.UpsertDevice(ctx, dev); uErr != nil {
+		return "", false, fmt.Errorf("create device: %w", uErr)
+	}
+	return dev.ID, true, nil
+}
+
+// markUnseen sets offline status for WiFi-discovered devices under the AP
+// that were not observed during this sync cycle.
+func (s *WiFiAPSyncer) markUnseen(ctx context.Context, apDeviceID string, seen map[string]bool) error {
+	devices, err := s.store.FindChildDevicesByDiscovery(ctx, apDeviceID, string(models.DiscoveryWiFi))
+	if err != nil {
+		return fmt.Errorf("find wifi children: %w", err)
+	}
+	for i := range devices {
+		if !seen[devices[i].ID] && devices[i].Status == models.DeviceStatusOnline {
+			if markErr := s.store.MarkDeviceOffline(ctx, devices[i].ID); markErr != nil {
+				s.logger.Warn("failed to mark unseen wifi device offline",
+					zap.String("device_id", devices[i].ID), zap.Error(markErr))
+			}
+		}
+	}
+	return nil
+}

--- a/internal/recon/wifi_ap_sync_test.go
+++ b/internal/recon/wifi_ap_sync_test.go
@@ -1,0 +1,334 @@
+package recon
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/HerbHall/subnetree/pkg/models"
+	"go.uber.org/zap"
+)
+
+func TestWiFiAPSyncer_Sync_Unavailable(t *testing.T) {
+	s := testStore(t)
+	syncer := NewWiFiAPSyncer(s, nil, zap.NewNop())
+
+	enumerator := &mockAPClientEnumerator{available: false}
+	result, err := syncer.Sync(context.Background(), enumerator)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ClientsFound != 0 {
+		t.Errorf("ClientsFound = %d, want 0", result.ClientsFound)
+	}
+	if result.Created != 0 {
+		t.Errorf("Created = %d, want 0", result.Created)
+	}
+}
+
+func TestWiFiAPSyncer_Sync_CreatesChildDevices(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	// Create the AP device so the syncer can find it.
+	apDevice := &models.Device{
+		ID:              "ap-1",
+		Hostname:        "test-ap",
+		MACAddress:      "00:11:22:33:44:55",
+		DeviceType:      models.DeviceTypeAccessPoint,
+		Status:          models.DeviceStatusOnline,
+		DiscoveryMethod: models.DiscoveryWiFi,
+		FirstSeen:       time.Now().UTC(),
+		LastSeen:        time.Now().UTC(),
+	}
+	if _, err := s.UpsertDevice(ctx, apDevice); err != nil {
+		t.Fatalf("upsert AP: %v", err)
+	}
+
+	enumerator := &mockAPClientEnumerator{
+		available: true,
+		clients: []APClientInfo{
+			{
+				MACAddress: "aa:bb:cc:11:22:33",
+				Signal:     -55,
+				Connected:  2 * time.Hour,
+				RxBitrate:  300_000_000,
+				TxBitrate:  200_000_000,
+				APBSSID:    "00:11:22:33:44:55",
+				APSSID:     "TestNet",
+			},
+			{
+				MACAddress: "aa:bb:cc:44:55:66",
+				Signal:     -72,
+				Connected:  30 * time.Minute,
+				RxBitrate:  144_000_000,
+				TxBitrate:  130_000_000,
+				APBSSID:    "00:11:22:33:44:55",
+				APSSID:     "TestNet",
+			},
+		},
+	}
+
+	syncer := NewWiFiAPSyncer(s, nil, zap.NewNop())
+	result, err := syncer.Sync(ctx, enumerator)
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	if result.ClientsFound != 2 {
+		t.Errorf("ClientsFound = %d, want 2", result.ClientsFound)
+	}
+	if result.Created != 2 {
+		t.Errorf("Created = %d, want 2", result.Created)
+	}
+	if result.APsChecked != 1 {
+		t.Errorf("APsChecked = %d, want 1", result.APsChecked)
+	}
+
+	// Verify first client device was created correctly.
+	client1, err := s.GetDeviceByMAC(ctx, "aa:bb:cc:11:22:33")
+	if err != nil {
+		t.Fatalf("get client1: %v", err)
+	}
+	if client1 == nil {
+		t.Fatal("expected client1 to exist")
+	}
+	if client1.ParentDeviceID != "ap-1" {
+		t.Errorf("client1 ParentDeviceID = %q, want %q", client1.ParentDeviceID, "ap-1")
+	}
+	if client1.DiscoveryMethod != models.DiscoveryWiFi {
+		t.Errorf("client1 DiscoveryMethod = %q, want wifi", client1.DiscoveryMethod)
+	}
+	if client1.ConnectionType != models.ConnectionWiFi {
+		t.Errorf("client1 ConnectionType = %q, want wifi", client1.ConnectionType)
+	}
+	if client1.Status != models.DeviceStatusOnline {
+		t.Errorf("client1 Status = %q, want online", client1.Status)
+	}
+
+	// Verify WiFi client snapshot was stored.
+	snap, err := s.GetWiFiClient(ctx, client1.ID)
+	if err != nil {
+		t.Fatalf("get wifi client snap: %v", err)
+	}
+	if snap == nil {
+		t.Fatal("expected wifi client snapshot")
+	}
+	if snap.SignalDBm != -55 {
+		t.Errorf("SignalDBm = %d, want -55", snap.SignalDBm)
+	}
+	if snap.RxBitrate != 300_000_000 {
+		t.Errorf("RxBitrate = %d, want 300000000", snap.RxBitrate)
+	}
+}
+
+func TestWiFiAPSyncer_Sync_UpdatesExisting(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	// Create AP device.
+	apDevice := &models.Device{
+		ID:              "ap-1",
+		Hostname:        "test-ap",
+		MACAddress:      "00:11:22:33:44:55",
+		DeviceType:      models.DeviceTypeAccessPoint,
+		Status:          models.DeviceStatusOnline,
+		DiscoveryMethod: models.DiscoveryWiFi,
+		FirstSeen:       time.Now().UTC(),
+		LastSeen:        time.Now().UTC(),
+	}
+	if _, err := s.UpsertDevice(ctx, apDevice); err != nil {
+		t.Fatalf("upsert AP: %v", err)
+	}
+
+	// Pre-create a client device matching the MAC that will be enumerated.
+	existing := &models.Device{
+		ID:              "existing-client",
+		Hostname:        "my-phone",
+		MACAddress:      "aa:bb:cc:11:22:33",
+		DeviceType:      models.DeviceTypePhone,
+		Status:          models.DeviceStatusOffline,
+		DiscoveryMethod: models.DiscoveryWiFi,
+		ConnectionType:  models.ConnectionUnknown,
+		ParentDeviceID:  "ap-1",
+		FirstSeen:       time.Now().UTC(),
+		LastSeen:        time.Now().UTC(),
+	}
+	if _, err := s.UpsertDevice(ctx, existing); err != nil {
+		t.Fatalf("upsert existing: %v", err)
+	}
+
+	enumerator := &mockAPClientEnumerator{
+		available: true,
+		clients: []APClientInfo{
+			{
+				MACAddress: "aa:bb:cc:11:22:33",
+				Signal:     -60,
+				Connected:  1 * time.Hour,
+				APBSSID:    "00:11:22:33:44:55",
+				APSSID:     "TestNet",
+			},
+		},
+	}
+
+	syncer := NewWiFiAPSyncer(s, nil, zap.NewNop())
+	result, err := syncer.Sync(ctx, enumerator)
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	if result.Created != 0 {
+		t.Errorf("Created = %d, want 0 (existing device should be updated)", result.Created)
+	}
+	if result.Updated != 1 {
+		t.Errorf("Updated = %d, want 1", result.Updated)
+	}
+
+	// Verify the device was updated.
+	updated, err := s.GetDeviceByMAC(ctx, "aa:bb:cc:11:22:33")
+	if err != nil {
+		t.Fatalf("get updated device: %v", err)
+	}
+	if updated.Status != models.DeviceStatusOnline {
+		t.Errorf("status = %q, want online", updated.Status)
+	}
+	if updated.ConnectionType != models.ConnectionWiFi {
+		t.Errorf("connection_type = %q, want wifi", updated.ConnectionType)
+	}
+}
+
+func TestWiFiAPSyncer_Sync_MarksUnseenOffline(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	// Create AP device.
+	apDevice := &models.Device{
+		ID:              "ap-1",
+		Hostname:        "test-ap",
+		MACAddress:      "00:11:22:33:44:55",
+		DeviceType:      models.DeviceTypeAccessPoint,
+		Status:          models.DeviceStatusOnline,
+		DiscoveryMethod: models.DiscoveryWiFi,
+		FirstSeen:       time.Now().UTC(),
+		LastSeen:        time.Now().UTC(),
+	}
+	if _, err := s.UpsertDevice(ctx, apDevice); err != nil {
+		t.Fatalf("upsert AP: %v", err)
+	}
+
+	// Create two WiFi child devices -- one will be "seen", one will not.
+	for _, d := range []struct {
+		id, mac string
+	}{
+		{"client-seen", "aa:bb:cc:11:11:11"},
+		{"client-gone", "aa:bb:cc:22:22:22"},
+	} {
+		dev := &models.Device{
+			ID:              d.id,
+			MACAddress:      d.mac,
+			DeviceType:      models.DeviceTypePhone,
+			Status:          models.DeviceStatusOnline,
+			DiscoveryMethod: models.DiscoveryWiFi,
+			ConnectionType:  models.ConnectionWiFi,
+			ParentDeviceID:  "ap-1",
+			FirstSeen:       time.Now().UTC(),
+			LastSeen:        time.Now().UTC(),
+		}
+		if _, err := s.UpsertDevice(ctx, dev); err != nil {
+			t.Fatalf("upsert %s: %v", d.id, err)
+		}
+	}
+
+	// Only enumerate the "seen" client.
+	enumerator := &mockAPClientEnumerator{
+		available: true,
+		clients: []APClientInfo{
+			{
+				MACAddress: "aa:bb:cc:11:11:11",
+				Signal:     -55,
+				APBSSID:    "00:11:22:33:44:55",
+				APSSID:     "TestNet",
+			},
+		},
+	}
+
+	syncer := NewWiFiAPSyncer(s, nil, zap.NewNop())
+	if _, err := syncer.Sync(ctx, enumerator); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	// Verify "client-gone" was marked offline.
+	goneDevice, err := s.GetDeviceByMAC(ctx, "aa:bb:cc:22:22:22")
+	if err != nil {
+		t.Fatalf("get gone device: %v", err)
+	}
+	if goneDevice == nil {
+		t.Fatal("expected client-gone to still exist")
+	}
+	if goneDevice.Status != models.DeviceStatusOffline {
+		t.Errorf("client-gone status = %q, want offline", goneDevice.Status)
+	}
+
+	// Verify "client-seen" remains online.
+	seenDevice, err := s.GetDeviceByMAC(ctx, "aa:bb:cc:11:11:11")
+	if err != nil {
+		t.Fatalf("get seen device: %v", err)
+	}
+	if seenDevice == nil {
+		t.Fatal("expected client-seen to exist")
+	}
+	if seenDevice.Status != models.DeviceStatusOnline {
+		t.Errorf("client-seen status = %q, want online", seenDevice.Status)
+	}
+}
+
+func TestWiFiAPSyncer_Sync_SetsConfidence100(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	// Create AP device.
+	apDevice := &models.Device{
+		ID:              "ap-1",
+		Hostname:        "test-ap",
+		MACAddress:      "00:11:22:33:44:55",
+		DeviceType:      models.DeviceTypeAccessPoint,
+		Status:          models.DeviceStatusOnline,
+		DiscoveryMethod: models.DiscoveryWiFi,
+		FirstSeen:       time.Now().UTC(),
+		LastSeen:        time.Now().UTC(),
+	}
+	if _, err := s.UpsertDevice(ctx, apDevice); err != nil {
+		t.Fatalf("upsert AP: %v", err)
+	}
+
+	enumerator := &mockAPClientEnumerator{
+		available: true,
+		clients: []APClientInfo{
+			{
+				MACAddress: "aa:bb:cc:99:88:77",
+				Signal:     -60,
+				APBSSID:    "00:11:22:33:44:55",
+				APSSID:     "TestNet",
+			},
+		},
+	}
+
+	syncer := NewWiFiAPSyncer(s, nil, zap.NewNop())
+	if _, err := syncer.Sync(ctx, enumerator); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	device, err := s.GetDeviceByMAC(ctx, "aa:bb:cc:99:88:77")
+	if err != nil {
+		t.Fatalf("get device: %v", err)
+	}
+	if device == nil {
+		t.Fatal("expected device to exist")
+	}
+	if device.ClassificationConfidence != 100 {
+		t.Errorf("ClassificationConfidence = %d, want 100", device.ClassificationConfidence)
+	}
+	if device.ClassificationSource != "wifi_ap" {
+		t.Errorf("ClassificationSource = %q, want %q", device.ClassificationSource, "wifi_ap")
+	}
+}


### PR DESCRIPTION
## Summary

- Phase C of WiFi scanning (completes the WiFi epic: heuristic -> active scan -> AP client enumeration)
- Enumerates clients connected to the server's own WiFi AP/hotspot with definitive identification (confidence 100)
- Linux: nl80211 `StationInfo()` via `mdlayher/wifi` + hostapd control socket fallback
- Windows: `netsh wlan show hostednetwork` + ARP table scan on hotspot subnet
- `recon_wifi_clients` sidecar table (migration v13) for signal/bitrate/connected-time data
- `GET /recon/wifi/clients` API endpoint with optional AP device ID filter
- Seed data: 3 WiFi client snapshots for demo mode
- 17 files changed, 1,854 lines added, 13 new tests

## Test plan

- [ ] `go build ./...` compiles
- [ ] `GOOS=linux GOARCH=amd64 go build ./...` cross-compiles
- [ ] `go test ./internal/recon/... -count=1` all tests pass
- [ ] Swagger drift check passes
- [ ] All CI checks green

Closes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)