### PR TITLE
chore: gitignore .claude/skills/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,8 @@ coverage.html
 *.swo
 *~
 
-# Claude Code local settings (user-specific, modified every session)
+# Claude Code local files (skills are machine-specific, settings.local is user-specific)
+.claude/skills/
 .claude/settings.local.json
 
 # OS

--- a/.samverk/status.md
+++ b/.samverk/status.md
@@ -1,6 +1,6 @@
 ---
 phase: delivery
-updated: 2026-04-07T09:00:00Z
+updated: 2026-04-07T10:30:00Z
 updated_by: claude-code
 ---
 
@@ -8,42 +8,43 @@ updated_by: claude-code
 
 ## Phase
 
-v0.6.3 release pending (release-please PR #529 open).
-All CI blockers resolved. Active UI/topology improvements in review.
+v0.6.3 release pending (release-please PR #529 open, auto-managed).
+All feature PRs merged. Zero open PRs besides release-please.
 
 ## Pending
 
-- PR #529: release-please v0.6.3 (auto-managed)
-- PR #555: Device hostname rename (#546)
-- PR #556: CODEOWNERS fix (#528)
-- PR #557: Dockerfile Go version pin
-- PR #562: Gateway link inference + unified toolbar + UI fixes (#559, #560)
+- PR #529: release-please v0.6.3 (auto-managed, merges when ready)
 
 ## Next Actions
 
-- #561: Collapse unclassified devices in topology (critical UX improvement)
-- Merge pending PRs after CI green
-- Phase 1A Docker Desktop validation (#493) -- partially complete, QC passed
+- #493-#498: deployment validation phases (human hardware work)
+- #487: community engagement launch prep
+- #499: content capture for community launch
+- #489: Ansible dynamic inventory plugin (Phase 3+)
 
 ## Recently Completed
+
+Session 2026-04-07 (massive catchup):
 
 - Fixed govulncheck CI blocker (#552): Go 1.25.8, grpc, go-sdk, sqlite
 - Batch dep bumps (#554): grpc v1.80.0, x/crypto, x/net, x/time
 - Merged 10 Dependabot + CI PRs, closed 10 superseded
-- Device hostname rename feature (#546 -> PR #555)
-- CODEOWNERS repair (#528 -> PR #556)
-- Topology: gateway link inference, unified toolbar, dashed inferred edges
+- Device hostname rename (#546 -> merged via #555)
+- CODEOWNERS repair (#528 -> merged via #556)
+- Dockerfile Go version pin (merged via #557)
+- Topology: gateway link inference + hierarchical edges (#559 -> merged via #562)
+- Topology: unified toolbar, dashed inferred edges (#558 -> merged via #562)
+- Topology: collapse unclassified devices (#561 -> merged via #563)
+- Topology: zoom limits for large device counts (#560 -> merged via #562)
 - Monitoring: wider trend sparklines with table-fixed layout
 - RouteErrorBoundary for chunk load errors
-- Docker QC testing: all endpoints pass, 101 MiB memory, persistence OK
+- Docker QC testing passed: all endpoints, 101 MiB memory, persistence OK
 
 ## Queued (Roadmap)
 
-- #489: Ansible dynamic inventory plugin
-- #487: community engagement launch prep
-- #499: content capture for community launch
-- #493-#498: deployment validation phases
-- #280, #286, #289: future roadmap (Phase 4+)
+- #280: multi-tenancy support (Phase 4+)
+- #286: IPv6 scanning (Phase 4+)
+- #289: PostgreSQL + TimescaleDB (Phase 4+)
 
 ## Start Here (Cold Start Protocol)
 


### PR DESCRIPTION
## Summary

`.claude/skills/` contains machine-local Claude Code skill files (21 files) that were showing as untracked in VS Code Source Control. Added to `.gitignore`.

Also updates `.samverk/status.md` with session progress.

## Test plan

- [x] `git check-ignore .claude/skills/dashboard/SKILL.md` returns ignored
- [x] Tracked `.claude/` files (CLAUDE.md, settings.json, rules/) unaffected
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)