### PR TITLE
feat: add topology-aware alert correlation engine

### DIFF
--- a/api/swagger/docs.go
+++ b/api/swagger/docs.go
@@ -1708,6 +1708,41 @@ const docTemplate = `{
                 }
             }
         },
+        "/pulse/alerts/correlated": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns active alerts grouped by topology correlation. Parent alerts include their suppressed children.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "pulse"
+                ],
+                "summary": "Correlated alerts",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/internal_pulse.CorrelatedAlertGroup"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/pulse/alerts/{id}": {
             "get": {
                 "security": [
@@ -7474,6 +7509,20 @@ const docTemplate = `{
                 },
                 "success": {
                     "type": "boolean"
+                }
+            }
+        },
+        "internal_pulse.CorrelatedAlertGroup": {
+            "type": "object",
+            "properties": {
+                "parent_alert": {
+                    "$ref": "#/definitions/internal_pulse.Alert"
+                },
+                "suppressed_children": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/internal_pulse.Alert"
+                    }
                 }
             }
         },

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -1701,6 +1701,41 @@
                 }
             }
         },
+        "/pulse/alerts/correlated": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns active alerts grouped by topology correlation. Parent alerts include their suppressed children.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "pulse"
+                ],
+                "summary": "Correlated alerts",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/internal_pulse.CorrelatedAlertGroup"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/pulse/alerts/{id}": {
             "get": {
                 "security": [
@@ -7467,6 +7502,20 @@
                 },
                 "success": {
                     "type": "boolean"
+                }
+            }
+        },
+        "internal_pulse.CorrelatedAlertGroup": {
+            "type": "object",
+            "properties": {
+                "parent_alert": {
+                    "$ref": "#/definitions/internal_pulse.Alert"
+                },
+                "suppressed_children": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/internal_pulse.Alert"
+                    }
                 }
             }
         },

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -1202,6 +1202,15 @@ definitions:
       success:
         type: boolean
     type: object
+  internal_pulse.CorrelatedAlertGroup:
+    properties:
+      parent_alert:
+        $ref: '#/definitions/internal_pulse.Alert'
+      suppressed_children:
+        items:
+          $ref: '#/definitions/internal_pulse.Alert'
+        type: array
+    type: object
   internal_pulse.MetricDataPoint:
     properties:
       timestamp:
@@ -3257,6 +3266,29 @@ paths:
       security:
       - BearerAuth: []
       summary: Resolve alert
+      tags:
+      - pulse
+  /pulse/alerts/correlated:
+    get:
+      description: Returns active alerts grouped by topology correlation. Parent alerts
+        include their suppressed children.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/internal_pulse.CorrelatedAlertGroup'
+            type: array
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Correlated alerts
       tags:
       - pulse
   /pulse/checks:

--- a/internal/pulse/config.go
+++ b/internal/pulse/config.go
@@ -10,6 +10,8 @@ type PulseConfig struct {
 	RetentionPeriod     time.Duration `mapstructure:"retention_period"`
 	MaxWorkers          int           `mapstructure:"max_workers"`
 	MaintenanceInterval time.Duration `mapstructure:"maintenance_interval"`
+	CorrelationEnabled  bool          `mapstructure:"correlation_enabled"`
+	CorrelationWindow   time.Duration `mapstructure:"correlation_window"`
 }
 
 func DefaultConfig() PulseConfig {
@@ -21,5 +23,7 @@ func DefaultConfig() PulseConfig {
 		RetentionPeriod:     30 * 24 * time.Hour,
 		MaxWorkers:          10,
 		MaintenanceInterval: 1 * time.Hour,
+		CorrelationEnabled:  true,
+		CorrelationWindow:   5 * time.Minute,
 	}
 }

--- a/internal/pulse/correlation.go
+++ b/internal/pulse/correlation.go
@@ -1,0 +1,67 @@
+package pulse
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// CorrelationEngine checks whether a new alert on a child device should be
+// suppressed because its parent device already has active alerts within a
+// configurable time window.
+type CorrelationEngine struct {
+	store  *PulseStore
+	window time.Duration
+	logger *zap.Logger
+}
+
+// NewCorrelationEngine creates a correlation engine with the given window.
+func NewCorrelationEngine(store *PulseStore, window time.Duration, logger *zap.Logger) *CorrelationEngine {
+	return &CorrelationEngine{
+		store:  store,
+		window: window,
+		logger: logger,
+	}
+}
+
+// CorrelationResult holds the outcome of a correlation check.
+type CorrelationResult struct {
+	Suppressed     bool
+	ParentDeviceID string
+}
+
+// Check determines whether the alert for the given device should be
+// suppressed based on parent device alert status. It returns a result
+// indicating suppression state and the parent device ID if applicable.
+func (c *CorrelationEngine) Check(ctx context.Context, deviceID string) (result CorrelationResult, err error) {
+	parentAlerts, parentDeviceID, err := c.store.GetParentActiveAlerts(ctx, deviceID, c.window)
+	if err != nil {
+		return CorrelationResult{}, err
+	}
+
+	if len(parentAlerts) == 0 {
+		c.logger.Debug("no parent alerts for correlation",
+			zap.String("device_id", deviceID),
+		)
+		return CorrelationResult{Suppressed: false}, nil
+	}
+
+	c.logger.Debug("alert correlated with parent device",
+		zap.String("device_id", deviceID),
+		zap.String("parent_device_id", parentDeviceID),
+		zap.Int("parent_active_alerts", len(parentAlerts)),
+		zap.Duration("correlation_window", c.window),
+	)
+
+	return CorrelationResult{
+		Suppressed:     true,
+		ParentDeviceID: parentDeviceID,
+	}, nil
+}
+
+// CorrelatedAlertGroup represents a parent alert with its suppressed children.
+type CorrelatedAlertGroup struct {
+	ParentAlert        Alert   `json:"parent_alert"`
+	SuppressedChildren []Alert `json:"suppressed_children"`
+}

--- a/internal/pulse/correlation_test.go
+++ b/internal/pulse/correlation_test.go
@@ -1,0 +1,452 @@
+package pulse
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/HerbHall/subnetree/internal/store"
+	"go.uber.org/zap"
+)
+
+// correlationTestStore creates an in-memory store with recon_devices table
+// including parent_device_id for correlation tests.
+func correlationTestStore(t *testing.T) *PulseStore {
+	t.Helper()
+	db, err := store.New(":memory:")
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	ctx := context.Background()
+	if err := db.Migrate(ctx, "pulse", migrations()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	// Create recon_devices table with parent_device_id column.
+	_, err = db.DB().ExecContext(ctx, `CREATE TABLE IF NOT EXISTS recon_devices (
+		id               TEXT PRIMARY KEY,
+		hostname         TEXT NOT NULL DEFAULT '',
+		ip_addresses     TEXT NOT NULL DEFAULT '[]',
+		mac_address      TEXT NOT NULL DEFAULT '',
+		manufacturer     TEXT NOT NULL DEFAULT '',
+		device_type      TEXT NOT NULL DEFAULT 'unknown',
+		os               TEXT NOT NULL DEFAULT '',
+		status           TEXT NOT NULL DEFAULT 'unknown',
+		discovery_method TEXT NOT NULL DEFAULT 'icmp',
+		agent_id         TEXT NOT NULL DEFAULT '',
+		first_seen       DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		last_seen        DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		notes            TEXT NOT NULL DEFAULT '',
+		tags             TEXT NOT NULL DEFAULT '[]',
+		custom_fields    TEXT NOT NULL DEFAULT '{}',
+		parent_device_id TEXT NOT NULL DEFAULT '',
+		network_layer    INTEGER NOT NULL DEFAULT 0,
+		connection_type  TEXT NOT NULL DEFAULT ''
+	)`)
+	if err != nil {
+		t.Fatalf("create recon_devices table: %v", err)
+	}
+
+	return NewPulseStore(db.DB())
+}
+
+// insertTestDevice inserts a device with optional parent into the recon_devices table.
+func insertTestDevice(t *testing.T, ps *PulseStore, id, hostname, parentID string) {
+	t.Helper()
+	_, err := ps.db.ExecContext(context.Background(),
+		`INSERT INTO recon_devices (id, hostname, ip_addresses, parent_device_id) VALUES (?, ?, '["10.0.0.1"]', ?)`,
+		id, hostname, parentID,
+	)
+	if err != nil {
+		t.Fatalf("insert test device %s: %v", id, err)
+	}
+}
+
+// insertTestAlert inserts an alert directly into the store for testing.
+func insertTestAlert(t *testing.T, ps *PulseStore, alert *Alert) {
+	t.Helper()
+	if err := ps.InsertAlert(context.Background(), alert); err != nil {
+		t.Fatalf("insert test alert: %v", err)
+	}
+}
+
+func TestCorrelation_ParentAlerting_SuppressesChild(t *testing.T) {
+	ps := correlationTestStore(t)
+	ctx := context.Background()
+	logger := zap.NewNop()
+
+	// Setup: router (parent) -> switch (child).
+	insertTestDevice(t, ps, "router-1", "router", "")
+	insertTestDevice(t, ps, "switch-1", "switch", "router-1")
+
+	// Create checks for both devices.
+	insertCorrelationCheck(t, ps, "chk-router", "router-1")
+	insertCorrelationCheck(t, ps, "chk-switch", "switch-1")
+
+	// Parent has an active alert.
+	now := time.Now().UTC()
+	insertTestAlert(t, ps, &Alert{
+		ID:                  "alert-router-1",
+		CheckID:             "chk-router",
+		DeviceID:            "router-1",
+		Severity:            "critical",
+		Message:             "router unreachable",
+		TriggeredAt:         now.Add(-2 * time.Minute),
+		ConsecutiveFailures: 5,
+	})
+
+	engine := NewCorrelationEngine(ps, 5*time.Minute, logger)
+	result, err := engine.Check(ctx, "switch-1")
+	if err != nil {
+		t.Fatalf("correlation check: %v", err)
+	}
+	if !result.Suppressed {
+		t.Error("expected child alert to be suppressed, got not suppressed")
+	}
+	if result.ParentDeviceID != "router-1" {
+		t.Errorf("ParentDeviceID = %q, want %q", result.ParentDeviceID, "router-1")
+	}
+}
+
+func TestCorrelation_NoParentAlert_NotSuppressed(t *testing.T) {
+	ps := correlationTestStore(t)
+	ctx := context.Background()
+	logger := zap.NewNop()
+
+	// Setup: router (parent) -> switch (child), no alerts on parent.
+	insertTestDevice(t, ps, "router-1", "router", "")
+	insertTestDevice(t, ps, "switch-1", "switch", "router-1")
+
+	engine := NewCorrelationEngine(ps, 5*time.Minute, logger)
+	result, err := engine.Check(ctx, "switch-1")
+	if err != nil {
+		t.Fatalf("correlation check: %v", err)
+	}
+	if result.Suppressed {
+		t.Error("expected alert not to be suppressed when parent has no alerts")
+	}
+}
+
+func TestCorrelation_WindowExpiry_NotSuppressed(t *testing.T) {
+	ps := correlationTestStore(t)
+	ctx := context.Background()
+	logger := zap.NewNop()
+
+	// Setup: router (parent) -> switch (child).
+	insertTestDevice(t, ps, "router-1", "router", "")
+	insertTestDevice(t, ps, "switch-1", "switch", "router-1")
+
+	insertCorrelationCheck(t, ps, "chk-router", "router-1")
+
+	// Parent alert was triggered 10 minutes ago (outside 5-minute window).
+	insertTestAlert(t, ps, &Alert{
+		ID:                  "alert-router-old",
+		CheckID:             "chk-router",
+		DeviceID:            "router-1",
+		Severity:            "critical",
+		Message:             "router unreachable",
+		TriggeredAt:         time.Now().UTC().Add(-10 * time.Minute),
+		ConsecutiveFailures: 5,
+	})
+
+	engine := NewCorrelationEngine(ps, 5*time.Minute, logger)
+	result, err := engine.Check(ctx, "switch-1")
+	if err != nil {
+		t.Fatalf("correlation check: %v", err)
+	}
+	if result.Suppressed {
+		t.Error("expected alert not to be suppressed when parent alert is outside correlation window")
+	}
+}
+
+func TestCorrelation_NoParentDevice_NotSuppressed(t *testing.T) {
+	ps := correlationTestStore(t)
+	ctx := context.Background()
+	logger := zap.NewNop()
+
+	// Device has no parent_device_id set.
+	insertTestDevice(t, ps, "standalone-1", "standalone", "")
+
+	engine := NewCorrelationEngine(ps, 5*time.Minute, logger)
+	result, err := engine.Check(ctx, "standalone-1")
+	if err != nil {
+		t.Fatalf("correlation check: %v", err)
+	}
+	if result.Suppressed {
+		t.Error("expected alert not to be suppressed when device has no parent")
+	}
+}
+
+func TestCorrelation_DeviceNotInDB_NotSuppressed(t *testing.T) {
+	ps := correlationTestStore(t)
+	ctx := context.Background()
+	logger := zap.NewNop()
+
+	// Device doesn't exist in the database at all.
+	engine := NewCorrelationEngine(ps, 5*time.Minute, logger)
+	result, err := engine.Check(ctx, "nonexistent-device")
+	if err != nil {
+		t.Fatalf("correlation check: %v", err)
+	}
+	if result.Suppressed {
+		t.Error("expected alert not to be suppressed for nonexistent device")
+	}
+}
+
+func TestCorrelation_ParentAlertResolved_NotSuppressed(t *testing.T) {
+	ps := correlationTestStore(t)
+	ctx := context.Background()
+	logger := zap.NewNop()
+
+	insertTestDevice(t, ps, "router-1", "router", "")
+	insertTestDevice(t, ps, "switch-1", "switch", "router-1")
+
+	insertCorrelationCheck(t, ps, "chk-router", "router-1")
+
+	// Parent has a resolved alert (not active).
+	now := time.Now().UTC()
+	resolvedAt := now.Add(-1 * time.Minute)
+	insertTestAlert(t, ps, &Alert{
+		ID:                  "alert-router-resolved",
+		CheckID:             "chk-router",
+		DeviceID:            "router-1",
+		Severity:            "critical",
+		Message:             "router unreachable",
+		TriggeredAt:         now.Add(-3 * time.Minute),
+		ResolvedAt:          &resolvedAt,
+		ConsecutiveFailures: 5,
+	})
+
+	engine := NewCorrelationEngine(ps, 5*time.Minute, logger)
+	result, err := engine.Check(ctx, "switch-1")
+	if err != nil {
+		t.Fatalf("correlation check: %v", err)
+	}
+	if result.Suppressed {
+		t.Error("expected alert not to be suppressed when parent alert is resolved")
+	}
+}
+
+func TestGetCorrelatedAlerts_GroupsByParent(t *testing.T) {
+	ps := correlationTestStore(t)
+	ctx := context.Background()
+
+	insertTestDevice(t, ps, "router-1", "router", "")
+	insertTestDevice(t, ps, "switch-1", "switch", "router-1")
+	insertTestDevice(t, ps, "switch-2", "switch-2", "router-1")
+
+	insertCorrelationCheck(t, ps, "chk-router", "router-1")
+	insertCorrelationCheck(t, ps, "chk-switch1", "switch-1")
+	insertCorrelationCheck(t, ps, "chk-switch2", "switch-2")
+
+	now := time.Now().UTC()
+
+	// Parent alert (not suppressed).
+	insertTestAlert(t, ps, &Alert{
+		ID:                  "alert-router-1",
+		CheckID:             "chk-router",
+		DeviceID:            "router-1",
+		Severity:            "critical",
+		Message:             "router unreachable",
+		TriggeredAt:         now.Add(-2 * time.Minute),
+		ConsecutiveFailures: 5,
+	})
+
+	// Child alerts (suppressed by router-1).
+	insertTestAlert(t, ps, &Alert{
+		ID:                  "alert-switch-1",
+		CheckID:             "chk-switch1",
+		DeviceID:            "switch-1",
+		Severity:            "warning",
+		Message:             "switch unreachable",
+		TriggeredAt:         now.Add(-1 * time.Minute),
+		ConsecutiveFailures: 3,
+		Suppressed:          true,
+		SuppressedBy:        "router-1",
+	})
+	insertTestAlert(t, ps, &Alert{
+		ID:                  "alert-switch-2",
+		CheckID:             "chk-switch2",
+		DeviceID:            "switch-2",
+		Severity:            "warning",
+		Message:             "switch-2 unreachable",
+		TriggeredAt:         now.Add(-1 * time.Minute),
+		ConsecutiveFailures: 3,
+		Suppressed:          true,
+		SuppressedBy:        "router-1",
+	})
+
+	groups, err := ps.GetCorrelatedAlerts(ctx)
+	if err != nil {
+		t.Fatalf("GetCorrelatedAlerts: %v", err)
+	}
+
+	if len(groups) != 1 {
+		t.Fatalf("got %d groups, want 1", len(groups))
+	}
+
+	group := groups[0]
+	if group.ParentAlert.ID != "alert-router-1" {
+		t.Errorf("parent alert ID = %q, want %q", group.ParentAlert.ID, "alert-router-1")
+	}
+	if len(group.SuppressedChildren) != 2 {
+		t.Errorf("got %d suppressed children, want 2", len(group.SuppressedChildren))
+	}
+}
+
+func TestGetParentActiveAlerts_ReturnsParentAlerts(t *testing.T) {
+	ps := correlationTestStore(t)
+	ctx := context.Background()
+
+	insertTestDevice(t, ps, "router-1", "router", "")
+	insertTestDevice(t, ps, "switch-1", "switch", "router-1")
+
+	insertCorrelationCheck(t, ps, "chk-router", "router-1")
+
+	now := time.Now().UTC()
+	insertTestAlert(t, ps, &Alert{
+		ID:                  "alert-router-1",
+		CheckID:             "chk-router",
+		DeviceID:            "router-1",
+		Severity:            "critical",
+		Message:             "router down",
+		TriggeredAt:         now.Add(-1 * time.Minute),
+		ConsecutiveFailures: 5,
+	})
+
+	alerts, parentID, err := ps.GetParentActiveAlerts(ctx, "switch-1", 5*time.Minute)
+	if err != nil {
+		t.Fatalf("GetParentActiveAlerts: %v", err)
+	}
+	if parentID != "router-1" {
+		t.Errorf("parentID = %q, want %q", parentID, "router-1")
+	}
+	if len(alerts) != 1 {
+		t.Fatalf("got %d alerts, want 1", len(alerts))
+	}
+	if alerts[0].ID != "alert-router-1" {
+		t.Errorf("alert ID = %q, want %q", alerts[0].ID, "alert-router-1")
+	}
+}
+
+func TestAlerter_CorrelationIntegration(t *testing.T) {
+	ps := correlationTestStore(t)
+	bus := &mockEventBus{}
+	threshold := 3
+	alerter := NewAlerter(ps, bus, threshold, zap.NewNop())
+
+	// Enable correlation.
+	corr := NewCorrelationEngine(ps, 5*time.Minute, zap.NewNop())
+	alerter.SetCorrelation(corr)
+
+	ctx := context.Background()
+
+	// Setup: router -> switch.
+	insertTestDevice(t, ps, "router-1", "router", "")
+	insertTestDevice(t, ps, "switch-1", "switch", "router-1")
+
+	routerCheck := makeCorrelationCheck(t, ps, "router-1", "ping", "10.0.0.1")
+	switchCheck := makeCorrelationCheck(t, ps, "switch-1", "ping", "10.0.0.2")
+
+	failResult := func(check Check) *CheckResult {
+		return &CheckResult{
+			CheckID:      check.ID,
+			DeviceID:     check.DeviceID,
+			Success:      false,
+			ErrorMessage: "timeout",
+			CheckedAt:    time.Now().UTC(),
+		}
+	}
+
+	// Trigger alert on router first.
+	for i := 0; i < threshold; i++ {
+		alerter.ProcessResult(ctx, routerCheck, failResult(routerCheck))
+	}
+
+	// Verify router alert exists and is not suppressed.
+	routerAlert, err := ps.GetActiveAlert(ctx, routerCheck.ID)
+	if err != nil {
+		t.Fatalf("GetActiveAlert router: %v", err)
+	}
+	if routerAlert == nil {
+		t.Fatal("router alert should exist")
+	}
+	if routerAlert.Suppressed {
+		t.Error("router alert should not be suppressed")
+	}
+
+	// Reset bus events.
+	bus.events = nil
+
+	// Now trigger alert on switch (child).
+	for i := 0; i < threshold; i++ {
+		alerter.ProcessResult(ctx, switchCheck, failResult(switchCheck))
+	}
+
+	// Switch alert should be suppressed due to parent correlation.
+	switchAlert, err := ps.GetActiveAlert(ctx, switchCheck.ID)
+	if err != nil {
+		t.Fatalf("GetActiveAlert switch: %v", err)
+	}
+	if switchAlert == nil {
+		t.Fatal("switch alert should exist")
+	}
+	if !switchAlert.Suppressed {
+		t.Error("switch alert should be suppressed via correlation")
+	}
+	if switchAlert.SuppressedBy != "router-1" {
+		t.Errorf("SuppressedBy = %q, want %q", switchAlert.SuppressedBy, "router-1")
+	}
+
+	// Should publish suppressed event, not triggered.
+	var suppressedCount int
+	for _, e := range bus.events {
+		if e.Topic == TopicAlertSuppressed {
+			suppressedCount++
+		}
+	}
+	if suppressedCount != 1 {
+		t.Errorf("got %d suppressed events, want 1", suppressedCount)
+	}
+}
+
+// insertCorrelationCheck inserts a check for correlation tests.
+func insertCorrelationCheck(t *testing.T, ps *PulseStore, checkID, deviceID string) {
+	t.Helper()
+	now := time.Now().UTC()
+	if err := ps.InsertCheck(context.Background(), &Check{
+		ID:              checkID,
+		DeviceID:        deviceID,
+		CheckType:       "icmp",
+		Target:          "10.0.0.1",
+		IntervalSeconds: 30,
+		Enabled:         true,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}); err != nil {
+		t.Fatalf("insert check %s: %v", checkID, err)
+	}
+}
+
+// makeCorrelationCheck inserts a check with a unique ID and returns it.
+func makeCorrelationCheck(t *testing.T, ps *PulseStore, deviceID, checkType, target string) Check {
+	t.Helper()
+	now := time.Now().UTC()
+	check := Check{
+		ID:              fmt.Sprintf("corr-check-%s-%s", deviceID, checkType),
+		DeviceID:        deviceID,
+		CheckType:       checkType,
+		Target:          target,
+		IntervalSeconds: 60,
+		Enabled:         true,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	if err := ps.InsertCheck(context.Background(), &check); err != nil {
+		t.Fatalf("insert check: %v", err)
+	}
+	return check
+}

--- a/internal/pulse/pulse.go
+++ b/internal/pulse/pulse.go
@@ -94,6 +94,13 @@ func (m *Module) Start(_ context.Context) error {
 
 	if m.store != nil {
 		m.alerter = NewAlerter(m.store, m.bus, m.cfg.ConsecutiveFailures, m.logger)
+		if m.cfg.CorrelationEnabled {
+			corr := NewCorrelationEngine(m.store, m.cfg.CorrelationWindow, m.logger)
+			m.alerter.SetCorrelation(corr)
+			m.logger.Info("topology-aware alert correlation enabled",
+				zap.Duration("correlation_window", m.cfg.CorrelationWindow),
+			)
+		}
 		m.dispatcher = NewNotificationDispatcher(m.store, m.logger)
 
 		m.scheduler = NewScheduler(


### PR DESCRIPTION
## Summary
- Add correlation engine that suppresses child device alerts when parent is alerting within configurable window (default 5min)
- New `GET /api/v1/pulse/alerts/correlated` endpoint returns alerts grouped as parent/children tree
- Integrates into existing alerter flow after dependency suppression check
- 9 test functions covering all correlation scenarios including window expiry and no-parent cases

## Test plan
- [ ] `go test ./internal/pulse/...` passes all tests
- [ ] Cross-compile check passes
- [ ] Swagger drift check passes (spec regenerated)
- [ ] Child device alerts suppressed when parent is actively alerting

Closes #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)