### PR TITLE
feat: add GitHub Copilot integration

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,75 @@
+# SubNetree -- Copilot Instructions
+
+Network monitoring and infrastructure management platform for home labs and small
+networks. Discovers devices, maps topology, monitors health, and provides a React
+dashboard.
+
+## Tech Stack
+
+- **Backend**: Go 1.25, standard library HTTP server (Go 1.22+ enhanced ServeMux)
+- **Frontend**: React 19, TypeScript 5, MUI v5 (`@docker/docker-mui-theme` compatible), TanStack Query v5, Recharts v3
+- **Database**: SQLite via `modernc.org/sqlite` (pure-Go, no CGO)
+- **API**: REST with Swagger (swaggo/swag v1.16), WebSocket (`coder/websocket`)
+- **Build**: Make targets (`build`, `test`, `lint`, `swagger`)
+- **Lint**: golangci-lint v2 (Go), ESLint + TypeScript strict (frontend)
+- **Test**: Go `testing` package + table-driven tests, Vitest + Testing Library (frontend)
+- **Package manager**: pnpm (frontend)
+
+## Project Structure
+
+```text
+SubNetree/
+├── cmd/
+│   ├── subnetree/       - Main server entry point
+│   └── scout/           - Network scout agent binary
+├── internal/            - Private application packages (30+ modules)
+├── pkg/models/          - Shared types and enums (DeviceType, etc.)
+├── api/swagger/         - Generated Swagger specs
+├── web/                 - React frontend (Vite + pnpm)
+│   └── src/
+│       ├── api/         - Typed API client layer
+│       ├── components/  - Reusable UI components (MUI v5)
+│       ├── hooks/       - Custom React hooks
+│       ├── pages/       - Route-level page components
+│       └── stores/      - Client state (Zustand)
+├── plugins/             - Plugin system
+├── .github/             - CI workflows and Copilot config
+└── CLAUDE.md            - Claude Code instructions
+```
+
+## Code Style
+
+- Conventional commits: `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`
+- Co-author tag: `Co-Authored-By: GitHub Copilot <noreply@github.com>`
+- Errors wrapped with context: `fmt.Errorf("operation: %w", err)`
+- Table-driven tests with `t.Run` and descriptive names
+- All lint checks must pass before committing (golangci-lint v2)
+
+## Coding Guidelines
+
+- Fix errors immediately -- never classify them as pre-existing
+- Build, test, and lint must pass before any commit
+- Never skip hooks (`--no-verify`) or force-push main
+- Validate only at system boundaries (user input, external APIs)
+- Remove unused code completely; no backwards-compatibility hacks
+
+## Available Resources
+
+```bash
+make build        # Compile server, scout, and dashboard
+make test         # Run all Go tests
+make lint         # Run golangci-lint
+make swagger      # Regenerate API spec from handler annotations
+go build ./...    # Direct build verification
+go test ./...     # Direct test run
+```
+
+## Do NOT
+
+- Add `//nolint` directives without fixing the root cause first
+- Use `any` in TypeScript or suppress TypeScript errors with `as unknown`
+- Commit generated files without regenerating them first
+- Add dependencies without updating the lock file
+- Use `panic` in library code; return errors instead
+- Store secrets, tokens, or credentials in code or config files
+- Mark work as complete when known errors remain

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -1,0 +1,121 @@
+---
+applyTo: "**/*.go"
+---
+
+# Go Coding Instructions
+
+## Error Handling
+
+Always wrap errors with context using `fmt.Errorf`:
+
+```go
+// GOOD: wraps error with context
+if err != nil {
+    return fmt.Errorf("fetch device %s: %w", id, err)
+}
+
+// BAD: discards context
+if err != nil {
+    return err
+}
+```
+
+Never return `(result, nil)` when `err != nil`. Propagate both:
+
+```go
+// GOOD: nilerr compliant
+return &Result{Message: runErr.Error()}, fmt.Errorf("run: %w", runErr)
+```
+
+## Named Returns
+
+When golangci-lint flags `unnamedResult`, add named returns. After adding names,
+change `:=` to `=` for those variables and remove redundant `var` declarations:
+
+```go
+// GOOD: named returns, = not :=
+func compute(data []float64) (score float64, detail string) {
+    switch {
+    case len(data) == 0:
+        detail = "no data"
+    default:
+        score = average(data)
+        detail = fmt.Sprintf("n=%d", len(data))
+    }
+    return score, detail
+}
+```
+
+## Lint Patterns (golangci-lint v2)
+
+Fix these before committing:
+
+- **rangeValCopy**: `for _, v := range slice` on structs >64 bytes -- use `for i := range slice { slice[i]... }`
+- **prealloc**: `var result []T` in a loop -- use `make([]T, 0, len(source))`
+- **appendCombine**: two consecutive `append()` to same slice -- combine into one call
+- **emptyStringTest**: `len(s) > 0` -- use `s != ""`
+- **httpNoBody**: `http.NewRequestWithContext(ctx, method, url, nil)` -- use `http.NoBody`
+- **bodyclose**: always close `resp.Body`, including deferred: `defer func() { _ = resp.Body.Close() }()`
+- **exhaustive**: switch on enum types must list ALL cases explicitly
+- **noctx**: use `ExecContext`, `QueryContext`, `QueryRowContext` instead of context-less variants
+- **paramTypeCombine**: `(a int, b int)` -- combine consecutive same-type params to `(a, b int)`
+- **builtinShadow**: don't use `new`, `make`, `len`, `cap`, `close`, `delete`, `copy`, `append`, `min`, `max`, `clear` as parameter names
+- **gosec G101**: constants named like credentials (containing "password", "token", "secret") need `//nolint:gosec // G101: <reason>`
+- **preferFprint**: `b.WriteString(fmt.Sprintf(...))` -- use `fmt.Fprintf(&b, ...)` instead
+- **dupBranchBody**: identical `if`/`else` branches -- remove the conditional, keep just the body
+- **sloppyReassign**: `if err = f(); err != nil` with named return `err` -- use `:=` to shadow instead
+
+## Testing
+
+Use table-driven tests with `t.Run`:
+
+```go
+func TestSomething(t *testing.T) {
+    tests := []struct {
+        name    string
+        input   string
+        want    int
+        wantErr bool
+    }{
+        {name: "valid input", input: "abc", want: 3},
+        {name: "empty input", input: "", wantErr: true},
+    }
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            got, err := Something(tt.input)
+            if (err != nil) != tt.wantErr {
+                t.Errorf("error = %v, wantErr %v", err, tt.wantErr)
+            }
+            if got != tt.want {
+                t.Errorf("got %v, want %v", got, tt.want)
+            }
+        })
+    }
+}
+```
+
+## HTTP Handlers (Go 1.22+)
+
+Use Go 1.22 enhanced `ServeMux` patterns:
+
+```go
+mux.HandleFunc("GET /items/{id}", h.getItem)
+mux.HandleFunc("POST /items", h.createItem)
+```
+
+Always name `*http.Request` parameter even if unused -- expanding stubs later requires it.
+
+## Imports
+
+Group imports in three blocks separated by blank lines:
+
+```go
+import (
+    "context"
+    "fmt"
+
+    "github.com/external/pkg"
+
+    "github.com/HerbHall/subnetree/internal/models"
+)
+```

--- a/.github/instructions/react.instructions.md
+++ b/.github/instructions/react.instructions.md
@@ -1,0 +1,147 @@
+---
+applyTo: "web/**/*.{ts,tsx}"
+---
+
+# React/TypeScript Coding Instructions
+
+## Component Patterns
+
+Define props interfaces above the component, use functional components:
+
+```tsx
+interface ItemCardProps {
+    id: string
+    label: string
+    onSelect: (id: string) => void
+}
+
+export function ItemCard({ id, label, onSelect }: ItemCardProps) {
+    return <button onClick={() => onSelect(id)}>{label}</button>
+}
+```
+
+## State Management
+
+- **TanStack Query** for all server state (fetching, caching, mutations)
+- **Zustand** or `useState` for client-only UI state
+- **No `useEffect` for data syncing** -- use nullable local override instead:
+
+```tsx
+// GOOD: nullable override, no useEffect sync
+const { data: serverValue } = useQuery({ queryKey: ['config'], queryFn: getConfig })
+const [localOverride, setLocalOverride] = useState<string | null>(null)
+const displayValue = localOverride ?? serverValue ?? ''
+
+// Reset on save success to re-sync from server
+onSuccess: () => { setLocalOverride(null); queryClient.invalidateQueries(['config']) }
+```
+
+## API Integration
+
+Always use the typed API layer; never call `fetch` directly from components:
+
+```tsx
+// mutations invalidate relevant queries on success
+const mutation = useMutation({ mutationFn: updateItem, onSuccess: () =>
+    queryClient.invalidateQueries({ queryKey: ['items'] })
+})
+```
+
+## Union Return Types
+
+When a function returns a union type, add a type guard and use it at EVERY call site:
+
+```tsx
+// BAD: TS2339 -- access_token not on union
+const result = await loginApi(user, pass)
+setToken(result.access_token)
+
+// GOOD: narrow first
+const result = await loginApi(user, pass)
+if (isMFAChallenge(result)) throw new Error('unexpected MFA')
+setToken(result.access_token)
+```
+
+## TypeScript
+
+- Strict mode -- no `any`; use `unknown` with type guards
+- JSX short-circuit: `{expanded && item.details != null && <div/>}` (use `!= null`, not bare `&&` on `unknown`)
+- Unused imports: ESLint catches these even when `tsc` does not -- verify every named import is used
+
+## React Compiler Lint
+
+Do not mutate `ref.current` during render -- wrap in `useEffect`:
+
+```tsx
+// BAD: ref mutation during render
+onMessageRef.current = onMessage
+
+// GOOD: wrap in effect
+useEffect(() => { onMessageRef.current = onMessage }, [onMessage])
+```
+
+For Popper/Popover anchor elements, use callback ref with `useState` instead of `useRef`:
+
+```tsx
+// GOOD: callback ref avoids reading ref.current during render
+const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
+<Button ref={setAnchorEl}>Menu</Button>
+<Popper anchorEl={anchorEl} open={open}>...</Popper>
+```
+
+## Recharts Tooltips
+
+Custom tooltip components receive empty `{}` props initially. Use `Partial<>`:
+
+```tsx
+function CustomTooltip({ active, payload }: Partial<TooltipContentProps<number, string>>) {
+    if (!active || !payload?.length) return null
+    // ...
+}
+```
+
+## UI Components (MUI v5)
+
+This project uses MUI v5 via `@mui/material`. Key patterns:
+
+- Use `InputProps` (not `slotProps.input`) for TextField adornments
+- Use `SelectProps` for Select customization
+- Use `inputProps` (lowercase `i`) for native input HTML attributes
+- Always reference MUI v5 documentation -- current MUI docs default to v6 syntax
+
+```tsx
+// GOOD: MUI v5 TextField with adornment
+<TextField
+    InputProps={{
+        startAdornment: <InputAdornment position="start"><SearchIcon /></InputAdornment>
+    }}
+/>
+
+// BAD: MUI v6 syntax -- does not work with MUI v5
+<TextField slotProps={{ input: { startAdornment: ... } }} />
+```
+
+For Tooltip wrapping disabled buttons, add a `<span>` wrapper:
+
+```tsx
+<Tooltip title="Refresh">
+    <span>
+        <IconButton disabled={loading}><RefreshIcon /></IconButton>
+    </span>
+</Tooltip>
+```
+
+## Testing
+
+Vitest + Testing Library. Prefer `mergeConfig(viteConfig, defineConfig(...))` so Vite
+plugins and defines are inherited:
+
+```ts
+// vitest.config.ts
+import { mergeConfig, defineConfig } from 'vitest/config'
+import viteConfig from './vite.config'
+
+export default mergeConfig(viteConfig, defineConfig({
+    test: { environment: 'jsdom', globals: true, setupFiles: './src/test-setup.ts' }
+}))
+```

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,39 @@
+name: Copilot Setup Steps
+
+on: workflow_dispatch
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+
+      - name: Download Go modules
+        run: go mod download
+
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Install frontend dependencies
+        run: pnpm install
+        working-directory: web
+
+      - name: Verify Go build
+        run: go build ./...
+
+      - name: Verify TypeScript compilation
+        run: npx tsc --noEmit
+        working-directory: web

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,184 @@
+<!--
+  Scope: AGENTS.md guides the Copilot coding agent and Copilot Chat.
+  For code completion and code review patterns, see .github/copilot-instructions.md
+  and .github/instructions/*.instructions.md
+  For Claude Code, see CLAUDE.md
+-->
+
+# SubNetree
+
+Network monitoring and infrastructure management platform for home labs and small
+networks. Discovers devices, maps topology, monitors health, and provides a React
+dashboard.
+
+## Tech Stack
+
+- **Backend**: Go 1.25, standard library HTTP server (Go 1.22+ enhanced ServeMux)
+- **Frontend**: React 19, TypeScript, MUI v5, TanStack Query, Recharts
+- **Database**: SQLite (via `modernc.org/sqlite`, pure-Go driver)
+- **API**: REST with Swagger (swaggo/swag), WebSocket for real-time events
+- **Build**: Make, Docker multi-stage
+- **Lint**: golangci-lint v2 (Go), ESLint + TypeScript strict (frontend)
+- **Test**: Go `testing` package, Vitest + Testing Library (frontend)
+
+## Build and Test Commands
+
+```bash
+# Build
+make build          # Build dashboard, server, and scout binaries
+
+# Test
+make test           # Run all Go tests
+make test-race      # Run Go tests with race detection
+
+# Lint
+make lint           # Run golangci-lint
+
+# Swagger
+make swagger        # Regenerate API spec from handler annotations
+
+# Frontend
+cd web && pnpm install && pnpm run build   # Build frontend
+cd web && pnpm run lint                    # Lint frontend
+cd web && npx tsc --noEmit                 # TypeScript check
+```
+
+## Project Structure
+
+```text
+SubNetree/
+├── cmd/
+│   ├── subnetree/       - Main server entry point
+│   └── scout/           - Network scout agent binary
+├── internal/
+│   ├── auth/            - JWT authentication and authorization
+│   ├── config/          - Configuration management (Viper)
+│   ├── dashboard/       - Dashboard aggregation module
+│   ├── gateway/         - SSH gateway module
+│   ├── insight/         - Analytics and anomaly detection
+│   ├── llm/             - LLM integration (Ollama)
+│   ├── pulse/           - Health monitoring and alerting
+│   ├── recon/           - Network reconnaissance and discovery
+│   ├── scout/           - Scout agent coordination
+│   ├── server/          - HTTP server and middleware
+│   ├── settings/        - Runtime settings management
+│   ├── store/           - SQLite data access layer
+│   ├── vault/           - Secrets management (encrypted at rest)
+│   └── ...              - Additional internal packages
+├── pkg/models/          - Shared types (DeviceType, enums)
+├── api/swagger/         - Generated Swagger specs
+├── web/                 - React frontend (Vite + pnpm)
+│   └── src/
+│       ├── api/         - Typed API client layer
+│       ├── components/  - Reusable UI components
+│       ├── hooks/       - Custom React hooks
+│       ├── pages/       - Route-level page components
+│       └── stores/      - Client state (Zustand)
+├── plugins/             - Plugin system
+├── configs/             - Configuration templates
+├── deploy/              - Deployment configurations
+├── .github/             - CI workflows and Copilot config
+├── Makefile             - Build, test, lint targets
+└── CLAUDE.md            - Claude Code instructions
+```
+
+## Workflow Rules
+
+### Always Do
+
+- Create a feature branch for every change (`feature/issue-NNN-description`)
+- Use conventional commits: `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`
+- Run build, test, and lint before opening a PR
+- Write table-driven tests with descriptive names
+- Wrap errors with context: `fmt.Errorf("operation: %w", err)`
+- Fix every error you find, regardless of who introduced it
+
+### Ask First
+
+- Adding new dependencies (check if stdlib covers the need)
+- Architectural changes (new packages, major interface changes)
+- Database schema migrations
+- Changes to CI/CD workflows
+- Removing or renaming public APIs
+
+### Never Do
+
+- Commit directly to `main` -- always use feature branches
+- Skip tests or lint checks -- even for "small changes"
+- Use `--no-verify` or `--force` flags
+- Commit secrets, credentials, or API keys
+- Add TODO comments without a linked issue number
+- Mark work as complete when build, test, or lint failures remain
+
+## Core Principles
+
+These are unconditional -- no optimization or time pressure overrides them:
+
+1. **Quality**: Once found, always fix, never leave. There is no "pre-existing" error.
+2. **Verification**: Build, test, and lint must pass before any commit.
+3. **Safety**: Never force-push `main`. Never skip hooks. Never commit secrets.
+4. **Honesty**: Never mark work as complete when it is not.
+
+## Error Handling
+
+```go
+// Wrap errors with context -- every return site should add meaning
+if err != nil {
+    return fmt.Errorf("load config: %w", err)
+}
+
+// Use sentinel errors for caller-distinguishable conditions
+var ErrNotFound = errors.New("not found")
+if errors.Is(err, ErrNotFound) { ... }
+```
+
+## Testing Conventions
+
+```go
+// Table-driven tests with descriptive names
+func TestFunctionName(t *testing.T) {
+    tests := []struct {
+        name    string
+        input   string
+        want    string
+        wantErr bool
+    }{
+        {
+            name:  "valid input returns expected output",
+            input: "example",
+            want:  "result",
+        },
+        {
+            name:    "empty input returns error",
+            input:   "",
+            wantErr: true,
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            got, err := FunctionName(tt.input)
+            if (err != nil) != tt.wantErr {
+                t.Errorf("FunctionName() error = %v, wantErr %v", err, tt.wantErr)
+            }
+            if got != tt.want {
+                t.Errorf("FunctionName() = %v, want %v", got, tt.want)
+            }
+        })
+    }
+}
+```
+
+## Commit Format
+
+```text
+feat: add user authentication endpoint
+
+Implements JWT-based login and token refresh. Tokens expire after 1h.
+
+Closes #42
+Co-Authored-By: GitHub Copilot <copilot@github.com>
+```
+
+Types: `feat` (new feature), `fix` (bug fix), `refactor` (no behavior change),
+`docs` (documentation only), `test` (tests only), `chore` (build/tooling).


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` with three-tier boundaries (always/ask/never) for Copilot coding agent
- Add `.github/copilot-instructions.md` with project context for completions and code review
- Add `.github/workflows/copilot-setup-steps.yml` for coding agent dependency setup
- Add `.github/instructions/go.instructions.md` for Go-specific inline patterns
- Add `.github/instructions/react.instructions.md` for React/TypeScript/MUI v5 inline patterns

## Test plan

- [ ] Verify Copilot inline completions respect .instructions.md patterns
- [ ] Assign Copilot to a simple issue and verify setup-steps runs correctly
- [ ] Check that Copilot code review reads copilot-instructions.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)