### PR TITLE
feat: add Cosign keyless container image signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,37 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract tag name
+        run: echo "TAG=${GITHUB_REF_NAME}" >> "$GITHUB_ENV"
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign container images with Cosign
+        run: |
+          IMAGES=(
+            "ghcr.io/herbhall/subnetree:${TAG}"
+            "ghcr.io/herbhall/subnetree:latest"
+          )
+          for IMAGE in "${IMAGES[@]}"; do
+            echo "Signing ${IMAGE}"
+            cosign sign --yes "$IMAGE"
+          done
+
+      - name: Verify container image signatures
+        run: |
+          IMAGES=(
+            "ghcr.io/herbhall/subnetree:${TAG}"
+            "ghcr.io/herbhall/subnetree:latest"
+          )
+          for IMAGE in "${IMAGES[@]}"; do
+            echo "Verifying ${IMAGE}"
+            cosign verify \
+              --certificate-identity-regexp="https://github.com/HerbHall/subnetree/" \
+              --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+              "$IMAGE"
+          done
+
   smoke-test:
     name: Smoke Test Docker Image
     needs: release


### PR DESCRIPTION
## Summary
- Add Sigstore Cosign keyless signing to release workflow using GitHub OIDC
- Sign both versioned (`v*`) and `latest` Docker image tags
- Verify signatures with certificate identity matching after signing
- Uses `sigstore/cosign-installer@v3` action

## Test plan
- [ ] Release workflow signs images after GoReleaser push
- [ ] Verification step confirms signatures with OIDC issuer
- [ ] No changes needed for existing `id-token: write` permission

Closes #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)