### PR TITLE
chore: add stale issue bot and update README modules

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,36 @@
+name: Stale Issues
+
+on:
+  schedule:
+    - cron: '0 6 * * 1' # Every Monday at 6am UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not
+            had recent activity. It will be closed in 14 days if no further
+            activity occurs. If this issue is still relevant, please comment or
+            remove the stale label.
+          stale-pr-message: >
+            This PR has been automatically marked as stale because it has not
+            had recent activity. It will be closed in 14 days if no further
+            activity occurs.
+          close-issue-message: >
+            This issue was closed because it has been stale for 14 days with no
+            activity. Feel free to reopen if still relevant.
+          days-before-stale: 60
+          days-before-close: 14
+          stale-issue-label: stale
+          stale-pr-label: stale
+          exempt-issue-labels: pinned,security,blocked,in-progress
+          exempt-pr-labels: pinned,blocked,in-progress
+          operations-per-run: 30

--- a/README.md
+++ b/README.md
@@ -268,6 +268,9 @@ graph TD
         Vault["Vault"]
         Gateway["Gateway"]
         Webhook["Webhook"]
+        MQTT["MQTT"]
+        Tailscale["Tailscale"]
+        MCP["MCP"]
         EventBus(["Event Bus"])
 
         Recon --> EventBus
@@ -275,6 +278,7 @@ graph TD
         Docs --> EventBus
         Insight --> EventBus
         Webhook --> EventBus
+        MQTT --> EventBus
     end
 
     Dashboard -- "REST / WebSocket" --> Server
@@ -282,6 +286,7 @@ graph TD
     Recon -- "ARP / ICMP" --> Devices
     Pulse -- "ICMP" --> Devices
     Insight --> LLM
+    MQTT -- "MQTT" --> HA["Home Assistant"]
 ```
 
 ### Modules
@@ -295,8 +300,13 @@ graph TD
 | **Vault** | Encrypted credential storage |
 | **Gateway** | Browser-based remote access (SSH, HTTP proxy) |
 | **Webhook** | Event-driven webhook notifications |
+| **MQTT** | MQTT publisher with Home Assistant auto-discovery |
 | **LLM** | AI provider integration (Ollama, OpenAI, Anthropic) |
 | **Insight** | Statistical analytics, anomaly detection, NL queries |
+| **Tailscale** | Tailscale network device sync and status monitoring |
+| **MCP** | Model Context Protocol server for AI tool integration |
+| **NetBox** | NetBox DCIM export for device inventory sync |
+| **Autodoc** | Automated infrastructure documentation engine |
 
 ### Building from Source
 
@@ -342,6 +352,11 @@ internal/
   webhook/        Webhook notification module
   llm/            LLM plugin (Ollama provider)
   insight/        Analytics and anomaly detection
+  mqtt/           MQTT publisher with HA auto-discovery
+  tailscale/      Tailscale network integration
+  mcp/            Model Context Protocol server
+  netbox/         NetBox DCIM export
+  autodoc/        Infrastructure documentation engine
 web/              React dashboard (Vite + shadcn/ui)
 pkg/
   plugin/         Public plugin SDK (Apache 2.0)
@@ -358,8 +373,8 @@ api/
 - **v0.4.x** (shipped): mDNS discovery, metrics history, alert suppression, vault UI, analytics dashboard
 - **v0.5.0** (shipped): MQTT publisher, Alertmanager webhooks, CSV import/export, recommendation engine
 - **v0.6.x** (shipped): Device classification engine, LLDP discovery, composite scoring, scan analytics, network hierarchy
-- **Sprints 1-6** (shipped): Traceroute, diagnostics, SNMP FDB walks, E2E tests, hardware profiles, MCP server, WiFi scanning, demo mode, Windows Scout service + installer, contextual help
-- **Next**: Proxmox VE monitoring, MFA/TOTP, Tailscale, multi-tenant, PostgreSQL
+- **Sprints 1-11** (shipped): Traceroute, diagnostics, SNMP FDB walks, E2E tests, hardware profiles, MCP server, WiFi scanning, demo mode, Windows installer, Proxmox VE monitoring, MFA/TOTP, Tailscale, autodoc engine
+- **Next**: NetBox integration, Home Assistant MQTT discovery, community launch, multi-tenant, PostgreSQL
 
 ## License
 


### PR DESCRIPTION
## Summary

- Adds GitHub Actions stale workflow: marks issues stale after 60 days, closes after 14 more days of inactivity
- Exempt labels: pinned, security, blocked, in-progress
- Updates README architecture diagram to include MQTT, Tailscale, MCP modules
- Updates module table with 4 new modules (MQTT, Tailscale, MCP, NetBox, Autodoc)
- Updates project structure and roadmap sections to reflect Sprints 1-11

Partial work for #487 (remaining: awesome-selfhosted submission, Discord, launch announcements)

## Test plan

- [ ] CI passes (no code changes, workflow syntax only)
- [ ] Stale workflow triggers on schedule or manual dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)