### PR TITLE
fix(deps): bump Go 1.25.10 -> 1.25.11 for new stdlib CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN pnpm run build
 # ============================================================================
 # Stage 2: Build Go binary
 # ============================================================================
-FROM golang:1.25.10-alpine AS go-builder
+FROM golang:1.25.11-alpine AS go-builder
 
 # Install build dependencies
 RUN apk add --no-cache git ca-certificates tzdata

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/HerbHall/subnetree
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/coder/websocket v1.8.14


### PR DESCRIPTION
## Summary

A fresh govulncheck DB update (one day after #602) flagged two new **stdlib** vulnerabilities in go1.25.10, re-blocking the entire PR queue — main itself, the remaining Dependabot PRs (#588/#591/#596), and release #603 all fail `Vulnerability Check`:

| Vuln | Package | Fixed in |
|------|---------|----------|
| GO-2026-5039 | net/textproto | go1.25.11 |
| GO-2026-5037 | crypto/x509 | go1.25.11 |

Pure toolchain bump — no module changes. Bumps the `go` directive **and** the Dockerfile `go-builder` image in lockstep (CI reads `go-version-file: go.mod`; the Docker build pins the builder explicitly and fails on a version mismatch otherwise).

## Verification (local)

- `go build ./...` / `go vet ./...` — clean
- `GOTOOLCHAIN=go1.25.11 govulncheck ./...` — **"No vulnerabilities found"**

Once merged, rebasing #588/#591/#596 onto main clears their vuln check, and #603 (v0.6.5) can be cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)