### PR TITLE
chore(status): sync session 2026-04-23 state file

### DIFF
--- a/.samverk/status.md
+++ b/.samverk/status.md
@@ -1,6 +1,6 @@
 ---
 phase: delivery
-updated: 2026-04-07T10:30:00Z
+updated: 2026-04-23T17:40:00Z
 updated_by: claude-code
 ---
 
@@ -8,37 +8,41 @@ updated_by: claude-code
 
 ## Phase
 
-v0.6.3 release pending (release-please PR #529 open, auto-managed).
-All feature PRs merged. Zero open PRs besides release-please.
+Post-PR cleanup. Main is at 2113239. Zero open PRs. Open Dependabot alerts: 0.
 
 ## Pending
-
-- PR #529: release-please v0.6.3 (auto-managed, merges when ready)
-
-## Next Actions
 
 - #493-#498: deployment validation phases (human hardware work)
 - #487: community engagement launch prep
 - #499: content capture for community launch
-- #489: Ansible dynamic inventory plugin (Phase 3+)
+
+## Next Actions
+
+- #493-#498: Docker Desktop / UNRAID / Proxmox validation
+- #499: content capture for community launch
+- #286: IPv6 scanning (Phase 4+)
 
 ## Recently Completed
 
-Session 2026-04-07 (massive catchup):
+Session 2026-04-23 (3 PRs merged, 6 Dependabot alerts cleared):
 
-- Fixed govulncheck CI blocker (#552): Go 1.25.8, grpc, go-sdk, sqlite
-- Batch dep bumps (#554): grpc v1.80.0, x/crypto, x/net, x/time
-- Merged 10 Dependabot + CI PRs, closed 10 superseded
-- Device hostname rename (#546 -> merged via #555)
-- CODEOWNERS repair (#528 -> merged via #556)
-- Dockerfile Go version pin (merged via #557)
-- Topology: gateway link inference + hierarchical edges (#559 -> merged via #562)
-- Topology: unified toolbar, dashed inferred edges (#558 -> merged via #562)
-- Topology: collapse unclassified devices (#561 -> merged via #563)
-- Topology: zoom limits for large device counts (#560 -> merged via #562)
-- Monitoring: wider trend sparklines with table-fixed layout
-- RouteErrorBoundary for chunk load errors
-- Docker QC testing passed: all endpoints, 101 MiB memory, persistence OK
+- Merged PR #580 (7f41f77): Ansible dynamic inventory plugin + YAML export endpoint.
+  Closes #489. Fixes along the way: gofmt on `internal/recon/ansible.go`, Go toolchain
+  bump 1.25.8 -> 1.25.9 (stdlib CVE hotfix: GO-2026-4947/4946/4870/4869/4865), Dockerfile
+  golang:1.25.8-alpine -> 1.25.9-alpine sibling update.
+- Merged PR #581 (47a4729): Resolved 6 Dependabot alerts in web deps. happy-dom bump +
+  pnpm.overrides for minimatch/picomatch/flatted. Scoped PR kept narrow via exact pins on
+  recharts (3.7.0) and eslint-plugin-react-hooks (7.0.1); follow-up filed as #582.
+- Merged PR #583 (2113239): Closes #582. Unpinned both deps (eslint-plugin-react-hooks
+  ^7.1.1, recharts ^3.8.1) and refactored the code each bump revealed -- derived-state
+  effect in color-picker.tsx replaced with "adjust state on prop change" pattern;
+  setup.tsx network-interfaces fetch migrated to TanStack Query; two Recharts Tooltip
+  sites moved to JSX element form with Partial<TooltipContentProps<...>> per KG#6.
+- Claude Code plugin registry repaired (Windows profile case-drift; marketplaces
+  remove+re-add). Captured as SYN#5954 + devkit#274.
+- Autolearn: 4 new Synapset memories this session (#5954 plugin gotcha, #5956 pnpm
+  override requires clean install, #5957 caret-bump cascade needs exact-pin in scoped
+  PRs, #5958 Go toolchain Dockerfile sibling-update). DevKit issues filed: #274, #275.
 
 ## Queued (Roadmap)
 


### PR DESCRIPTION
## Summary

Updates \`.samverk/status.md\` to reflect end-of-session state on 2026-04-23 so Cold Start Protocol on the next session reads accurate context.

## Changes

- \`updated\` timestamp → 2026-04-23T17:40:00Z
- Main HEAD reference → \`2113239\`
- Pending list cleaned: #582 closed by #583, no open PRs besides this one
- Recently-completed list now lists PRs #580, #581, #583 with one-line summaries
- References the 4 new Synapset autolearn memories (#5954–#5958) + DevKit issues #274, #275

## Test plan

No code changes — documentation-only update. Markdown lint should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)