### PR TITLE
fix: auto-fit topology viewport to readable node size

### DIFF
--- a/web/src/components/topology/topology-toolbar.tsx
+++ b/web/src/components/topology/topology-toolbar.tsx
@@ -212,7 +212,7 @@ export const TopologyToolbar = memo(function TopologyToolbar({
         <ZoomOut className="h-4 w-4" />
       </button>
       <button
-        onClick={() => fitView({ duration: 300, padding: 0.2 })}
+        onClick={() => fitView({ duration: 300, padding: 0.2, minZoom: 0.3 })}
         title="Fit to view"
         className="rounded-md p-1.5 transition-colors hover:bg-[var(--nv-bg-hover)]"
         style={{ color: 'var(--nv-text-secondary)' }}

--- a/web/src/pages/topology.tsx
+++ b/web/src/pages/topology.tsx
@@ -466,6 +466,13 @@ export function TopologyPage() {
   const [nodes, setNodes, onNodesChangeRaw] = useNodesState(initialNodes)
   const [edges, setEdges, onEdgesChangeRaw] = useEdgesState(initialEdges)
 
+  const fitViewOptions = useMemo(() => {
+    const count = initialNodes.length
+    if (count <= 10) return { padding: 0.3, minZoom: 0.8, maxZoom: 1.2 }
+    if (count <= 30) return { padding: 0.2, minZoom: 0.5, maxZoom: 1.0 }
+    return { padding: 0.15, minZoom: 0.3, maxZoom: 0.8 }
+  }, [initialNodes.length])
+
   useEffect(() => { setNodes(initialNodes) }, [initialNodes, setNodes])
   useEffect(() => { setEdges(initialEdges) }, [initialEdges, setEdges])
 
@@ -642,7 +649,7 @@ export function TopologyPage() {
         onNodeClick={handleNodeClick} onEdgeClick={handleEdgeClick} onPaneClick={handlePaneClick}
         nodeTypes={nodeTypes} edgeTypes={edgeTypes}
         minZoom={0.05} maxZoom={4} fitView
-        fitViewOptions={{ padding: 0.2, minZoom: 0.15, maxZoom: 1.5 }}
+        fitViewOptions={fitViewOptions}
         proOptions={{ hideAttribution: true }}
         className="rounded-lg" style={{ backgroundColor: 'var(--nv-bg-surface)' }}
       >


### PR DESCRIPTION
## Summary

- Computes dynamic `fitViewOptions` based on device count so topology nodes are always readable on initial load
- 1-10 devices: zoom 0.8-1.2x with 30% padding (large, comfortable)
- 11-30 devices: zoom 0.5-1.0x with 20% padding (readable)
- 31+ devices: zoom 0.3-0.8x with 15% padding (compact but legible)
- Toolbar "fit to view" button also enforces minZoom=0.3 to prevent manual fit from zooming to illegible levels
- Global minZoom (0.05) preserved so users can still manually zoom out further if needed

Closes #560

## Test plan

- [ ] Load topology with 1-5 devices -- nodes should be large and readable without manual zoom
- [ ] Load topology with 15-20 devices -- nodes should be medium-sized but text clearly legible
- [ ] Load topology with 40+ devices -- nodes compact but hostnames/IPs still readable
- [ ] Click toolbar "fit to view" button -- should snap to readable zoom, not tiny stamps
- [ ] Manual zoom out past the fit level should still work (scroll wheel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)