### PR TITLE
fix: add missing playwright peer dependency

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -77,6 +77,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.0",
     "happy-dom": "^20.5.0",
+    "playwright": "^1.58.2",
     "postcss": "^8.5.6",
     "prettier": "^3.8.1",
     "tailwindcss": "^3.4.19",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       happy-dom:
         specifier: ^20.5.0
         version: 20.5.0
+      playwright:
+        specifier: ^1.58.2
+        version: 1.58.2
       postcss:
         specifier: ^8.5.6
         version: 8.5.6


### PR DESCRIPTION
## Summary

- Adds `playwright` core package as a dev dependency (required peer dep for `@playwright/test`)
- Fixes `Cannot find module 'playwright/lib/program'` error when running E2E tests

## Test plan

- [x] `pnpm install` succeeds
- [x] `npx playwright install chromium` succeeds
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)