### PR TITLE
fix(web): sort device IP addresses numerically by octet

### DIFF
--- a/web/src/lib/ip.test.ts
+++ b/web/src/lib/ip.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { parseIpv4, compareIpAddresses } from './ip'
+
+describe('parseIpv4', () => {
+  it('parses a valid dotted-quad into four octets', () => {
+    expect(parseIpv4('192.168.1.12')).toEqual([192, 168, 1, 12])
+    expect(parseIpv4('0.0.0.0')).toEqual([0, 0, 0, 0])
+    expect(parseIpv4('255.255.255.255')).toEqual([255, 255, 255, 255])
+  })
+
+  it('rejects out-of-range octets', () => {
+    expect(parseIpv4('192.168.1.256')).toBeNull()
+    expect(parseIpv4('999.1.1.1')).toBeNull()
+  })
+
+  it('rejects malformed values', () => {
+    expect(parseIpv4('')).toBeNull()
+    expect(parseIpv4('192.168.1')).toBeNull()
+    expect(parseIpv4('192.168.1.1.1')).toBeNull()
+    expect(parseIpv4('192.168.1.')).toBeNull()
+    expect(parseIpv4('192.168.1.x')).toBeNull()
+    expect(parseIpv4(' 192.168.1.1')).toBeNull()
+  })
+
+  it('rejects IPv6 addresses', () => {
+    expect(parseIpv4('fe80::1')).toBeNull()
+    expect(parseIpv4('2001:db8::1')).toBeNull()
+  })
+})
+
+describe('compareIpAddresses', () => {
+  it('orders by numeric octet value, not lexicographically (issue #585)', () => {
+    // The original bug: "111" < "12" as strings, so .111 sorted before .12.
+    expect(compareIpAddresses('192.168.1.12', '192.168.1.111')).toBeLessThan(0)
+    expect(compareIpAddresses('192.168.1.111', '192.168.1.12')).toBeGreaterThan(0)
+  })
+
+  it('sorts a realistic list of same-subnet IPs ascending', () => {
+    const sorted = ['192.168.1.111', '192.168.1.2', '192.168.1.12', '192.168.1.20'].sort(
+      compareIpAddresses
+    )
+    expect(sorted).toEqual(['192.168.1.2', '192.168.1.12', '192.168.1.20', '192.168.1.111'])
+  })
+
+  it('compares across all octets, highest-order first', () => {
+    expect(compareIpAddresses('10.0.0.1', '9.255.255.255')).toBeGreaterThan(0)
+    expect(compareIpAddresses('192.168.2.1', '192.168.10.1')).toBeLessThan(0)
+  })
+
+  it('returns 0 for identical addresses', () => {
+    expect(compareIpAddresses('192.168.1.1', '192.168.1.1')).toBe(0)
+  })
+
+  it('sorts valid IPv4 before invalid/missing values (valid-first)', () => {
+    expect(compareIpAddresses('192.168.1.1', '')).toBeLessThan(0)
+    expect(compareIpAddresses('', '192.168.1.1')).toBeGreaterThan(0)
+    expect(compareIpAddresses('192.168.1.1', 'fe80::1')).toBeLessThan(0)
+  })
+
+  it('falls back to string comparison when neither value is valid IPv4', () => {
+    expect(compareIpAddresses('aaa', 'bbb')).toBeLessThan(0)
+    expect(compareIpAddresses('fe80::2', 'fe80::1')).toBeGreaterThan(0)
+    expect(compareIpAddresses('', '')).toBe(0)
+  })
+
+  it('pushes empty/invalid IPs to the bottom of an ascending sort', () => {
+    const sorted = ['', '192.168.1.50', 'fe80::1', '192.168.1.5'].sort(compareIpAddresses)
+    expect(sorted.slice(0, 2)).toEqual(['192.168.1.5', '192.168.1.50'])
+    // The two invalid entries land last (order among them is string-stable).
+    expect(sorted.slice(2).sort()).toEqual(['', 'fe80::1'].sort())
+  })
+})

--- a/web/src/lib/ip.ts
+++ b/web/src/lib/ip.ts
@@ -35,9 +35,10 @@ export function parseIpv4(ip: string): [number, number, number, number] | null {
  *   1. Two valid IPv4 addresses compare numerically, octet by octet,
  *      so 192.168.1.12 sorts before 192.168.1.111.
  *   2. Values that are NOT valid IPv4 (empty, IPv6, malformed) fall back
- *      to plain string comparison so the sort stays stable and total —
- *      and they sort AFTER all valid IPv4 addresses (invalid/missing data
- *      sinks to the bottom of an ascending sort, where it's least noisy).
+ *      to a deterministic, locale-independent string comparison so the sort
+ *      stays stable and total — and they sort AFTER all valid IPv4 addresses
+ *      (invalid/missing data sinks to the bottom of an ascending sort, where
+ *      it's least noisy).
  *
  * Note: this comparator is direction-agnostic — it always describes
  * ascending order. The caller flips the sign for descending sorts.
@@ -57,7 +58,12 @@ export function compareIpAddresses(a: string, b: string): number {
   if (pa) return -1
   if (pb) return 1
 
-  // Neither is valid IPv4 (empty, IPv6, malformed): keep a stable,
-  // deterministic order via plain string comparison.
-  return a.localeCompare(b)
+  // Neither is valid IPv4 (empty, IPv6, malformed): fall back to a
+  // deterministic, locale-independent code-unit comparison. (localeCompare
+  // would vary the order by the host's runtime locale, breaking the
+  // determinism this fallback promises.) Matches the plain string sort used
+  // by the devices table's other columns.
+  if (a < b) return -1
+  if (a > b) return 1
+  return 0
 }

--- a/web/src/lib/ip.ts
+++ b/web/src/lib/ip.ts
@@ -1,0 +1,63 @@
+// IP address helpers — pure functions, no side effects.
+//
+// Why this exists: the devices table sorted IP addresses as plain strings,
+// so 192.168.1.111 sorted before 192.168.1.12 (lexicographically "111" < "12").
+// This module provides a numeric, octet-aware comparator instead. See issue #585.
+
+/**
+ * Parse a dotted-quad IPv4 string into its four numeric octets.
+ * Returns null for anything that is not a valid IPv4 address
+ * (empty string, IPv6, hostnames, out-of-range octets, etc.).
+ */
+export function parseIpv4(ip: string): [number, number, number, number] | null {
+  const parts = ip.split('.')
+  if (parts.length !== 4) return null
+
+  const octets: number[] = []
+  for (const part of parts) {
+    // Reject empty, non-numeric, or values with leading/trailing junk.
+    if (part === '' || !/^\d{1,3}$/.test(part)) return null
+    const n = Number(part)
+    if (n < 0 || n > 255) return null
+    octets.push(n)
+  }
+  return octets as [number, number, number, number]
+}
+
+/**
+ * Compare two IP address strings for sorting in ascending order.
+ *
+ * Returns a negative number if `a` should come before `b`, a positive
+ * number if `a` should come after `b`, and 0 if they are equal — the
+ * standard Array.prototype.sort() comparator contract.
+ *
+ * Design decisions this function encodes:
+ *   1. Two valid IPv4 addresses compare numerically, octet by octet,
+ *      so 192.168.1.12 sorts before 192.168.1.111.
+ *   2. Values that are NOT valid IPv4 (empty, IPv6, malformed) fall back
+ *      to plain string comparison so the sort stays stable and total —
+ *      and they sort AFTER all valid IPv4 addresses (invalid/missing data
+ *      sinks to the bottom of an ascending sort, where it's least noisy).
+ *
+ * Note: this comparator is direction-agnostic — it always describes
+ * ascending order. The caller flips the sign for descending sorts.
+ */
+export function compareIpAddresses(a: string, b: string): number {
+  const pa = parseIpv4(a)
+  const pb = parseIpv4(b)
+
+  if (pa && pb) {
+    for (let i = 0; i < 4; i++) {
+      if (pa[i] !== pb[i]) return pa[i] - pb[i]
+    }
+    return 0
+  }
+
+  // Exactly one is a valid IPv4 address: it sorts before the invalid one.
+  if (pa) return -1
+  if (pb) return 1
+
+  // Neither is valid IPv4 (empty, IPv6, malformed): keep a stable,
+  // deterministic order via plain string comparison.
+  return a.localeCompare(b)
+}

--- a/web/src/pages/devices/index.tsx
+++ b/web/src/pages/devices/index.tsx
@@ -43,6 +43,7 @@ import {
 } from '@/api/devices'
 import type { Device, DeviceStatus, DeviceType } from '@/api/types'
 import { cn } from '@/lib/utils'
+import { compareIpAddresses } from '@/lib/ip'
 import { useKeyboardShortcuts } from '@/hooks/use-keyboard-shortcuts'
 import { useScanStore } from '@/stores/scan'
 import { HelpIcon, HelpPopover } from '@/components/contextual-help'
@@ -358,6 +359,13 @@ export function DevicesPage() {
     const result = [...filteredDevices]
 
     result.sort((a, b) => {
+      // IP addresses need numeric octet-by-octet comparison, not string
+      // comparison, or 192.168.1.111 sorts before 192.168.1.12 (issue #585).
+      if (sortField === 'ip') {
+        const cmp = compareIpAddresses(a.ip_addresses?.[0] || '', b.ip_addresses?.[0] || '')
+        return sortDirection === 'asc' ? cmp : -cmp
+      }
+
       let aVal: string = ''
       let bVal: string = ''
 
@@ -365,10 +373,6 @@ export function DevicesPage() {
         case 'hostname':
           aVal = a.hostname || ''
           bVal = b.hostname || ''
-          break
-        case 'ip':
-          aVal = a.ip_addresses?.[0] || ''
-          bVal = b.ip_addresses?.[0] || ''
           break
         case 'mac':
           aVal = a.mac_address || ''


### PR DESCRIPTION
## Summary

The devices/clients table sorted IP addresses **lexicographically as strings**, so `192.168.1.111` sorted before `192.168.1.12` (because `"111" < "12"` character by character). Reported in #585.

This adds a pure, numeric, octet-aware comparator and wires it into the `ip` sort column only — every other column keeps its existing string sort.

## Changes

- **`web/src/lib/ip.ts`** (new) — pure helpers:
  - `parseIpv4()` — validates a dotted-quad and returns its four octets, or `null` for anything invalid (empty, IPv6, out-of-range, malformed).
  - `compareIpAddresses()` — compares two IPs numerically octet-by-octet. Honors the `Array.prototype.sort` contract and is direction-agnostic (caller flips the sign for descending).
- **`web/src/pages/devices/index.tsx`** — special-case `sortField === 'ip'` to use the comparator; removed the old string-based `ip` case.
- **`web/src/lib/ip.test.ts`** (new) — 11 tests covering the exact bug, full-octet ordering, identical addresses, and invalid/empty/IPv6 fallback.

## Design decision: where do invalid IPs sort?

**Valid-first** — devices with empty/IPv6/malformed IPs sink to the bottom of an ascending sort via string fallback, keeping the order total and stable. Chosen because SubNetree is IPv4-dominant and the original complaint was about clean IPv4 ordering.

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint` (changed files) — clean
- `npx vitest run` — full suite **129 passed**, new `ip.test.ts` **11 passed**

Closes #585.

🤖 Generated with [Claude Code](https://claude.com/claude-code)