### PR TITLE
chore(web): bump eslint-plugin-react-hooks + recharts, fix 2 anti-patterns

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -54,7 +54,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router-dom": "^7.13.0",
-    "recharts": "3.7.0",
+    "recharts": "^3.8.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
     "zustand": "^5.0.11"
@@ -74,7 +74,7 @@
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-jsx-a11y": "^6.10.2",
-    "eslint-plugin-react-hooks": "7.0.1",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.0",
     "happy-dom": "^20.8.9",
     "playwright": "^1.58.2",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -66,8 +66,8 @@ importers:
         specifier: ^7.13.0
         version: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       recharts:
-        specifier: 3.7.0
-        version: 3.7.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@19.2.5)(react@19.2.5)(redux@5.0.1)
+        specifier: ^3.8.1
+        version: 3.8.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@19.2.5)(react@19.2.5)(redux@5.0.1)
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -121,8 +121,8 @@ importers:
         specifier: ^6.10.2
         version: 6.10.2(eslint@9.39.4(jiti@1.21.7))
       eslint-plugin-react-hooks:
-        specifier: 7.0.1
-        version: 7.0.1(eslint@9.39.4(jiti@1.21.7))
+        specifier: ^7.1.1
+        version: 7.1.1(eslint@9.39.4(jiti@1.21.7))
       eslint-plugin-react-refresh:
         specifier: ^0.5.0
         version: 0.5.2(eslint@9.39.4(jiti@1.21.7))
@@ -1618,11 +1618,11 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
 
-  eslint-plugin-react-hooks@7.0.1:
-    resolution: {integrity: sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==}
+  eslint-plugin-react-hooks@7.1.1:
+    resolution: {integrity: sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==}
     engines: {node: '>=18'}
     peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
 
   eslint-plugin-react-refresh@0.5.2:
     resolution: {integrity: sha512-hmgTH57GfzoTFjVN0yBwTggnsVUF2tcqi7RJZHqi9lIezSs4eFyAMktA68YD4r5kNw1mxyY4dmkyoFDb3FIqrA==}
@@ -2387,8 +2387,8 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
-  recharts@3.7.0:
-    resolution: {integrity: sha512-l2VCsy3XXeraxIID9fx23eCb6iCBsxUQDnE8tWm6DFdszVAO7WVY/ChAD9wVit01y6B2PMupYiMmQwhgPHc9Ew==}
+  recharts@3.8.1:
+    resolution: {integrity: sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -4329,7 +4329,7 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-react-hooks@7.0.1(eslint@9.39.4(jiti@1.21.7)):
+  eslint-plugin-react-hooks@7.1.1(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/parser': 7.29.2
@@ -5058,7 +5058,7 @@ snapshots:
     dependencies:
       picomatch: 2.3.2
 
-  recharts@3.7.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@19.2.5)(react@19.2.5)(redux@5.0.1):
+  recharts@3.8.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@19.2.5)(react@19.2.5)(redux@5.0.1):
     dependencies:
       '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.5)(redux@5.0.1))(react@19.2.5)
       clsx: 2.1.1

--- a/web/src/components/settings/color-picker.tsx
+++ b/web/src/components/settings/color-picker.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { RotateCcw } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -60,11 +60,16 @@ export function ColorPicker({
 }: ColorPickerProps) {
   const label = varName.replace('--nv-', '')
   const showColorInput = isColorValue(value) || isColorValue(defaultValue)
+  // Local editable copy of `value` so mid-edit strings (e.g. "#12") don't
+  // propagate upstream until length >= 3. Sync when the prop changes externally
+  // (e.g. reset button) using the "adjusting state on prop change" pattern:
+  // https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
   const [textValue, setTextValue] = useState(value)
-
-  useEffect(() => {
+  const [lastSyncedValue, setLastSyncedValue] = useState(value)
+  if (value !== lastSyncedValue) {
+    setLastSyncedValue(value)
     setTextValue(value)
-  }, [value])
+  }
 
   function handleTextChange(newValue: string) {
     setTextValue(newValue)

--- a/web/src/components/time-series-chart.tsx
+++ b/web/src/components/time-series-chart.tsx
@@ -51,7 +51,12 @@ function formatXAxisTick(timestamp: string, range: MetricRange): string {
   return `${String(date.getMonth() + 1).padStart(2, '0')}/${String(date.getDate()).padStart(2, '0')}`
 }
 
-function CustomTooltip({ active, payload, label, metric }: TooltipContentProps<number, string> & { metric: MetricName }) {
+function CustomTooltip({
+  active,
+  payload,
+  label,
+  metric,
+}: Partial<TooltipContentProps<number, string>> & { metric: MetricName }) {
   if (!active || !payload || payload.length === 0) return null
 
   const cfg = metricConfig[metric]
@@ -129,11 +134,7 @@ export function TimeSeriesChart({ data, metric, range, loading, className }: Tim
             }}
             width={50}
           />
-          <Tooltip
-            content={(props: TooltipContentProps<number, string>) => (
-              <CustomTooltip {...props} metric={metric} />
-            )}
-          />
+          <Tooltip content={<CustomTooltip metric={metric} />} />
           <Area
             type="monotone"
             dataKey="displayValue"

--- a/web/src/pages/setup.tsx
+++ b/web/src/pages/setup.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { useAuthStore } from '@/stores/auth'
 import { setupApi, loginApi, checkSetupRequired, isMFAChallenge } from '@/api/auth'
-import { getNetworkInterfaces, setScanInterface, type NetworkInterface } from '@/api/settings'
+import { getNetworkInterfaces, setScanInterface } from '@/api/settings'
 import { setActiveTheme } from '@/api/themes'
 import { getHealth } from '@/api/system'
 import { detectColorScheme } from '@/lib/theme-preference'
@@ -110,8 +110,16 @@ export function SetupPage() {
   const [errors, setErrors] = useState<FormErrors>({})
   const [apiError, setApiError] = useState('')
   const [loading, setLoading] = useState(false)
-  const [interfaces, setInterfaces] = useState<NetworkInterface[]>([])
-  const [interfacesLoading, setInterfacesLoading] = useState(false)
+  const {
+    data: interfaces = [],
+    isLoading: interfacesLoading,
+    error: interfacesError,
+  } = useQuery({
+    queryKey: ['network-interfaces'],
+    queryFn: getNetworkInterfaces,
+    enabled: step === 2,
+    staleTime: 5 * 60 * 1000,
+  })
   const [showPassword, setShowPassword] = useState(false)
   const setTokens = useAuthStore((s) => s.setTokens)
   const navigate = useNavigate()
@@ -136,22 +144,6 @@ export function SetupPage() {
       .finally(() => setCheckingStatus(false))
   }, [])
 
-  // Fetch network interfaces when entering step 2
-  useEffect(() => {
-    if (step === 2 && interfaces.length === 0) {
-      setInterfacesLoading(true)
-      getNetworkInterfaces()
-        .then((data) => {
-          setInterfaces(data)
-        })
-        .catch((err) => {
-          setApiError(err instanceof Error ? err.message : 'Failed to load network interfaces')
-        })
-        .finally(() => {
-          setInterfacesLoading(false)
-        })
-    }
-  }, [step, interfaces.length])
 
   const passwordStrength = useMemo(
     () => getPasswordStrength(formData.password),
@@ -538,7 +530,19 @@ export function SetupPage() {
                     </label>
                   ))}
 
-                  {interfaces.length === 0 && !interfacesLoading && (
+                  {interfacesError && (
+                    <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-center">
+                      <p className="text-sm text-destructive">
+                        Failed to load network interfaces:{' '}
+                        {interfacesError instanceof Error
+                          ? interfacesError.message
+                          : 'Unknown error'}
+                        . Auto-detect will still work.
+                      </p>
+                    </div>
+                  )}
+
+                  {interfaces.length === 0 && !interfacesLoading && !interfacesError && (
                     <div className="rounded-lg border border-dashed border-muted-foreground/25 p-4 text-center">
                       <p className="text-sm text-muted-foreground">
                         No network interfaces found. SubNetree will use auto-detection.

--- a/web/src/pages/timeline.tsx
+++ b/web/src/pages/timeline.tsx
@@ -387,7 +387,7 @@ export function TimelinePage() {
                   allowDecimals={false}
                   width={40}
                 />
-                <Tooltip content={(props: TooltipContentProps<number, string>) => <ChartTooltip {...props} />} />
+                <Tooltip content={<ChartTooltip />} />
                 {eventTypes.map((type) => {
                   const typeKey = type.replace(/\./g, '_')
                   const cfg = EVENT_TYPE_CONFIG[type]
@@ -556,7 +556,7 @@ export function TimelinePage() {
 // Chart tooltip
 // ---------------------------------------------------------------------------
 
-function ChartTooltip({ active, payload, label }: TooltipContentProps<number, string>) {
+function ChartTooltip({ active, payload, label }: Partial<TooltipContentProps<number, string>>) {
   if (!active || !payload || payload.length === 0) return null
 
   const total = payload.reduce((sum, item) => sum + ((item.value as number) || 0), 0)


### PR DESCRIPTION
Closes #582. Follow-up to PR #581.

## Summary

Undoes the exact-version pins introduced by PR #581 (security hotfix scope control) and refactors the code each bump revealed.

**Bumps:**
- `eslint-plugin-react-hooks`: `7.0.1` → `^7.1.1` (adds `react-hooks/set-state-in-effect` rule)
- `recharts`: `3.7.0` → `^3.8.1` (tighter `<Tooltip content>` render-function type)

## Refactors

### 1. `color-picker.tsx` — derived-state anti-pattern

Replaced `useEffect(() => setTextValue(value), [value])` (mirroring a prop into local state) with React's official [\"adjust state on prop change\"](https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes) pattern: setState during render, guarded by a prev-value sentinel. Same behavior, no effect.

### 2. `setup.tsx` — setState-in-effect before async fetch

Migrated network-interfaces fetch from manual \`useState\` + \`useEffect\` + \`setState\` to TanStack Query with \`enabled: step === 2\`. Eliminates both state variables and the setState-in-effect. Errors now render inline in the interface list instead of routing through the global \`apiError\` banner (which stays dedicated to submit actions).

### 3. `time-series-chart.tsx` + `timeline.tsx` — Recharts Tooltip typing (KG#6)

Switched Recharts `<Tooltip>` from render-function form to JSX element form. Tooltip content component props typed as \`Partial<TooltipContentProps<...>>\` so Recharts' cloneElement injection satisfies TypeScript under 3.8+ stricter types.

## Test plan

- [x] \`pnpm type-check\` — clean
- [x] \`pnpm lint\` — clean (both setState-in-effect violations resolved)
- [x] \`pnpm test\` — 118/118 pass
- [ ] CI passes (build, lint, test, E2E)
- [ ] Manual QC: color picker reset button still syncs text input; setup wizard step 2 still loads interfaces and selects one; dashboard metric charts + timeline tooltips still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)