### PR TITLE
chore: fix CI swagger drift and add shared auth mock factory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,12 +224,11 @@ jobs:
         run: go mod download
 
       - name: Regenerate swagger spec
-        run: >-
-          swag init
-          -g cmd/subnetree/main.go
-          -o api/swagger
-          --parseDependency
-          --parseInternal
+        run: |
+          swag init -g cmd/subnetree/main.go -o api/swagger --parseDependency --parseInternal
+          # Strip x-enum-descriptions (Windows swag generates them, Linux doesn't)
+          perl -i -0pe 's/\s*"x-enum-descriptions":\s*\[[^\]]*\],?//gs' api/swagger/docs.go api/swagger/swagger.json
+          perl -i -0pe 's/^    x-enum-descriptions:\n(    - [^\n]*\n)*//gm' api/swagger/swagger.yaml
 
       - name: Check for drift
         run: |

--- a/web/src/pages/login.test.tsx
+++ b/web/src/pages/login.test.tsx
@@ -17,17 +17,10 @@ vi.mock('react-router-dom', async () => {
 })
 
 // Mock auth API
-vi.mock('@/api/auth', () => ({
-  checkSetupRequired: vi.fn(),
-  loginApi: vi.fn(),
-  refreshApi: vi.fn(),
-  logoutApi: vi.fn(),
-  verifyMFAApi: vi.fn(),
-  verifyMFARecoveryApi: vi.fn(),
-  isMFAChallenge: vi.fn((data: unknown) => {
-    return typeof data === 'object' && data !== null && 'mfa_required' in data
-  }),
-}))
+vi.mock('@/api/auth', async () => {
+  const { authMockFactory } = await import('@/test/mocks/auth')
+  return authMockFactory()
+})
 
 describe('LoginPage', () => {
   const user = userEvent.setup()

--- a/web/src/pages/setup.test.tsx
+++ b/web/src/pages/setup.test.tsx
@@ -16,12 +16,13 @@ vi.mock('react-router-dom', async () => {
 })
 
 // Mock auth API
-vi.mock('@/api/auth', () => ({
-  setupApi: vi.fn(),
-  loginApi: vi.fn(),
-  checkSetupRequired: vi.fn().mockResolvedValue(true),
-  isMFAChallenge: vi.fn(() => false),
-}))
+vi.mock('@/api/auth', async () => {
+  const { authMockFactory } = await import('@/test/mocks/auth')
+  const mocks = authMockFactory()
+  mocks.checkSetupRequired.mockResolvedValue(true)
+  mocks.isMFAChallenge.mockReturnValue(false)
+  return mocks
+})
 
 // Mock settings API
 vi.mock('@/api/settings', () => ({

--- a/web/src/stores/auth.test.ts
+++ b/web/src/stores/auth.test.ts
@@ -25,16 +25,10 @@ vi.mock('jwt-decode', () => ({
 }))
 
 // Mock API calls
-vi.mock('@/api/auth', () => ({
-  loginApi: vi.fn(),
-  refreshApi: vi.fn(),
-  logoutApi: vi.fn(),
-  verifyMFAApi: vi.fn(),
-  verifyMFARecoveryApi: vi.fn(),
-  isMFAChallenge: vi.fn((data: unknown) => {
-    return typeof data === 'object' && data !== null && 'mfa_required' in data
-  }),
-}))
+vi.mock('@/api/auth', async () => {
+  const { authMockFactory } = await import('@/test/mocks/auth')
+  return authMockFactory()
+})
 
 describe('useAuthStore', () => {
   beforeEach(() => {

--- a/web/src/test/mocks/auth.ts
+++ b/web/src/test/mocks/auth.ts
@@ -1,0 +1,27 @@
+import { vi } from 'vitest'
+
+/**
+ * Canonical mock factory for @/api/auth.
+ *
+ * Usage:
+ *   import { authMockFactory } from '@/test/mocks/auth'
+ *   vi.mock('@/api/auth', () => authMockFactory())
+ *
+ * To override specific behavior (e.g., setup.test.tsx where MFA is never triggered):
+ *   const { isMFAChallenge } = await import('@/api/auth')
+ *   vi.mocked(isMFAChallenge).mockReturnValue(false)
+ */
+export function authMockFactory() {
+  return {
+    checkSetupRequired: vi.fn(),
+    setupApi: vi.fn(),
+    loginApi: vi.fn(),
+    refreshApi: vi.fn(),
+    logoutApi: vi.fn(),
+    verifyMFAApi: vi.fn(),
+    verifyMFARecoveryApi: vi.fn(),
+    isMFAChallenge: vi.fn((data: unknown) => {
+      return typeof data === 'object' && data !== null && 'mfa_required' in data
+    }),
+  }
+}


### PR DESCRIPTION
## Summary

- Add perl x-enum-descriptions cleanup to CI swagger drift check, matching local `make swagger` behavior. This prevents the recurring CI failures from Windows/Linux swag output differences (gotchas #12, #57, #59).
- Create shared auth mock factory at `web/src/test/mocks/auth.ts` with all 8 exports and correct `isMFAChallenge` type guard.
- Migrate `login.test.tsx`, `auth.test.ts`, and `setup.test.tsx` to use the shared factory instead of duplicated inline mocks.

## Test plan

- [x] All 40 frontend tests pass locally (`vitest run` on 3 migrated files)
- [x] TypeScript compilation clean (`tsc --noEmit`)
- [ ] CI swagger drift check passes with new perl cleanup
- [ ] All CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)