### PR TITLE
feat: add release gate and nightly build workflows

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,187 @@
+name: Nightly Build
+
+# Builds and pushes a nightly Docker image from main.
+# Does NOT create a GitHub Release or git tag.
+# Useful for testing latest main without waiting for a formal release.
+
+on:
+  schedule:
+    - cron: '0 2 * * *' # Every day at 2 AM UTC
+  workflow_dispatch: # Manual trigger
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  check-changes:
+    name: Check for Changes
+    runs-on: ubuntu-latest
+    outputs:
+      has_changes: ${{ steps.check.outputs.has_changes }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for commits since last nightly
+        id: check
+        run: |
+          # Skip build if no commits in the last 24 hours
+          RECENT=$(git log --since="24 hours ago" --oneline origin/main | head -1)
+          if [ -n "$RECENT" ]; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "Changes found since last nightly"
+          else
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "No changes in last 24 hours, skipping build"
+          fi
+
+  build:
+    name: Nightly Docker Image
+    needs: check-changes
+    if: needs.check-changes.outputs.has_changes == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Build frontend
+        working-directory: web
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm run build
+
+      - name: Embed frontend in Go binary
+        run: |
+          rm -rf internal/dashboard/dist
+          cp -r web/dist internal/dashboard/dist
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate build metadata
+        id: meta
+        run: |
+          DATE=$(date -u +%Y%m%d)
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          echo "date=$DATE" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/herbhall/subnetree:nightly
+            ghcr.io/herbhall/subnetree:nightly-${{ steps.meta.outputs.date }}
+          build-args: |
+            VERSION=nightly-${{ steps.meta.outputs.date }}-${{ steps.meta.outputs.short_sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  binaries:
+    name: Nightly Binaries
+    needs: check-changes
+    if: needs.check-changes.outputs.has_changes == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+          - goos: windows
+            goarch: amd64
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Build frontend
+        working-directory: web
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm run build
+
+      - name: Embed frontend in Go binary
+        run: |
+          rm -rf internal/dashboard/dist
+          cp -r web/dist internal/dashboard/dist
+
+      - name: Build binary
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: '0'
+        run: |
+          DATE=$(date -u +%Y%m%d)
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          EXT=""
+          if [ "$GOOS" = "windows" ]; then EXT=".exe"; fi
+
+          go build -ldflags "\
+            -s -w \
+            -X github.com/HerbHall/subnetree/internal/version.Version=nightly-${DATE}-${SHORT_SHA} \
+            -X github.com/HerbHall/subnetree/internal/version.GitCommit=${SHORT_SHA} \
+            -X github.com/HerbHall/subnetree/internal/version.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            -o "subnetree-${GOOS}-${GOARCH}${EXT}" ./cmd/subnetree/
+
+          go build -ldflags "\
+            -s -w \
+            -X github.com/HerbHall/subnetree/internal/version.Version=nightly-${DATE}-${SHORT_SHA} \
+            -X github.com/HerbHall/subnetree/internal/version.GitCommit=${SHORT_SHA} \
+            -X github.com/HerbHall/subnetree/internal/version.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            -o "scout-${GOOS}-${GOARCH}${EXT}" ./cmd/scout/
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: nightly-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: |
+            subnetree-*
+            scout-*
+          retention-days: 7

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -1,0 +1,170 @@
+name: Release Gate
+
+# Evaluates release-please PRs and auto-merges when criteria are met.
+#
+# Release tiers:
+#   Immediate  - Critical/security fix → auto-merge now
+#   Threshold  - Minor bump (features) OR 5+ patch fixes → auto-merge
+#   Batched    - Below threshold → stays open for manual merge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  evaluate:
+    name: Evaluate Release
+    if: >-
+      github.event.pull_request.user.login == 'github-actions[bot]' &&
+      contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
+    runs-on: ubuntu-latest
+    outputs:
+      decision: ${{ steps.gate.outputs.decision }}
+      reason: ${{ steps.gate.outputs.reason }}
+      version_from: ${{ steps.gate.outputs.version_from }}
+      version_to: ${{ steps.gate.outputs.version_to }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Evaluate release criteria
+        id: gate
+        run: |
+          set -euo pipefail
+
+          # Get version info
+          CURRENT=$(git show origin/main:.release-please-manifest.json | jq -r '."."')
+          NEW=$(jq -r '."."' .release-please-manifest.json)
+          echo "version_from=$CURRENT" >> "$GITHUB_OUTPUT"
+          echo "version_to=$NEW" >> "$GITHUB_OUTPUT"
+
+          CUR_MAJOR=$(echo "$CURRENT" | cut -d. -f1)
+          CUR_MINOR=$(echo "$CURRENT" | cut -d. -f2)
+          NEW_MAJOR=$(echo "$NEW" | cut -d. -f1)
+          NEW_MINOR=$(echo "$NEW" | cut -d. -f2)
+
+          # Get commits since last release tag
+          LAST_TAG=$(git describe --tags --abbrev=0 origin/main 2>/dev/null || echo "")
+          if [ -n "$LAST_TAG" ]; then
+            COMMIT_LOG=$(git log "${LAST_TAG}..origin/main" --format="%s" 2>/dev/null || echo "")
+          else
+            COMMIT_LOG=$(git log origin/main --format="%s" 2>/dev/null || echo "")
+          fi
+
+          # Count changelog entries by type
+          FEAT_COUNT=$(echo "$COMMIT_LOG" | grep -c "^feat" || true)
+          FIX_COUNT=$(echo "$COMMIT_LOG" | grep -c "^fix" || true)
+          TOTAL=$((FEAT_COUNT + FIX_COUNT))
+
+          echo "Commits since $LAST_TAG: feat=$FEAT_COUNT fix=$FIX_COUNT total=$TOTAL"
+          echo "Version: $CURRENT -> $NEW"
+
+          # Tier 1: Immediate - critical/security fix
+          HAS_CRITICAL=false
+          if echo "$COMMIT_LOG" | grep -qiE '^fix!:|BREAKING CHANGE'; then
+            HAS_CRITICAL=true
+          fi
+          if echo "$COMMIT_LOG" | grep -qiE 'CVE-|security|vulnerability|critical'; then
+            HAS_CRITICAL=true
+          fi
+
+          if [ "$HAS_CRITICAL" = "true" ]; then
+            echo "decision=immediate" >> "$GITHUB_OUTPUT"
+            echo "reason=Critical or security fix detected" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Tier 2: Threshold - minor/major bump OR 5+ accumulated fixes
+          if [ "$NEW_MAJOR" -gt "$CUR_MAJOR" ]; then
+            echo "decision=threshold" >> "$GITHUB_OUTPUT"
+            echo "reason=Major version bump ($CURRENT -> $NEW)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$NEW_MINOR" -gt "$CUR_MINOR" ]; then
+            echo "decision=threshold" >> "$GITHUB_OUTPUT"
+            echo "reason=Minor version bump with $FEAT_COUNT feature(s) ($CURRENT -> $NEW)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$FIX_COUNT" -ge 5 ]; then
+            echo "decision=threshold" >> "$GITHUB_OUTPUT"
+            echo "reason=$FIX_COUNT bug fixes accumulated ($CURRENT -> $NEW)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Below threshold - stay batched
+          echo "decision=batched" >> "$GITHUB_OUTPUT"
+          echo "reason=Patch only with $TOTAL change(s), below threshold ($CURRENT -> $NEW)" >> "$GITHUB_OUTPUT"
+
+      - name: Label PR with decision
+        run: |
+          DECISION="${{ steps.gate.outputs.decision }}"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+
+          # Remove old release labels
+          gh pr edit "$PR_NUMBER" --remove-label "release:auto" 2>/dev/null || true
+          gh pr edit "$PR_NUMBER" --remove-label "release:batched" 2>/dev/null || true
+
+          if [ "$DECISION" = "immediate" ] || [ "$DECISION" = "threshold" ]; then
+            gh label create "release:auto" --color "0E8A16" --description "Auto-release approved" --force 2>/dev/null || true
+            gh pr edit "$PR_NUMBER" --add-label "release:auto"
+          else
+            gh label create "release:batched" --color "FBCA04" --description "Batched, waiting for threshold" --force 2>/dev/null || true
+            gh pr edit "$PR_NUMBER" --add-label "release:batched"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Post decision comment
+        run: |
+          DECISION="${{ steps.gate.outputs.decision }}"
+          REASON="${{ steps.gate.outputs.reason }}"
+          FROM="${{ steps.gate.outputs.version_from }}"
+          TO="${{ steps.gate.outputs.version_to }}"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+
+          if [ "$DECISION" = "immediate" ] || [ "$DECISION" = "threshold" ]; then
+            ICON="🟢"
+            ACTION="Auto-merge enabled."
+          else
+            ICON="🟡"
+            ACTION="Waiting for more changes or manual merge."
+          fi
+
+          BODY=$(cat <<EOF
+          ### $ICON Release Gate: \`$DECISION\`
+
+          **Version**: $FROM → $TO
+          **Reason**: $REASON
+          **Action**: $ACTION
+          EOF
+          )
+
+          # Delete previous bot gate comments to avoid spam
+          gh api "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
+            --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | contains("Release Gate"))) | .id' \
+            | xargs -I{} gh api -X DELETE "repos/${{ github.repository }}/issues/comments/{}" 2>/dev/null || true
+
+          gh pr comment "$PR_NUMBER" --body "$BODY"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  auto-merge:
+    name: Auto-merge Release
+    needs: evaluate
+    if: needs.evaluate.outputs.decision == 'immediate' || needs.evaluate.outputs.decision == 'threshold'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge
+        run: |
+          gh pr merge "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --squash --auto
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds **release-gate.yml** — evaluates release-please PRs and auto-merges when criteria are met
- Adds **nightly.yml** — scheduled Docker image + binary builds from main

## Release Gate Tiers

| Tier | Trigger | Action |
|------|---------|--------|
| **Immediate** | `fix!:`, CVE, security/vulnerability in commits | Auto-merge now |
| **Threshold** | Minor+ bump (has features) OR 5+ accumulated fixes | Auto-merge |
| **Batched** | Below threshold | Stays open, labels `release:batched` |

The workflow posts a comment on the release-please PR explaining its decision and labels accordingly.

## Nightly Build

- Runs at 2 AM UTC, skips if no commits in last 24 hours
- Docker image pushed to GHCR: `nightly` and `nightly-YYYYMMDD`
- Cross-compiled binaries (5 platform/arch combos) as 7-day artifacts
- Manual trigger available via `workflow_dispatch`

## Test plan

- [ ] Verify release-gate triggers on release-please PR #524
- [ ] Verify nightly builds via manual workflow_dispatch
- [ ] Confirm auto-merge enables when threshold is met

🤖 Generated with [Claude Code](https://claude.com/claude-code)