### PR TITLE
docs: Claude Desktop guide, ADR-0010, and nav updates

### DIFF
--- a/docs/adr/0010-hardware-inventory-schema.md
+++ b/docs/adr/0010-hardware-inventory-schema.md
@@ -1,0 +1,152 @@
+# 10. Hardware inventory schema for multi-source device profiling
+
+Date: 2026-02-21
+
+## Status
+
+Accepted
+
+## Context
+
+SubNetree collects hardware information from multiple sources: Scout agents
+(real-time profiling), manual entry (user overrides), and potentially future
+SNMP/WMI collectors. Hardware data is heterogeneous -- a device has one CPU
+info but multiple storage devices and GPUs. Existing schema needs to track
+which source provided each piece of data and preserve manual overrides when
+automated collection runs.
+
+The previous approach of storing hardware as a JSON blob in the device table
+limited querying (SQLite JSON functions are limited in pure Go) and made
+aggregation across a fleet impractical.
+
+## Decision
+
+Use structured relational tables instead of JSON blobs for hardware inventory:
+
+1. **Core hardware table**: `recon_device_hardware` stores CPU, memory, and OS
+   information. One row per device.
+
+2. **Storage devices table**: `recon_device_storage` stores disk/volume information.
+   One row per disk (multiple rows per device).
+
+3. **GPU devices table**: `recon_device_gpu` stores GPU information. One row per GPU
+   (multiple rows per device).
+
+4. **Collection provenance**: All three tables include:
+   - `collection_source` field ("scout", "manual", "snmp", "wmi") indicating the
+     data source
+   - `collected_at` timestamp tracking when the data was collected
+
+5. **Manual override protection**: When `collection_source = "manual"`, automated
+   collection never overwrites. The `UpsertDeviceHardware` store method checks
+   the existing source before updating. Manual data persists across automated scans.
+
+6. **Fleet aggregation**: A hardware summary endpoint aggregates across the fleet:
+   - Total device count and OS distribution
+   - CPU/memory statistics (min, max, average across fleet)
+   - Storage utilization by device type
+   - GPU inventory and VRAM totals
+
+7. **Device hardware API**: `GET /api/v1/recon/devices/{id}/hardware` returns a
+   combined profile including CPU, memory, storage list, and GPU list. The response
+   structure is tailored for UI and API consumption, not the raw database schema.
+
+## Consequences
+
+### Positive
+
+- **SQL-queryable hardware data** -- standard SQL can answer questions like
+  "find all devices with >16GB RAM" or "group devices by OS" without JSON parsing
+- **Multi-source tracking** -- audit trail showing which source provided each
+  piece of data
+- **Manual override preservation** -- user edits are protected from automated
+  overwrite, maintaining trust in the data
+- **Flexible cardinality** -- each table can independently store 1-to-many
+  relationships (one device → multiple disks, multiple GPUs)
+- **MCP tool support** -- `query_devices` MCP tool can filter by hardware specs
+  directly via SQL
+
+### Negative
+
+- **Migration complexity** -- converting from JSON to three tables requires a
+  careful schema migration with data transformation
+- **Adding hardware categories** -- future hardware types (network adapters,
+  TPMs, RAID controllers) require new migrations and store methods
+- **More JOIN queries** -- retrieving a complete device profile now requires
+  JOINs across three tables instead of a single JSON fetch
+
+### Neutral
+
+- Follows the existing pattern of `recon_` prefixed tables (consistent with
+  `recon_devices`, `recon_device_services`, etc.)
+- Hardware data is exposed through both REST API (`/api/v1/recon/devices/{id}/hardware`)
+  and MCP tools (`get_hardware_profile`, `query_devices`)
+- Scout agent collects hardware profiles during check-in and stores them via
+  the Dispatch module's `UpsertDeviceHardware` call
+
+## Alternatives Considered
+
+### Alternative 1: JSON columns in device table
+
+Store hardware as a JSON blob directly in the `recon_devices` table:
+
+```sql
+ALTER TABLE recon_devices ADD COLUMN hardware JSON;
+-- hardware: { "cpu": {...}, "memory": {...}, "storage": [...], "gpus": [...] }
+```
+
+**Rejected** because:
+- SQLite's JSON functions are limited (`json_extract` for simple paths, but no
+  powerful aggregation)
+- Pure Go SQLite bindings (modernc.org/sqlite) don't expose extended JSON operators
+- Fleet aggregation queries (group by OS, aggregate memory) become impossible
+  in pure SQL
+- Each update requires parsing, modifying, and re-serializing the JSON blob
+
+### Alternative 2: Single hardware table with JSON sub-fields
+
+One `device_hardware` table with JSON columns for storage and GPUs:
+
+```sql
+CREATE TABLE device_hardware (
+  id INTEGER PRIMARY KEY,
+  device_id INTEGER,
+  cpu_info JSON,
+  memory_mb INTEGER,
+  os_type TEXT,
+  storage_devices JSON,  -- array of disk objects
+  gpus JSON              -- array of GPU objects
+);
+```
+
+**Rejected** because it combines the worst of both approaches:
+- Relational overhead (foreign key, indexed lookups)
+- JSON query limitations (can't efficiently search within the arrays)
+- Still requires application-level parsing for multi-GPU or multi-disk iteration
+
+### Alternative 3: Generic key-value attribute store
+
+Store hardware as flexible key-value pairs:
+
+```sql
+CREATE TABLE device_attributes (
+  device_id INTEGER,
+  attribute_name TEXT,      -- "cpu.cores", "memory.total_mb", "os.type"
+  attribute_value TEXT,
+  collection_source TEXT,
+  collected_at TIMESTAMP
+);
+```
+
+**Rejected** because:
+- Loses type safety (everything is a string, requires casting)
+- Aggregation queries become verbose (nested CASE statements)
+- No foreign key constraints or schema definition
+- Difficult to validate (no schema enforcement)
+
+## Related Decisions
+
+- **ADR-0002 SQLite-First Database** -- Hardware inventory confirms the
+  SQLite-first approach by using relational tables (not JSON) for queryable data
+- **Hardware Profiles Feature** -- Implemented in Sprint 4 (PR #441-443) with
+  this schema design

--- a/docs/guides/claude-desktop-setup.md
+++ b/docs/guides/claude-desktop-setup.md
@@ -1,0 +1,133 @@
+# Claude Desktop Integration
+
+This guide shows you how to connect Claude Desktop to SubNetree's MCP server, giving Claude access to your device inventory and hardware profiles directly.
+
+## Prerequisites
+
+- SubNetree server running (default http://localhost:8080)
+- [Claude Desktop](https://claude.ai/download) installed
+- SubNetree MCP API key configured (optional, for authenticated access)
+
+## Configuration
+
+To add SubNetree to Claude Desktop, edit the `claude_desktop_config.json` file:
+
+### On macOS/Linux
+
+```bash
+$HOME/.config/Claude/claude_desktop_config.json
+```
+
+### On Windows
+
+```
+%APPDATA%\Claude\claude_desktop_config.json
+```
+
+Add or update the `mcpServers` section:
+
+```json
+{
+  "mcpServers": {
+    "subnetree": {
+      "command": "/path/to/subnetree",
+      "args": ["mcp"],
+      "env": {}
+    }
+  }
+}
+```
+
+### Setting the correct path
+
+- **Linux/macOS**: Full path to the binary, e.g. `/usr/local/bin/subnetree` or `$HOME/.local/bin/subnetree`
+- **Windows**: Full path with forward slashes, e.g. `C:/Program Files/SubNetree/subnetree.exe`
+- **macOS (Homebrew)**: `/usr/local/bin/subnetree`
+- **Docker**: If SubNetree runs in a container, mount the binary or use the HTTP transport (see below)
+
+The `mcp` subcommand starts the MCP server in stdio mode, communicating over stdin/stdout with Claude Desktop.
+
+## Available Tools
+
+Claude Desktop can now use these seven tools to query your SubNetree instance:
+
+1. **get_device** -- Retrieve full details for a specific device by ID
+2. **list_devices** -- Get a paginated list of all discovered devices (with pagination support)
+3. **get_hardware_profile** -- View hardware details (CPU, memory, storage, GPU) for a device
+4. **get_fleet_summary** -- Aggregate statistics across your entire fleet (total devices, OS distribution, resource totals)
+5. **query_devices** -- Search devices by hardware criteria (OS, CPU cores, memory, storage)
+6. **get_stale_devices** -- Find devices that haven't checked in recently (customizable threshold)
+7. **get_service_inventory** -- List services and applications running on devices
+
+## Example Queries
+
+Ask Claude questions like:
+
+- "Show me all devices running Ubuntu"
+- "How many devices have more than 16GB of RAM?"
+- "Which devices haven't checked in for over 24 hours?"
+- "What's the hardware summary of my fleet?"
+- "Give me a breakdown of operating systems in my network"
+- "List all services running on my servers"
+
+Claude uses SubNetree's MCP tools to answer these questions directly from your live device data.
+
+## Troubleshooting
+
+### Connection Refused
+
+**Error**: "Connection to subnetree MCP server failed"
+
+**Solution**: Verify that:
+- SubNetree server is running (`http://localhost:8080` responds)
+- The binary path in `claude_desktop_config.json` is correct
+- On macOS/Linux, the binary has execute permissions: `chmod +x /path/to/subnetree`
+
+### Binary Not Found
+
+**Error**: "Cannot execute /path/to/subnetree: file not found"
+
+**Solution**: Verify the path exists and is spelled correctly. Use the full absolute path (not `~/`). For example:
+- Correct: `/Users/john/bin/subnetree`
+- Incorrect: `~/bin/subnetree`
+
+### No Devices Returned
+
+**Error**: Tool returns "no devices found" even though you have devices
+
+**Solution**: You need to run at least one network scan first:
+1. Open http://localhost:8080 in your browser
+2. Go to **Devices** → **Scan**
+3. Enter your network range (e.g., `192.168.1.0/24`)
+4. Click **Start Scan** and wait for it to complete
+
+Claude will then see the discovered devices.
+
+### Authentication Error
+
+**Error**: "401 Unauthorized" when Claude tries to query devices
+
+**Solution**: If your SubNetree server requires API key authentication, you must use the HTTP transport instead of stdio. See "HTTP Transport" section below.
+
+## HTTP Transport (Remote or Authenticated Access)
+
+For remote servers or when API key authentication is enabled, use HTTP transport instead of stdio:
+
+```json
+{
+  "mcpServers": {
+    "subnetree": {
+      "url": "http://your-server:8080/api/v1/mcp/",
+      "headers": {
+        "Authorization": "Bearer your-api-key-here"
+      }
+    }
+  }
+}
+```
+
+Replace:
+- `your-server` with the IP or hostname of your SubNetree instance
+- `your-api-key-here` with the actual API key from your SubNetree configuration
+
+This allows Claude Desktop to connect to SubNetree over the network with authentication.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
       - Quick Start: guides/getting-started.md
       - Development Setup: guides/development-setup.md
       - Common Tasks: guides/common-tasks.md
+      - Claude Desktop: guides/claude-desktop-setup.md
   - Deployment:
       - Tailscale Deployment: guides/tailscale-deployment.md
       - Tailscale Funnel: guides/tailscale-funnel.md
@@ -69,6 +70,10 @@ nav:
       - ADR-0004 Integer Protocol Versioning: adr/0004-integer-protocol-versioning.md
       - ADR-0005 Hugo Website: adr/0005-hugo-website-github-pages.md
       - ADR-0006 Architecture Patterns: adr/0006-architecture-pattern-adoption.md
+      - ADR-0007 Scout WebSocket Transport: adr/0007-scout-websocket-transport.md
+      - ADR-0008 Workspace Consolidation: adr/0008-consolidate-workspace.md
+      - ADR-0009 MCP Server Architecture: adr/0009-mcp-server-architecture.md
+      - ADR-0010 Hardware Inventory Schema: adr/0010-hardware-inventory-schema.md
   - Requirements:
       - Overview: requirements/README.md
       - Product Vision: requirements/01-product-vision.md


### PR DESCRIPTION
## Summary

- Add Claude Desktop integration guide (`docs/guides/claude-desktop-setup.md`) covering stdio and HTTP transport configuration, all 7 MCP tools, example queries, and troubleshooting
- Add ADR-0010 documenting hardware inventory schema decisions (structured tables vs JSON, collection_source tracking, manual override protection)
- Add ADRs 0007-0010 to mkdocs.yml navigation (files existed on disk but were missing from nav)
- Add Claude Desktop guide to Getting Started nav section

Closes #440

## Test plan

- [ ] Verify `mkdocs build` succeeds with new pages
- [ ] Verify new ADR follows established format (compare with ADR-0009)
- [ ] Verify Claude Desktop guide has accurate tool names matching `internal/mcp/tools.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)