### PR TITLE
chore(status): sync session 2026-06-01 state file

### DIFF
--- a/.samverk/status.md
+++ b/.samverk/status.md
@@ -1,6 +1,6 @@
 ---
 phase: delivery
-updated: 2026-04-23T17:40:00Z
+updated: 2026-06-01T22:00:00Z
 updated_by: claude-code
 ---
 
@@ -8,41 +8,54 @@ updated_by: claude-code
 
 ## Phase
 
-Post-PR cleanup. Main is at 2113239. Zero open PRs. Open Dependabot alerts: 0.
+Post-PR cleanup. Main is at f568739 (#601). Latest release v0.6.4; v0.6.5
+queued via release-please (#603). Open PRs: 7 (1 release + 6 Dependabot).
+Open issues: 8.
 
 ## Pending
 
+- #603: release-please PR for v0.6.5 (auto-managed; merge to cut the release)
 - #493-#498: deployment validation phases (human hardware work)
 - #487: community engagement launch prep
 - #499: content capture for community launch
+- Dependabot backlog: #588 (zap), #591 (x/mod), #592 (sqlite), #596 (grpc),
+  #599 (x/net 0.55.0), #600 (go-sdk). #591/#599 have stale bases after the
+  #602 x/* bump and need a rebase; batch with `@dependabot squash and merge`.
 
 ## Next Actions
 
+- Merge #603 to release v0.6.5 (carries the #601/#602 fixes)
+- Clear the Dependabot backlog (rebase #591/#599 first; AP#200 batch-merge)
 - #493-#498: Docker Desktop / UNRAID / Proxmox validation
 - #499: content capture for community launch
 - #286: IPv6 scanning (Phase 4+)
 
 ## Recently Completed
 
+Session 2026-06-01 (2 PRs merged):
+
+- Merged PR #601 (f568739): Fixed device-table IP sort -- IPs were sorted
+  lexicographically (192.168.1.111 before 192.168.1.12). New pure
+  `compareIpAddresses` comparator in `web/src/lib/ip.ts` (octet-numeric,
+  valid-IPv4-first fallback), 11 tests. Closes #585. Copilot review caught a
+  real bug: `localeCompare` fallback was locale-dependent, replaced with
+  code-unit comparison (captured as SYN#6585).
+- Merged PR #602 (security): Cleared a day-of govulncheck DB hit (10 vulns)
+  blocking the whole PR queue -- x/crypto 0.50.0->0.52.0, x/net 0.52.0->0.54.0,
+  Go directive 1.25.9->1.25.10 (stdlib CVEs), Dockerfile go-builder
+  1.25.9->1.25.10-alpine sibling update. Superseded Dependabot #598 (auto-closed).
+- Dashboard skill (`.claude/skills/dashboard/`) de-hardcoded: stale absolute
+  paths (family-folder move + Windows profile-casing + deleted dev-mode skill)
+  replaced with relative paths + bare git + ~/.claude tilde. Local-only
+  (.claude is gitignored). Captured as SYN#6582; DevKit issue #389 filed.
+
 Session 2026-04-23 (3 PRs merged, 6 Dependabot alerts cleared):
 
-- Merged PR #580 (7f41f77): Ansible dynamic inventory plugin + YAML export endpoint.
-  Closes #489. Fixes along the way: gofmt on `internal/recon/ansible.go`, Go toolchain
-  bump 1.25.8 -> 1.25.9 (stdlib CVE hotfix: GO-2026-4947/4946/4870/4869/4865), Dockerfile
-  golang:1.25.8-alpine -> 1.25.9-alpine sibling update.
-- Merged PR #581 (47a4729): Resolved 6 Dependabot alerts in web deps. happy-dom bump +
-  pnpm.overrides for minimatch/picomatch/flatted. Scoped PR kept narrow via exact pins on
-  recharts (3.7.0) and eslint-plugin-react-hooks (7.0.1); follow-up filed as #582.
-- Merged PR #583 (2113239): Closes #582. Unpinned both deps (eslint-plugin-react-hooks
-  ^7.1.1, recharts ^3.8.1) and refactored the code each bump revealed -- derived-state
-  effect in color-picker.tsx replaced with "adjust state on prop change" pattern;
-  setup.tsx network-interfaces fetch migrated to TanStack Query; two Recharts Tooltip
-  sites moved to JSX element form with Partial<TooltipContentProps<...>> per KG#6.
-- Claude Code plugin registry repaired (Windows profile case-drift; marketplaces
-  remove+re-add). Captured as SYN#5954 + devkit#274.
-- Autolearn: 4 new Synapset memories this session (#5954 plugin gotcha, #5956 pnpm
-  override requires clean install, #5957 caret-bump cascade needs exact-pin in scoped
-  PRs, #5958 Go toolchain Dockerfile sibling-update). DevKit issues filed: #274, #275.
+- Merged PR #580 (7f41f77): Ansible dynamic inventory plugin + YAML export
+  endpoint. Closes #489. Go toolchain 1.25.8->1.25.9, Dockerfile sibling update.
+- Merged PR #581 (47a4729): Resolved 6 Dependabot alerts in web deps.
+- Merged PR #583 (2113239): Closes #582. Unpinned recharts +
+  eslint-plugin-react-hooks, refactored revealed anti-patterns.
 
 ## Queued (Roadmap)
 


### PR DESCRIPTION
Routine state-file sync after this session's merges (#601 IP sort, #602 govulncheck security sweep).

## Changes to `.samverk/status.md`

- **Phase**: main at f568739 (#601); latest release v0.6.4, v0.6.5 queued (#603); 7 open PRs; 8 open issues
- **Recently completed**: added the 2026-06-01 session (#601 IP sort + Copilot localeCompare catch, #602 security sweep, dashboard skill path de-hardcoding)
- **Pending / Next actions**: surfaced the open-PR backlog — release-please #603 and 6 Dependabot PRs, flagging #591 (x/mod) and #599 (x/net) as needing rebase after the #602 x/* bump

Docs-only / state-file change. No code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)